### PR TITLE
fix: set MCP error flag for tool error payloads

### DIFF
--- a/src/arxiv_mcp_server/server.py
+++ b/src/arxiv_mcp_server/server.py
@@ -5,6 +5,7 @@ Arxiv MCP Server
 This module implements an MCP server for interacting with arXiv.
 """
 
+import json
 import logging
 from typing import Any, Dict, List
 
@@ -78,36 +79,58 @@ async def list_tools() -> List[types.Tool]:
     ]
 
 
+def _tool_error_message(result: List[types.TextContent]) -> str | None:
+    """Return the error text if a tool result is an error payload."""
+    if len(result) != 1 or result[0].type != "text":
+        return None
+
+    text = result[0].text
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return text if text.startswith("Error:") else None
+
+    if isinstance(payload, dict) and payload.get("status") == "error":
+        return text
+    return None
+
+
 @server.call_tool()
 async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Handle tool calls for arXiv research functionality."""
     logger.debug(f"Calling tool {name} with arguments {arguments}")
     try:
         if name == "search_papers":
-            return await handle_search(arguments)
+            result = await handle_search(arguments)
         elif name == "download_paper":
-            return await handle_download(arguments)
+            result = await handle_download(arguments)
         elif name == "list_papers":
-            return await handle_list_papers(arguments)
+            result = await handle_list_papers(arguments)
         elif name == "read_paper":
-            return await handle_read_paper(arguments)
+            result = await handle_read_paper(arguments)
         elif name == "get_abstract":
-            return await handle_get_abstract(arguments)
+            result = await handle_get_abstract(arguments)
         elif name == "semantic_search":
-            return await handle_semantic_search(arguments)
+            result = await handle_semantic_search(arguments)
         elif name == "reindex":
-            return await handle_reindex(arguments)
+            result = await handle_reindex(arguments)
         elif name == "citation_graph":
-            return await handle_citation_graph(arguments)
+            result = await handle_citation_graph(arguments)
         elif name == "watch_topic":
-            return await handle_watch_topic(arguments)
+            result = await handle_watch_topic(arguments)
         elif name == "check_alerts":
-            return await handle_check_alerts(arguments)
+            result = await handle_check_alerts(arguments)
         else:
-            return [types.TextContent(type="text", text=f"Error: Unknown tool {name}")]
+            result = [
+                types.TextContent(type="text", text=f"Error: Unknown tool {name}")
+            ]
+
+        if error_message := _tool_error_message(result):
+            raise RuntimeError(error_message)
+        return result
     except Exception as e:
         logger.error(f"Tool error: {str(e)}")
-        return [types.TextContent(type="text", text=f"Error: {str(e)}")]
+        raise
 
 
 def _initialization_options() -> InitializationOptions:

--- a/tests/test_mcp_tool_error_semantics.py
+++ b/tests/test_mcp_tool_error_semantics.py
@@ -1,0 +1,40 @@
+"""MCP protocol-level error semantics for tool calls."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+import mcp.types as types
+
+from arxiv_mcp_server import server as server_module
+
+NO_ENTRIES_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>ArXiv Query: id_list=0000.00000</title>
+</feed>
+"""
+
+
+class MockResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+
+@pytest.mark.asyncio
+async def test_get_abstract_not_found_sets_mcp_is_error(mocker):
+    """JSON error payloads from get_abstract should be MCP tool errors."""
+    mocker.patch(
+        "arxiv_mcp_server.tools.get_abstract._rate_limited_get",
+        AsyncMock(return_value=MockResponse(NO_ENTRIES_XML)),
+    )
+
+    handler = server_module.server.request_handlers[types.CallToolRequest]
+    result = await handler(
+        types.CallToolRequest(
+            params=types.CallToolRequestParams(
+                name="get_abstract", arguments={"paper_id": "0000.00000"}
+            )
+        )
+    )
+
+    assert result.root.isError is True
+    assert "Paper 0000.00000 not found on arXiv" in result.root.content[0].text


### PR DESCRIPTION
Fixes #92

## Summary
- Treat JSON tool responses with `status: "error"` as MCP tool errors at the server boundary.
- Preserve the existing JSON error body while letting the MCP SDK emit `isError: true`.
- Add a protocol-level regression test for `get_abstract` not-found responses.

## Root cause
Tool handlers returned JSON error payloads as normal text content. The MCP Python SDK normalizes returned content with `isError: false`; it only sets `isError: true` when the registered tool callback raises/returns an SDK error result. So clients checking the MCP flag saw a successful tool call with an error-looking body.

## Tests
- `uv run pytest tests/test_mcp_tool_error_semantics.py::test_get_abstract_not_found_sets_mcp_is_error -q`
- `uv run pytest tests/tools/test_get_abstract.py tests/test_mcp_tool_error_semantics.py -q`
- `uv run pytest -q`
