### PR TITLE
feat: add get_abstract tool for token-efficient paper metadata retrieval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ This is an **MCP (Message Control Protocol) server** that provides AI models acc
    - `download.py`: Paper download and storage management  
    - `list_papers.py`: List locally stored papers
    - `read_paper.py`: Read paper content from storage
+   - `get_abstract.py`: Get paper abstract/metadata via arXiv API without downloading (token-saving alternative to download+read)
 3. **Resource Management** (`resources/papers.py`): `PaperManager` class handles paper storage, PDF-to-markdown conversion using pymupdf4llm, and local caching
 4. **Configuration** (`config.py`): Pydantic-based settings with environment variable support
 

--- a/src/arxiv_mcp_server/server.py
+++ b/src/arxiv_mcp_server/server.py
@@ -13,8 +13,8 @@ from mcp.server.models import InitializationOptions
 from mcp.server import NotificationOptions
 from mcp.server.stdio import stdio_server
 from .config import Settings
-from .tools import handle_search, handle_download, handle_list_papers, handle_read_paper
-from .tools import search_tool, download_tool, list_tool, read_tool
+from .tools import handle_search, handle_download, handle_list_papers, handle_read_paper, handle_get_abstract
+from .tools import search_tool, download_tool, list_tool, read_tool, abstract_tool
 from .prompts.handlers import list_prompts as handler_list_prompts
 from .prompts.handlers import get_prompt as handler_get_prompt
 
@@ -41,7 +41,7 @@ async def get_prompt(
 @server.list_tools()
 async def list_tools() -> List[types.Tool]:
     """List available arXiv research tools."""
-    return [search_tool, download_tool, list_tool, read_tool]
+    return [search_tool, download_tool, list_tool, read_tool, abstract_tool]
 
 
 @server.call_tool()
@@ -57,6 +57,8 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
             return await handle_list_papers(arguments)
         elif name == "read_paper":
             return await handle_read_paper(arguments)
+        elif name == "get_abstract":
+            return await handle_get_abstract(arguments)
         else:
             return [types.TextContent(type="text", text=f"Error: Unknown tool {name}")]
     except Exception as e:

--- a/src/arxiv_mcp_server/tools/__init__.py
+++ b/src/arxiv_mcp_server/tools/__init__.py
@@ -4,14 +4,17 @@ from .search import search_tool, handle_search
 from .download import download_tool, handle_download
 from .list_papers import list_tool, handle_list_papers
 from .read_paper import read_tool, handle_read_paper
+from .get_abstract import abstract_tool, handle_get_abstract
 
 __all__ = [
     "search_tool",
     "download_tool",
     "read_tool",
+    "abstract_tool",
     "handle_search",
     "handle_download",
     "handle_read_paper",
+    "handle_get_abstract",
     "list_tool",
     "handle_list_papers",
 ]

--- a/src/arxiv_mcp_server/tools/get_abstract.py
+++ b/src/arxiv_mcp_server/tools/get_abstract.py
@@ -1,0 +1,81 @@
+"""Get paper abstract functionality for the arXiv MCP server."""
+
+import arxiv
+import json
+import logging
+from typing import Dict, Any, List
+import mcp.types as types
+
+logger = logging.getLogger("arxiv-mcp-server")
+
+abstract_tool = types.Tool(
+    name="get_abstract",
+    description="""Get the abstract and metadata of a paper by its arXiv ID, WITHOUT downloading the full paper.
+
+USE THIS TOOL FIRST to assess whether a paper is relevant before using download_paper + read_paper.
+This saves significant tokens by avoiding full paper downloads when only the abstract is needed.
+
+Returns: title, authors, abstract, categories, published date, and PDF URL.""",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "paper_id": {
+                "type": "string",
+                "description": "The arXiv ID of the paper (e.g., '2401.12345')",
+            }
+        },
+        "required": ["paper_id"],
+    },
+)
+
+
+async def handle_get_abstract(arguments: Dict[str, Any]) -> List[types.TextContent]:
+    """Handle requests to get a paper's abstract without downloading."""
+    try:
+        paper_id = arguments["paper_id"]
+        client = arxiv.Client()
+        search = arxiv.Search(id_list=[paper_id])
+        results = list(client.results(search))
+
+        if not results:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "status": "error",
+                            "message": f"Paper {paper_id} not found on arXiv",
+                        }
+                    ),
+                )
+            ]
+
+        paper = results[0]
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "status": "success",
+                        "paper_id": paper_id,
+                        "title": paper.title,
+                        "authors": [a.name for a in paper.authors],
+                        "abstract": paper.summary,
+                        "categories": paper.categories,
+                        "published": paper.published.isoformat(),
+                        "pdf_url": paper.pdf_url,
+                    },
+                    indent=2,
+                ),
+            )
+        ]
+
+    except Exception as e:
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(
+                    {"status": "error", "message": f"Error: {str(e)}"}
+                ),
+            )
+        ]


### PR DESCRIPTION
## Summary

- Add a lightweight `get_abstract` tool that fetches paper metadata (title, authors, abstract, categories, published date) via arXiv API **without downloading the full PDF**
- Allows users to assess paper relevance before committing to a full `download_paper` + `read_paper` workflow, **saving significant tokens**
- Minimal changes: 1 new file + 3 small edits to existing files

## Changes

| File | Change |
|------|--------|
| `tools/get_abstract.py` | New tool implementation |
| `tools/__init__.py` | Export new tool (+2 lines) |
| `server.py` | Register and route new tool (+3 lines) |
| `CLAUDE.md` | Document new tool (+1 line) |

## Test plan

- [x] All 32 existing tests pass
- [x] Module imports correctly
- [x] Follows existing tool pattern (Tool definition + handler function)