### PR TITLE
Add explicit UTF-8 encoding for file operations

### DIFF
--- a/src/arxiv_mcp_server/resources/papers.py
+++ b/src/arxiv_mcp_server/resources/papers.py
@@ -40,7 +40,7 @@ class PaperManager:
             paper.download_pdf(dirpath=self.storage_path, filename=paper_pdf_path)
             markdown = pymupdf4llm.to_markdown(paper_pdf_path, show_progress=False)
 
-            async with aiofiles.open(paper_md_path, "w") as f:
+            async with aiofiles.open(paper_md_path, "w", encoding="utf-8") as f:
                 await f.write(markdown)
 
             paper_pdf_path.unlink()  # Remove PDF after conversion
@@ -98,5 +98,5 @@ class PaperManager:
         if not paper_path.exists():
             raise ValueError(f"Paper {paper_id} not found in storage")
 
-        async with aiofiles.open(paper_path, "r") as f:
+        async with aiofiles.open(paper_path, "r", encoding="utf-8") as f:
             return await f.read()

--- a/src/arxiv_mcp_server/test.ipynb
+++ b/src/arxiv_mcp_server/test.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(paper_path.with_suffix(\".md\"), \"w\") as f:\n",
+    "with open(paper_path.with_suffix(\".md\"), \"w\", encoding=\"utf-8\") as f:\n",
     "    f.write(text_content)\n"
    ]
   },

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -49,7 +49,7 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
             ]
 
         # Get paper content
-        content = Path(settings.STORAGE_PATH, f"{paper_id}.md").read_text()
+        content = Path(settings.STORAGE_PATH, f"{paper_id}.md").read_text(encoding="utf-8")
 
         return [
             types.TextContent(

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -23,7 +23,7 @@ async def test_download_paper_lifecycle(mocker, temp_storage_path):
     # Mock PDF to markdown conversion to happen immediately
     async def mock_convert(paper_id, pdf_path):
         md_path = get_paper_path(paper_id, ".md")
-        with open(md_path, "w") as f:
+        with open(md_path, "w", encoding="utf-8") as f:
             f.write("# Test Paper\nConverted content")
         if paper_id in conversion_statuses:
             status = conversion_statuses[paper_id]
@@ -55,7 +55,7 @@ async def test_download_existing_paper(temp_storage_path):
     
     # Create test markdown file
     md_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(md_path, "w") as f:
+    with open(md_path, "w", encoding="utf-8") as f:
         f.write("# Existing Paper\nTest content")
     
     response = await handle_download({"paper_id": paper_id})


### PR DESCRIPTION
## Purpose
This PR adds explicit UTF-8 encoding specification when opening files 
to prevent potential encoding-related issues (such as issue #17 ).

## Changes
- Added `encoding="utf-8"` parameter to all `open()` and `Path().read_text()` calls that handle text files
- Ensures consistent behavior across different platforms and locales

## Rationale
Without explicit encoding specification, Python uses the system default encoding which can vary across platforms and cause:
- Potential issues with special characters or non-ASCII text
- UnicodeDecodeError when reading files