### PR TITLE
Fix truncated arXiv PDF downloads by streaming pdf_url with httpx

### DIFF
--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -194,8 +194,68 @@ class PaperNotFoundError(Exception):
     """Raised when an arXiv paper ID cannot be found."""
 
 
+def _download_arxiv_pdf_to_path(paper: arxiv.Result, pdf_path: Path) -> None:
+    """Persist the arXiv PDF for ``paper`` to ``pdf_path`` using HTTP streaming.
+
+    The public ``arxiv`` package recommends ``Result.download_pdf()`` for ad-hoc
+    scripts; internally it uses :func:`urllib.request.urlretrieve` against
+    ``export.arxiv.org``. In production we have observed **incomplete response
+    bodies** for some larger PDFs (e.g. ``retrieval incomplete`` / truncated
+    reads at ~1–2 MiB), which breaks the PDF-to-markdown pipeline.
+
+    We instead stream the canonical ``pdf_url`` returned by the arXiv API —
+    typically ``https://arxiv.org/pdf/...`` — via :mod:`httpx`, which matches
+    the host used for our HTML fetches and has proven stable for the same
+    papers that fail under ``download_pdf``.
+
+    Args:
+        paper: Metadata row from :meth:`arxiv.Client.results`; must expose
+            ``pdf_url``.
+        pdf_path: Destination path on disk (parent directory should exist or
+            be created by the caller via :func:`get_paper_path`).
+
+    Raises:
+        ValueError: If ``paper.pdf_url`` is missing.
+        httpx.HTTPStatusError: If the HTTP response is not successful.
+        httpx.RequestError: On transport-level failures.
+
+    Note:
+        Read timeout uses :attr:`Settings.REQUEST_TIMEOUT` with a floor of
+        120 seconds so large PDFs on slower links are less likely to fail
+        prematurely. Data is written in 256 KiB chunks to bound memory use.
+    """
+    if paper.pdf_url is None:
+        raise ValueError("No PDF URL available for this arXiv result")
+
+    pdf_url = paper.pdf_url
+    read_timeout = max(120.0, float(settings.REQUEST_TIMEOUT))
+    timeout = httpx.Timeout(
+        connect=30.0,
+        read=read_timeout,
+        write=30.0,
+        pool=30.0,
+    )
+    headers = {
+        "User-Agent": (
+            f"{settings.APP_NAME}/{settings.APP_VERSION} "
+            "(https://github.com/blazickjp/arxiv-mcp-server; research tool)"
+        ),
+    }
+
+    with httpx.Client(timeout=timeout, follow_redirects=True, headers=headers) as client:
+        with client.stream("GET", pdf_url) as response:
+            response.raise_for_status()
+            with pdf_path.open("wb") as out:
+                for chunk in response.iter_bytes(chunk_size=256 * 1024):
+                    out.write(chunk)
+
+
 def _fetch_pdf_content(paper_id: str) -> tuple[str, arxiv.Result]:
     """Download the PDF from arXiv and convert it to Markdown synchronously.
+
+    The PDF bytes are fetched with :func:`_download_arxiv_pdf_to_path` rather
+    than ``arxiv.Result.download_pdf()`` to avoid truncated downloads on
+    ``export.arxiv.org`` for some files.
 
     Returns (markdown_text, arxiv_result).
     Raises PaperNotFoundError if the paper does not exist, or other exceptions
@@ -215,7 +275,7 @@ def _fetch_pdf_content(paper_id: str) -> tuple[str, arxiv.Result]:
         raise PaperNotFoundError(f"Paper {paper_id} not found on arXiv")
 
     pdf_path = get_paper_path(paper_id, ".pdf")
-    paper.download_pdf(dirpath=pdf_path.parent, filename=pdf_path.name)
+    _download_arxiv_pdf_to_path(paper, pdf_path)
 
     logger.info(f"Converting PDF to markdown for {paper_id}")
     markdown = pymupdf4llm.to_markdown(pdf_path, show_progress=False)

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -242,7 +242,9 @@ def _download_arxiv_pdf_to_path(paper: arxiv.Result, pdf_path: Path) -> None:
         ),
     }
 
-    with httpx.Client(timeout=timeout, follow_redirects=True, headers=headers) as client:
+    with httpx.Client(
+        timeout=timeout, follow_redirects=True, headers=headers
+    ) as client:
         with client.stream("GET", pdf_url) as response:
             response.raise_for_status()
             with pdf_path.open("wb") as out:

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -2,19 +2,65 @@
 
 import pytest
 import json
-from unittest.mock import MagicMock, patch
-from pathlib import Path
+from unittest.mock import MagicMock
 
 import arxiv
-import httpx
 
 from arxiv_mcp_server.tools.download import (
     handle_download,
     get_paper_path,
     _html_to_text,
     _fetch_html_content,
+    _download_arxiv_pdf_to_path,
     PaperNotFoundError,
 )
+
+# ---------------------------------------------------------------------------
+# PDF download helper (httpx streaming)
+# ---------------------------------------------------------------------------
+
+
+def test_download_arxiv_pdf_streams_via_httpx(temp_storage_path, mocker):
+    """_download_arxiv_pdf_to_path streams from paper.pdf_url; never calls download_pdf."""
+    import arxiv_mcp_server.tools.download as dl
+
+    stream_response = MagicMock()
+    stream_response.raise_for_status = MagicMock()
+    stream_response.iter_bytes.return_value = [b"chunk-one", b"chunk-two"]
+
+    stream_cm = MagicMock()
+    stream_cm.__enter__.return_value = stream_response
+    stream_cm.__exit__.return_value = False
+
+    http_client = MagicMock()
+    http_client.stream.return_value = stream_cm
+    http_client.__enter__.return_value = http_client
+    http_client.__exit__.return_value = False
+
+    mocker.patch.object(dl.httpx, "Client", return_value=http_client)
+
+    paper = MagicMock(spec=arxiv.Result)
+    paper.pdf_url = "https://arxiv.org/pdf/2103.00000.pdf"
+    dest = temp_storage_path / "paper.pdf"
+
+    _download_arxiv_pdf_to_path(paper, dest)
+
+    assert dest.read_bytes() == b"chunk-onechunk-two"
+    http_client.stream.assert_called_once()
+    assert http_client.stream.call_args[0][0] == "GET"
+    assert http_client.stream.call_args[0][1] == paper.pdf_url
+    paper.download_pdf.assert_not_called()
+
+
+def test_download_arxiv_pdf_requires_pdf_url(temp_storage_path):
+    """Missing pdf_url must fail fast with a clear error."""
+    paper = MagicMock(spec=arxiv.Result)
+    paper.pdf_url = None
+    dest = temp_storage_path / "missing.pdf"
+
+    with pytest.raises(ValueError, match="No PDF URL available"):
+        _download_arxiv_pdf_to_path(paper, dest)
+
 
 # ---------------------------------------------------------------------------
 # Unit tests for HTML parser


### PR DESCRIPTION
Fixes #98

## Problem

Some papers failed to convert after download: PDFs were incomplete (truncated reads, often around 1–2 MiB). The upstream `arxiv` package’s `Result.download_pdf()` ultimately fetches via `urllib` against `export.arxiv.org`, which has proven unreliable for certain larger PDFs in practice and breaks the PDF → markdown pipeline.

## Solution

Fetch PDF bytes using the canonical `pdf_url` from the arXiv API — typically `https://arxiv.org/pdf/...` — with **httpx**: HTTP/2-ready client already used elsewhere for HTML fetches, with **streaming**, explicit status checks, and redirect following.

## Implementation

- New helper `_download_arxiv_pdf_to_path(paper, pdf_path)` writes the response in **256 KiB chunks** to cap memory use.
- **Timeouts:** connect/write/pool 30s; read timeout `max(120s, REQUEST_TIMEOUT)` so slower links or large files are less likely to fail prematurely.
- **User-Agent** matches existing project identification for HTTP requests.
- `ValueError` when `pdf_url` is missing.
- `_fetch_pdf_content` now calls this helper instead of `paper.download_pdf()`.

## Testing

- Unit tests verify streaming GET against `pdf_url`, concatenated chunked output, and that `download_pdf` is **not** invoked.
- Test for missing `pdf_url` and expected error message.

## Checklist

- [x] Behaviour change localized to PDF download path
- [x] Tests added / updated for the new helper