### PR TITLE
feat: add streamable-http transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,25 @@ For Development:
 }
 ```
 
+### HTTP Transport
+
+For server deployments, run with HTTP transport:
+```bash
+TRANSPORT=http HOST=127.0.0.1 PORT=8080 arxiv-mcp-server --storage-path /path/to/papers
+```
+
+Then connect your MCP client:
+```json
+{
+    "mcpServers": {
+        "arxiv-mcp-server": {
+            "type": "http",
+            "url": "http://127.0.0.1:8080/mcp"
+        }
+    }
+}
+```
+
 ## 🔒 Security Note
 
 arXiv papers are user-generated, untrusted content. Paper text returned by this
@@ -297,7 +316,12 @@ Configure through environment variables:
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `ARXIV_STORAGE_PATH` | Paper storage location | ~/.arxiv-mcp-server/papers |
+| `ARXIV_STORAGE_PATH` | Paper storage location | `~/.arxiv-mcp-server/papers` |
+| `ARXIV_MAX_RESULTS` | Maximum search results | `50` |
+| `ARXIV_REQUEST_TIMEOUT` | API timeout in seconds | `60` |
+| `TRANSPORT` | Transport type: `stdio` or `http` | `stdio` |
+| `HOST` | Host to bind to in HTTP mode | `0.0.0.0` |
+| `PORT` | Port to listen on in HTTP mode | `8000` |
 
 ## 🧪 Testing
 

--- a/src/arxiv_mcp_server/config.py
+++ b/src/arxiv_mcp_server/config.py
@@ -35,6 +35,7 @@ class Settings(BaseSettings):
     MAX_RESULTS: int = 50
     BATCH_SIZE: int = 20
     REQUEST_TIMEOUT: int = 60
+    TRANSPORT: str = "stdio"
     HOST: str = "0.0.0.0"
     PORT: int = 8000
     model_config = SettingsConfigDict(extra="allow")

--- a/src/arxiv_mcp_server/server.py
+++ b/src/arxiv_mcp_server/server.py
@@ -7,11 +7,15 @@ This module implements an MCP server for interacting with arXiv.
 
 import logging
 import mcp.types as types
+import uvicorn
+from starlette.applications import Starlette
+from starlette.routing import Mount
 from typing import Dict, Any, List
 from mcp.server import Server
 from mcp.server.models import InitializationOptions
 from mcp.server import NotificationOptions
 from mcp.server.stdio import stdio_server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from .config import Settings
 from .tools import (
     handle_search,
@@ -104,19 +108,37 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
         logger.error(f"Tool error: {str(e)}")
         return [types.TextContent(type="text", text=f"Error: {str(e)}")]
 
-
 async def main():
     """Run the server async context."""
-    async with stdio_server() as streams:
-        await server.run(
-            streams[0],
-            streams[1],
-            InitializationOptions(
-                server_name=settings.APP_NAME,
-                server_version=settings.APP_VERSION,
-                capabilities=server.get_capabilities(
-                    notification_options=NotificationOptions(resources_changed=True),
-                    experimental_capabilities={},
-                ),
-            ),
+    if settings.TRANSPORT == "http":
+        session_manager = StreamableHTTPSessionManager(
+            app=server,
+            event_store=None,
+            json_response=False,
         )
+        starlette_app = Starlette(
+            routes=[Mount("/mcp", app=session_manager.handle_request)],
+        )
+        config = uvicorn.Config(
+            starlette_app,
+            host=settings.HOST,
+            port=settings.PORT,
+            log_level="info",
+        )
+        uvicorn_server = uvicorn.Server(config)
+        async with session_manager.run():
+            await uvicorn_server.serve()
+    else:
+        async with stdio_server() as streams:
+            await server.run(
+                streams[0],
+                streams[1],
+                InitializationOptions(
+                    server_name=settings.APP_NAME,
+                    server_version=settings.APP_VERSION,
+                    capabilities=server.get_capabilities(
+                        notification_options=NotificationOptions(resources_changed=True),
+                        experimental_capabilities={},
+                    ),
+                ),
+            )


### PR DESCRIPTION
This PR adds HTTP transport support to the arXiv MCP server, making it suitable for remote/server deployments where stdio is not practical (e.g. running as a systemd service behind an nginx reverse proxy).

The HOST and PORT fields in Settings suggested HTTP transport was planned but never implemented. This PR completes that intent with a minimal, non-breaking patch. The stdio default is preserved, so existing users and integrations are unaffected.

Tested running behind nginx on Fedora with @Claude.