### PR TITLE
Fix large paper truncation with paginated content responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,11 +272,18 @@ result = await call_tool("search_papers", {
 Supported categories include `cs.AI`, `cs.LG`, `cs.CL`, `cs.CV`, `cs.NE`, `stat.ML`, `math.OC`, `quant-ph`, `eess.SP`, and more. See tool description for the full list.
 
 ### 2. Paper Download
-Download a paper by its arXiv ID. Tries HTML first, falls back to PDF. Stores the paper locally for `read_paper` and `semantic_search`.
+Download a paper by its arXiv ID. Tries HTML first, falls back to PDF. Stores the paper locally for `read_paper` and `semantic_search`. The response includes `content_length`, `returned_chars`, `next_start`, and `is_truncated` so clients can safely page through very large papers without mistaking client-side output caps for failed downloads.
 
 ```python
 result = await call_tool("download_paper", {
     "paper_id": "2401.12345"
+})
+
+# For very large papers, request bounded chunks:
+result = await call_tool("download_paper", {
+    "paper_id": "2401.12345",
+    "start": 0,
+    "max_chars": 50000
 })
 ```
 
@@ -290,11 +297,17 @@ result = await call_tool("list_papers", {})
 ```
 
 ### 4. Read Paper
-Read the full text of a locally downloaded paper in markdown. **Requires `download_paper` to be called first.**
+Read the full text of a locally downloaded paper in markdown. **Requires `download_paper` to be called first.** Use `start` and `max_chars` with the returned `next_start` value to page through large papers.
 
 ```python
 result = await call_tool("read_paper", {
     "paper_id": "2401.12345"
+})
+
+result = await call_tool("read_paper", {
+    "paper_id": "2401.12345",
+    "start": 50000,
+    "max_chars": 50000
 })
 ```
 

--- a/src/arxiv_mcp_server/tools/content.py
+++ b/src/arxiv_mcp_server/tools/content.py
@@ -1,0 +1,66 @@
+"""Helpers for returning large paper content safely."""
+
+from typing import Any
+
+
+def _coerce_nonnegative_int(value: Any, default: int) -> int:
+    """Return ``value`` as a non-negative integer, or ``default`` if absent."""
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, parsed)
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    """Return ``value`` as a positive integer, or None if absent/invalid."""
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def paginate_content(content: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Slice paper content and report continuation metadata.
+
+    MCP clients and model gateways often impose per-tool-output display/context
+    caps. Returning explicit chunks lets callers retrieve complete papers without
+    mistaking client-side truncation for a failed download.
+    """
+    content_length = len(content)
+    start = min(_coerce_nonnegative_int(arguments.get("start"), 0), content_length)
+    max_chars = _coerce_positive_int(arguments.get("max_chars"))
+
+    end = (
+        content_length if max_chars is None else min(content_length, start + max_chars)
+    )
+    chunk = content[start:end]
+    is_truncated = end < content_length
+
+    return {
+        "content": chunk,
+        "content_length": content_length,
+        "start": start,
+        "returned_chars": len(chunk),
+        "next_start": end if is_truncated else None,
+        "is_truncated": is_truncated,
+    }
+
+
+def add_content_payload(
+    payload: dict[str, Any],
+    content: str,
+    arguments: dict[str, Any],
+    content_warning: str,
+) -> dict[str, Any]:
+    """Add paginated content fields to a JSON response payload."""
+    page = paginate_content(content, arguments)
+    chunk = page.pop("content")
+    payload.update(page)
+    payload["content"] = content_warning + chunk
+    return payload

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, List
 import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings, get_arxiv_client
+from .content import add_content_payload
 import logging
 
 _MAX_TRACKED_CONVERSIONS = 100  # prevent unbounded growth of conversion_statuses
@@ -146,10 +147,10 @@ download_tool = types.Tool(
     name="download_paper",
     annotations=ToolAnnotations(readOnlyHint=False, openWorldHint=True),
     description=(
-        "Download a paper from arXiv and return its full text content. "
+        "Download a paper from arXiv and return its text content. "
         "Tries the HTML version first for clean extraction; falls back to "
-        "PDF conversion if HTML is unavailable. Returns the paper content "
-        "directly so you can read it immediately."
+        "PDF conversion if HTML is unavailable. Stores the paper locally "
+        "and supports start/max_chars pagination for very large papers."
     ),
     inputSchema={
         "type": "object",
@@ -157,6 +158,16 @@ download_tool = types.Tool(
             "paper_id": {
                 "type": "string",
                 "description": "The arXiv ID of the paper to download (e.g. '2103.12345')",
+            },
+            "start": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Zero-based character offset for returning large papers in chunks",
+            },
+            "max_chars": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum raw paper characters to return from start; omit for full content",
             },
         },
         "required": ["paper_id"],
@@ -313,18 +324,21 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 asyncio.create_task(_run_index_by_id(paper_id))
             except RuntimeError:
                 pass
+            payload = add_content_payload(
+                {
+                    "status": "success",
+                    "message": "Paper already available (returned from cache)",
+                    "paper_id": paper_id,
+                    "source": "cache",
+                },
+                content,
+                arguments,
+                _CONTENT_WARNING,
+            )
             return [
                 types.TextContent(
                     type="text",
-                    text=json.dumps(
-                        {
-                            "status": "success",
-                            "message": "Paper already available (returned from cache)",
-                            "paper_id": paper_id,
-                            "source": "cache",
-                            "content": _CONTENT_WARNING + content,
-                        }
-                    ),
+                    text=json.dumps(payload),
                 )
             ]
 
@@ -339,18 +353,21 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 asyncio.create_task(_run_index_by_id(paper_id))
             except RuntimeError:
                 pass
+            payload = add_content_payload(
+                {
+                    "status": "success",
+                    "message": "Paper fetched from arXiv HTML endpoint",
+                    "paper_id": paper_id,
+                    "source": "html",
+                },
+                html_text,
+                arguments,
+                _CONTENT_WARNING,
+            )
             return [
                 types.TextContent(
                     type="text",
-                    text=json.dumps(
-                        {
-                            "status": "success",
-                            "message": "Paper fetched from arXiv HTML endpoint",
-                            "paper_id": paper_id,
-                            "source": "html",
-                            "content": _CONTENT_WARNING + html_text,
-                        }
-                    ),
+                    text=json.dumps(payload),
                 )
             ]
 
@@ -384,18 +401,21 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
         except RuntimeError:
             pass
 
+        payload = add_content_payload(
+            {
+                "status": "success",
+                "message": "Paper fetched via PDF conversion",
+                "paper_id": paper_id,
+                "source": "pdf",
+            },
+            markdown,
+            arguments,
+            _CONTENT_WARNING,
+        )
         return [
             types.TextContent(
                 type="text",
-                text=json.dumps(
-                    {
-                        "status": "success",
-                        "message": "Paper fetched via PDF conversion",
-                        "paper_id": paper_id,
-                        "source": "pdf",
-                        "content": _CONTENT_WARNING + markdown,
-                    }
-                ),
+                text=json.dumps(payload),
             )
         ]
 

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, List
 import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings
+from .content import add_content_payload
 
 settings = Settings()
 
@@ -19,8 +20,8 @@ read_tool = types.Tool(
     name="read_paper",
     annotations=ToolAnnotations(readOnlyHint=True),
     description=(
-        "Read the full text content of a paper that was previously downloaded via download_paper. "
-        "Returns the paper in markdown format. "
+        "Read the text content of a paper that was previously downloaded via download_paper. "
+        "Returns the paper in markdown format and supports start/max_chars pagination for large papers. "
         "Will fail with a clear error if the paper has not been downloaded yet — call download_paper first. "
         "Workflow: search_papers -> download_paper -> read_paper."
     ),
@@ -30,7 +31,17 @@ read_tool = types.Tool(
             "paper_id": {
                 "type": "string",
                 "description": "The arXiv ID of the paper to read",
-            }
+            },
+            "start": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Zero-based character offset for reading large papers in chunks",
+            },
+            "max_chars": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum raw paper characters to return from start; omit for full content",
+            },
         },
         "required": ["paper_id"],
         "additionalProperties": False,
@@ -67,16 +78,20 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
             encoding="utf-8"
         )
 
+        payload = add_content_payload(
+            {
+                "status": "success",
+                "paper_id": paper_id,
+            },
+            content,
+            arguments,
+            _CONTENT_WARNING,
+        )
+
         return [
             types.TextContent(
                 type="text",
-                text=json.dumps(
-                    {
-                        "status": "success",
-                        "paper_id": paper_id,
-                        "content": _CONTENT_WARNING + content,
-                    }
-                ),
+                text=json.dumps(payload),
             )
         ]
 

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -128,6 +128,45 @@ async def test_cached_paper_returns_immediately(temp_storage_path, mocker):
     assert result["status"] == "success"
     assert result["source"] == "cache"
     assert "Cached Paper" in result["content"]
+    assert result["content_length"] == len("# Cached Paper\nThis is cached content.")
+    assert result["next_start"] is None
+    assert result["is_truncated"] is False
+    mock_httpx.assert_not_called()
+    mock_pdf.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_download_cache_supports_content_pagination(temp_storage_path, mocker):
+    """download_paper can return a bounded chunk to avoid MCP client truncation."""
+    paper_id = "2505.13525"
+
+    def fake_path(pid, suffix=".md"):
+        return temp_storage_path / f"{pid}{suffix}"
+
+    mocker.patch(
+        "arxiv_mcp_server.tools.download.get_paper_path", side_effect=fake_path
+    )
+
+    md_path = temp_storage_path / f"{paper_id}.md"
+    content = "abcdefghijklmnopqrstuvwxyz"
+    md_path.write_text(content, encoding="utf-8")
+    mock_httpx = mocker.patch("arxiv_mcp_server.tools.download._fetch_html_content")
+    mock_pdf = mocker.patch("arxiv_mcp_server.tools.download._fetch_pdf_content")
+
+    response = await handle_download(
+        {"paper_id": paper_id, "start": 10, "max_chars": 5}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["source"] == "cache"
+    assert result["content_length"] == len(content)
+    assert result["start"] == 10
+    assert result["returned_chars"] == 5
+    assert result["next_start"] == 15
+    assert result["is_truncated"] is True
+    chunk = result["content"].split("\n\n", 1)[1]
+    assert chunk == "klmno"
     mock_httpx.assert_not_called()
     mock_pdf.assert_not_called()
 

--- a/tests/tools/test_read_paper.py
+++ b/tests/tools/test_read_paper.py
@@ -1,0 +1,62 @@
+"""Tests for reading downloaded papers."""
+
+import json
+
+import pytest
+
+from arxiv_mcp_server.tools import read_paper as read_module
+from arxiv_mcp_server.tools.read_paper import handle_read_paper
+
+
+@pytest.mark.asyncio
+async def test_read_paper_supports_content_pagination(temp_storage_path, monkeypatch):
+    """Large papers can be retrieved in bounded chunks instead of one huge payload."""
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "2505.13525"
+    content = "abcdefghijklmnopqrstuvwxyz"
+    (temp_storage_path / f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    response = await handle_read_paper(
+        {"paper_id": paper_id, "start": 5, "max_chars": 10}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["paper_id"] == paper_id
+    assert result["content_length"] == len(content)
+    assert result["start"] == 5
+    assert result["returned_chars"] == 10
+    assert result["next_start"] == 15
+    assert result["is_truncated"] is True
+    chunk = result["content"].split("\n\n", 1)[1]
+    assert chunk == "fghijklmno"
+
+
+@pytest.mark.asyncio
+async def test_read_paper_reports_end_of_content_for_final_chunk(
+    temp_storage_path, monkeypatch
+):
+    """Final chunks should make it obvious that there is no hidden continuation."""
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "2505.13525"
+    content = "abcdefghijklmnopqrstuvwxyz"
+    (temp_storage_path / f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    response = await handle_read_paper(
+        {"paper_id": paper_id, "start": 20, "max_chars": 20}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["returned_chars"] == 6
+    assert result["next_start"] is None
+    assert result["is_truncated"] is False
+    assert result["content"].endswith("uvwxyz")


### PR DESCRIPTION
Fixes #96

## Summary
- Add shared content pagination metadata for large paper payloads
- Support optional `start` and `max_chars` on both `download_paper` and `read_paper`
- Preserve legacy full-content behavior when pagination args are omitted
- Document chunked retrieval in the README

## Root cause
The paper download itself is not necessarily truncated; large JSON tool responses can be capped by MCP clients/model gateways. A caller then sees a synthetic `... (truncated)` suffix and cannot recover the remaining paper through the old API.

## Tests
- `uv run black --check src tests`
- `uv run pytest -q`