### PR TITLE
fix(tests): validate response shape before indexing in alert tests

### DIFF
--- a/tests/tools/test_alerts.py
+++ b/tests/tools/test_alerts.py
@@ -25,8 +25,11 @@ async def test_watch_topic_persists_topic(alerts_test_env):
         {"topic": "multi-agent systems", "categories": ["cs.AI"]}
     )
 
+    assert len(response) >= 1
     payload = json.loads(response[0].text)
     assert payload["status"] == "success"
+    assert "topic" in payload
+    assert isinstance(payload["topic"], dict)
     assert payload["topic"]["topic"] == "multi-agent systems"
 
 
@@ -53,7 +56,36 @@ async def test_check_alerts_returns_new_papers(monkeypatch, alerts_test_env):
     await alerts_module.handle_watch_topic({"topic": "agents"})
     response = await alerts_module.handle_check_alerts({})
 
+    assert len(response) >= 1
     payload = json.loads(response[0].text)
     assert payload["status"] == "success"
     assert payload["checked_topics"] == 1
+    assert "alerts" in payload
+    assert len(payload["alerts"]) >= 1
+    assert "new_paper_count" in payload["alerts"][0]
     assert payload["alerts"][0]["new_paper_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_handles_partial_paper_fields(monkeypatch, alerts_test_env):
+    """check_alerts must not raise KeyError when a paper entry is missing optional fields."""
+
+    async def _mock_partial(**kwargs):
+        return [
+            {
+                "id": "2501.00002",
+                "title": "Sparse Paper",
+                # "authors", "abstract", "url", "resource_uri" intentionally absent
+                "categories": ["cs.AI"],
+                "published": "2025-01-01T00:00:00Z",
+            }
+        ]
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_partial)
+
+    await alerts_module.handle_watch_topic({"topic": "agents"})
+    response = await alerts_module.handle_check_alerts({})
+
+    assert len(response) >= 1
+    payload = json.loads(response[0].text)
+    assert "status" in payload


### PR DESCRIPTION
## Summary
The alert tests accessed nested response keys (`payload["topic"]["topic"]`, `payload["alerts"][0]["new_paper_count"]`) and `response[0]` without first asserting the outer shape, so a malformed handler response would raise `KeyError`/`IndexError` instead of a clear assertion failure. The fix adds shape-guard assertions before each nested access and adds a test that verifies the handler returns a structured response rather than raising when a paper entry is missing optional fields.

## Why it matters
Without the shape guards, if `handle_check_alerts` returns `{"status": "success", "alerts": []}` or omits the `"topic"` key entirely, the test crashes with an opaque `IndexError`/`KeyError` rather than identifying the real regression.

## Testing
Existing tests are unchanged in intent; the new guard assertions are logically implied by the subsequent key accesses that were already present. The new `test_check_alerts_handles_partial_paper_fields` test exercises the partial-response path directly.