### PR TITLE
fix: close MCP tool schemas and align server metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.blazickjp/arxiv-mcp-server",
-  "version": "0.4.12",
+  "version": "0.5.0",
   "description": "Search arXiv papers, download full text, semantic search, citation graphs, and alerts via MCP.",
   "repository": {
     "url": "https://github.com/blazickjp/arxiv-mcp-server",
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "arxiv-mcp-server",
-      "version": "0.4.12",
+      "version": "0.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -59,6 +59,7 @@ watch_topic_tool = types.Tool(
             },
         },
         "required": ["topic"],
+        "additionalProperties": False,
     },
 )
 
@@ -84,6 +85,7 @@ check_alerts_tool = types.Tool(
                 ),
             }
         },
+        "additionalProperties": False,
     },
 )
 

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -31,6 +31,7 @@ citation_graph_tool = types.Tool(
             }
         },
         "required": ["paper_id"],
+        "additionalProperties": False,
     },
 )
 

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -160,6 +160,7 @@ download_tool = types.Tool(
             },
         },
         "required": ["paper_id"],
+        "additionalProperties": False,
     },
 )
 

--- a/src/arxiv_mcp_server/tools/get_abstract.py
+++ b/src/arxiv_mcp_server/tools/get_abstract.py
@@ -38,6 +38,7 @@ abstract_tool = types.Tool(
             }
         },
         "required": ["paper_id"],
+        "additionalProperties": False,
     },
 )
 

--- a/src/arxiv_mcp_server/tools/list_papers.py
+++ b/src/arxiv_mcp_server/tools/list_papers.py
@@ -37,6 +37,7 @@ list_tool = types.Tool(
         "type": "object",
         "properties": {},
         "required": [],
+        "additionalProperties": False,
     },
 )
 

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -33,6 +33,7 @@ read_tool = types.Tool(
             }
         },
         "required": ["paper_id"],
+        "additionalProperties": False,
     },
 )
 

--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -372,6 +372,7 @@ TIPS FOR FOUNDATIONAL RESEARCH:
             },
         },
         "required": ["query"],
+        "additionalProperties": False,
     },
 )
 

--- a/src/arxiv_mcp_server/tools/semantic_search.py
+++ b/src/arxiv_mcp_server/tools/semantic_search.py
@@ -78,6 +78,7 @@ semantic_search_tool = types.Tool(
                 "default": 10,
             },
         },
+        "additionalProperties": False,
     },
 )
 
@@ -97,6 +98,7 @@ reindex_tool = types.Tool(
                 "default": True,
             }
         },
+        "additionalProperties": False,
     },
 )
 

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,0 +1,15 @@
+"""Tool schema compatibility tests."""
+
+from arxiv_mcp_server.server import list_tools
+
+
+async def test_tool_input_schemas_are_closed():
+    """MCP clients expect tool schemas to reject unknown arguments."""
+    tools = await list_tools()
+
+    assert tools
+    for tool in tools:
+        assert tool.inputSchema["type"] == "object"
+        assert (
+            tool.inputSchema.get("additionalProperties") is False
+        ), f"{tool.name} inputSchema must set additionalProperties=False"


### PR DESCRIPTION
## Summary
- Add additionalProperties: false to every tool input schema for stricter MCP client compatibility
- Align server.json package metadata with the 0.5.0 project version
- Add a regression test that all listed tools expose closed object schemas

Closes #103

## Test Plan
- uv run black src tests
- uv run pytest
