### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "arxiv-mcp-server",
+  "version": "0.1.0",
+  "description": "A Model Context Protocol server for searching and analyzing arXiv papers",
+  "author": {
+    "name": "Joseph Blazick",
+    "url": "https://github.com/blazickjp"
+  },
+  "homepage": "https://github.com/blazickjp/arxiv-mcp-server",
+  "repository": "https://github.com/blazickjp/arxiv-mcp-server",
+  "keywords": ["mcp", "codex", "arxiv", "research", "academic"],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "arXiv Search",
+    "shortDescription": "Search and analyze arXiv papers",
+    "longDescription": "A Model Context Protocol server for searching and analyzing arXiv papers. Provides capabilities to search the arXiv academic paper repository, retrieve paper metadata, and analyze paper content.",
+    "category": "API",
+    "websiteURL": "https://github.com/blazickjp/arxiv-mcp-server"
+  }
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,22 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "arxiv": {
+      "command": "uvx",
+      "args": ["arxiv-mcp-server"]
+    }
+  }
+}

--- a/skills/arxiv/SKILL.md
+++ b/skills/arxiv/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: arxiv
+description: Search and analyze arXiv papers
+---
+
+# arXiv Search
+
+A Model Context Protocol server for searching and analyzing arXiv papers. Provides capabilities to search the arXiv academic paper repository, retrieve paper metadata, and analyze paper content.
+
+## When to use
+- When you need arXiv paper search capabilities in your Codex workflow
+- When you want to retrieve and analyze academic papers
+- See https://github.com/blazickjp/arxiv-mcp-server for full setup instructions


### PR DESCRIPTION
This repo already exposes a clear plugin surface, so I put together a small metadata pass for it.

A couple of repo-specific details I checked first:
- A Model Context Protocol server for searching and analyzing arXiv papers
- When an AI assistant downloads or reads a paper through this server, the paper's
- Use read-only MCP configurations — where possible, configure the MCP

This PR adds the Codex plugin metadata, an `.mcp.json` starting point, and the scanner workflow.
Permissions: read-only. No secrets. No publish. No runtime changes.
If you want different command wiring or manifest metadata, I can adjust the branch.