### PR TITLE
docs: Update installation link and command for ArXiv Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Agentic AI framework as **AG01: Prompt Injection in LLM-Integrated Systems**.
 
 ### Installing via Smithery
 
-To install ArXiv Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/arxiv-mcp-server):
+To install ArXiv Server for Claude Desktop automatically via [Smithery](https://smithery.ai/servers/cyanheads/arxiv-mcp-server):
 
 ```bash
-npx -y @smithery/cli install arxiv-mcp-server --client claude
+npx -y @smithery/cli install @cyanheads/arxiv-mcp-server --client claude
 ```
 
 ### Installing via Claude Desktop (.mcpb)


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to reflect the correct Smithery package path and name for the ArXiv Server for Claude Desktop.

Documentation updates:

* Updated the Smithery installation command to use the new package path `@cyanheads/arxiv-mcp-server` and the correct URL for the server.