### PR TITLE
removed unlink of pdf files

### DIFF
--- a/src/arxiv_mcp_server/resources/papers.py
+++ b/src/arxiv_mcp_server/resources/papers.py
@@ -43,7 +43,6 @@ class PaperManager:
             async with aiofiles.open(paper_md_path, "w", encoding="utf-8") as f:
                 await f.write(markdown)
 
-            paper_pdf_path.unlink()  # Remove PDF after conversion
             return True
 
         except StopIteration:

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -74,7 +74,6 @@ def convert_pdf_to_markdown(paper_id: str, pdf_path: Path) -> None:
             status.completed_at = datetime.now()
 
         # Clean up PDF after successful conversion
-        pdf_path.unlink()
         logger.info(f"Conversion completed for {paper_id}")
 
     except Exception as e:

--- a/tests/prompts/test_prompt_integration.py
+++ b/tests/prompts/test_prompt_integration.py
@@ -3,36 +3,37 @@
 import pytest
 from arxiv_mcp_server.prompts.handlers import list_prompts, get_prompt
 
+
 @pytest.mark.asyncio
 async def test_server_list_prompts():
     """Test server list_prompts endpoint."""
     prompts = await list_prompts()
     assert len(prompts) == 1
-    
+
     # Check that all prompts have required fields
     for prompt in prompts:
         assert prompt.name
         assert prompt.description
         assert prompt.arguments is not None
 
+
 @pytest.mark.asyncio
 async def test_server_get_analysis_prompt():
     """Test server get_prompt endpoint with analysis prompt."""
-    result = await get_prompt(
-        "deep-paper-analysis",
-        {"paper_id": "2401.00123"}
-    )
-    
+    result = await get_prompt("deep-paper-analysis", {"paper_id": "2401.00123"})
+
     assert len(result.messages) == 1
     message = result.messages[0]
     assert message.role == "user"
     assert "2401.00123" in message.content.text
+
 
 @pytest.mark.asyncio
 async def test_server_get_prompt_invalid_name():
     """Test server get_prompt endpoint with invalid prompt name."""
     with pytest.raises(ValueError, match="Prompt not found"):
         await get_prompt("invalid-prompt", {})
+
 
 @pytest.mark.asyncio
 async def test_server_get_prompt_missing_args():

--- a/tests/prompts/test_prompts.py
+++ b/tests/prompts/test_prompts.py
@@ -5,32 +5,32 @@ from typing import Dict
 from arxiv_mcp_server.prompts.handlers import list_prompts, get_prompt
 from mcp.types import GetPromptResult, PromptMessage, TextContent
 
+
 @pytest.mark.asyncio
 async def test_list_prompts():
     """Test listing available prompts."""
     prompts = await list_prompts()
     assert len(prompts) == 1
-    
+
     prompt_names = {p.name for p in prompts}
     expected_names = {"deep-paper-analysis"}
     assert prompt_names == expected_names
 
+
 @pytest.mark.asyncio
 async def test_get_paper_analysis_prompt():
     """Test getting paper analysis prompt."""
-    result = await get_prompt(
-        "deep-paper-analysis",
-        {"paper_id": "2401.00123"}
-    )
-    
+    result = await get_prompt("deep-paper-analysis", {"paper_id": "2401.00123"})
+
     assert isinstance(result, GetPromptResult)
     assert len(result.messages) == 1
     message = result.messages[0]
-    
+
     assert isinstance(message, PromptMessage)
     assert message.role == "user"
     assert isinstance(message.content, TextContent)
     assert "2401.00123" in message.content.text
+
 
 @pytest.mark.asyncio
 async def test_get_prompt_with_invalid_name():
@@ -38,11 +38,13 @@ async def test_get_prompt_with_invalid_name():
     with pytest.raises(ValueError, match="Prompt not found"):
         await get_prompt("invalid-prompt", {})
 
+
 @pytest.mark.asyncio
 async def test_get_prompt_with_no_arguments():
     """Test getting prompt with no arguments."""
     with pytest.raises(ValueError, match="No arguments provided"):
         await get_prompt("deep-paper-analysis", None)
+
 
 @pytest.mark.asyncio
 async def test_get_prompt_with_missing_required_argument():


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Removes PDF file deletion after conversion to markdown to preserve original PDF files in the storage directory.

- Removed `paper_pdf_path.unlink()` call in `src/arxiv_mcp_server/resources/papers.py` to prevent deletion of PDF files after conversion.
- Removed `pdf_path.unlink()` call in `src/arxiv_mcp_server/tools/download.py` to keep PDF files after successful conversion to markdown.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

Dropping the removal of PDF files. 