### PR TITLE
fix: respect max_results in arxiv client requests

### DIFF
--- a/src/arxiv_mcp_server/config.py
+++ b/src/arxiv_mcp_server/config.py
@@ -17,13 +17,19 @@ logger = logging.getLogger(__name__)
 _arxiv_client = None
 
 
-def get_arxiv_client():
-    """Return a shared arxiv.Client instance, creating it on first call."""
+def get_arxiv_client(page_size: int = 100):
+    """Return a shared arxiv.Client instance, creating it on first call.
+
+    The arxiv Python client fetches pages using its own page_size setting. If
+    left at the library default of 100, even a small max_results request causes
+    an upstream API URL with max_results=100. Keep the client page size aligned
+    with the requested result count so small searches make small API requests.
+    """
     global _arxiv_client
-    if _arxiv_client is None:
+    if _arxiv_client is None or getattr(_arxiv_client, "page_size", None) != page_size:
         import arxiv
 
-        _arxiv_client = arxiv.Client()
+        _arxiv_client = arxiv.Client(page_size=page_size)
     return _arxiv_client
 
 

--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -500,7 +500,7 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 return [types.TextContent(type="text", text=f"Error: {str(e)}")]
 
         # For non-date queries, use the shared arxiv client (lazy, avoids eager import overhead)
-        client = get_arxiv_client()
+        client = get_arxiv_client(page_size=max_results)
 
         # Build query components
         query_parts = []

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -223,6 +223,21 @@ async def test_search_max_results_limiting(mock_client):
 
 
 @pytest.mark.asyncio
+async def test_search_client_page_size_matches_requested_max_results(
+    mock_client, monkeypatch
+):
+    """Use the requested max_results as the arxiv client page size."""
+    from arxiv_mcp_server import config
+
+    monkeypatch.setattr(config, "_arxiv_client", None)
+
+    with patch("arxiv.Client", return_value=mock_client) as mock_client_class:
+        await handle_search({"query": "test", "max_results": 5})
+
+    mock_client_class.assert_called_once_with(page_size=5)
+
+
+@pytest.mark.asyncio
 async def test_search_sort_by_relevance(mock_client):
     """Test search with relevance sorting (default)."""
     with patch("arxiv.Client", return_value=mock_client):


### PR DESCRIPTION
## Summary
- Aligns the arxiv client page size with the requested `max_results`
- Prevents small searches from making upstream API requests with `max_results=100`
- Adds a regression test proving the requested result count is passed into the client page size

Closes #52

## Root cause
The arxiv Python client has an independent default `page_size=100`. Even when `Search.max_results` was smaller, the client still fetched pages using its default page size, producing API URLs with `max_results=100`.

## Test Plan
- [x] `uv run pytest tests/tools/test_search.py::test_search_client_page_size_matches_requested_max_results -q`
- [x] `uv run pytest tests/tools/test_search.py -q`
- [x] `uv run pytest -q`
