### PR TITLE
Add MCP Shield security scan

### DIFF
--- a/.github/workflows/mcp-shield.yml
+++ b/.github/workflows/mcp-shield.yml
@@ -1,0 +1,16 @@
+name: MCP Shield
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: thuggeelya/mcp-shield-action@v1
+        with:
+          server: 'uvx arxiv-mcp-server'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/arxiv-mcp-server.svg)](https://pypi.org/project/arxiv-mcp-server/)
 [![PyPI Version](https://img.shields.io/pypi/v/arxiv-mcp-server.svg)](https://pypi.org/project/arxiv-mcp-server/)
+[![MCP Shield](https://img.shields.io/badge/MCP_Shield-A--_(86)-brightgreen)](https://github.com/thuggeelya/mcp-shield)
 
 # ArXiv MCP Server
 


### PR DESCRIPTION
## Summary
Adds MCP Shield CI workflow for automated security scanning and security badge to README.
On every PR, the workflow posts a detailed comment with findings, affected tools, and recommendations.

## Scan results
**Score: 86/100 (Grade: A-)**
22 checks | 14 passed | 0 failed | 8 warnings

### Findings

**⚠️ [SEC-001](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md#sec-001--tool-poisoning-scan) WARN** — Found 1 poisoning indicator(s) (CWE-94)
- `[low] Excessively long description (2400 chars)`

**⚠️ [COMP-009](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md#comp-009--verify-schema-constraints) WARN** — 5 field(s) missing constraints
- `search_papers.query: string without maxLength`
- `search_papers.date_from: string without maxLength`
- `search_papers.date_to: string without maxLength`
- `download_paper.paper_id: string without maxLength`
- `read_paper.paper_id: string without maxLength`

**⚠️ [ADV-003](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md#adv-003--bulk-operation-warning) WARN** — 1 tool(s) may perform bulk operations
- `search_papers (unbounded array: categories)`

**⚠️ [ADV-005](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md#adv-005--external-network-access) WARN** — 2 tool(s) access external network
- `search_papers (network verb)`
- `download_paper (network verb)`

**⚠️ [SEC-002](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md#sec-002--injection-vector-analysis) WARN** — Found 1 potential injection vector(s) (CWE-78, CWE-89, CWE-22)
- `[medium] Potential injection vector: search_papers.query`

**⚠️ [SEC-003](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md#sec-003--security-score) WARN** — Security score: 78/100 (5 finding(s))

**⚠️ [SEC-005](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md#sec-005--write-scope-analysis) WARN** — Found 1 write scope concern(s) (CWE-434)
- `[medium] User-facing write: search_papers`

**⚠️ [SEC-006](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md#sec-006--idempotency-risk) WARN** — Found 2 non-idempotent operation(s) (CWE-352)
- `[medium] Non-idempotent operation: search_papers`
- `[medium] Non-idempotent operation: download_paper`

### Recommendations

🔴 **Review injection risks (1 found)** — Add maxLength/pattern to schemas, or --deny high-risk tools
> Affected: `search_papers.query`
🟡 **Confirm write scope (1 found)** — Require user confirmation for write operations
> Affected: `search_papers`
🟡 **Add idempotency keys (2 found)** — Add idempotency_key parameter to non-idempotent tools
> Affected: `search_papers`, `download_paper`
🔵 **Improve schemas (5 fields)** — Add descriptions, maxLength, and pattern constraints to inputSchema fields
> Affected: `search_papers.query`, `search_papers.date_from`, `search_papers.date_to`, `download_paper.paper_id`, `read_paper.paper_id`

---
[MCP Shield](https://github.com/thuggeelya/mcp-shield) · [Check reference](https://github.com/thuggeelya/mcp-shield/blob/main/docs/checks.md)