### PR TITLE
citation_graph: token-efficient pagination/compaction + 429 retry (opt-in, backward-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Optional parameters (all opt-in; omit them for the legacy full-output behavior):
 - `offset` (integer, ≥ 0): pagination offset. Applies **only** together with `limit` or `compact`; passing `offset` alone is ignored and falls through to the legacy path.
 - `compact` (boolean): strips author lists + nested `external_ids` and minifies the JSON for lower token cost.
 
-When paginating (`limit` or `compact` set), `citation_count`/`reference_count` report the edges returned in the **current page**, not the paper's totals. Use the `pagination` block's `next` value as the `offset` for the next page.
+When paginating (`limit` or `compact` set), `citation_count`/`reference_count` report the edges returned in the **current page**, not the paper's totals. The response carries a `pagination` block with an independent cursor per direction — `pagination.citations.next` and `pagination.references.next` (each is the next `offset`, or `null` when that direction is exhausted). `offset` is a single value applied to **both** directions, so to page deeply through one direction, advance `offset` to its `next`; the other direction re-paginates from the same `offset` (references are usually small enough to fit one page).
 
 ```python
 result = await call_tool("citation_graph", {

--- a/README.md
+++ b/README.md
@@ -401,6 +401,22 @@ result = await call_tool("citation_graph", {
 })
 ```
 
+Optional parameters (all opt-in; omit them for the legacy full-output behavior):
+
+- `limit` (integer, 1–1000): max edges per direction, using Semantic Scholar's paginated endpoints.
+- `offset` (integer, ≥ 0): pagination offset. Applies **only** together with `limit` or `compact`; passing `offset` alone is ignored and falls through to the legacy path.
+- `compact` (boolean): strips author lists + nested `external_ids` and minifies the JSON for lower token cost.
+
+When paginating (`limit` or `compact` set), `citation_count`/`reference_count` report the edges returned in the **current page**, not the paper's totals. Use the `pagination` block's `next` value as the `offset` for the next page.
+
+```python
+result = await call_tool("citation_graph", {
+    "paper_id": "2401.12345",
+    "compact": True,
+    "limit": 50
+})
+```
+
 ### Research Alerts
 Save topic watches and poll for newly published papers since the last check. Uses the same query syntax as `search_papers`.
 

--- a/src/arxiv_mcp_server/config.py
+++ b/src/arxiv_mcp_server/config.py
@@ -46,6 +46,7 @@ class Settings(BaseSettings):
     PORT: int = 8000
     ALLOWED_HOSTS: str = ""
     ALLOWED_ORIGINS: str = ""
+    CITATION_MAX_EDGES: int | None = None
     model_config = SettingsConfigDict(extra="allow")
 
     @property

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import random
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote
 
@@ -19,23 +20,47 @@ settings = Settings()
 
 SEMANTIC_SCHOLAR_BASE_URL = "https://api.semanticscholar.org/graph/v1/paper"
 
+# Cap on any single backoff sleep. asyncio.sleep is NOT covered by the httpx
+# request timeout, so an unbounded server-supplied Retry-After (or an unbounded
+# exponential backoff) could otherwise hang the tool for hours.
+MAX_RETRY_DELAY = 16.0
 
-async def _s2_get(client, url, *, headers=None, max_retries=4, base_delay=1.0):
-    """GET with exponential backoff on HTTP 429 (S2 unauthenticated rate limit).
+# Transient HTTP statuses worth retrying. 500 is deliberately excluded: it is
+# often a permanent server-side error, not a transient one.
+RETRYABLE_STATUS = {429, 502, 503, 504}
 
-    Honors a numeric Retry-After header when present. Returns the final response
-    (caller still calls raise_for_status())."""
-    response = await client.get(url, headers=headers or {})
-    for attempt in range(max_retries):
-        if response.status_code != 429:
+
+def _backoff_delay(retry_after, base_delay, attempt):
+    """Compute the next sleep, clamped to MAX_RETRY_DELAY.
+
+    A numeric Retry-After (status responses only) is honored but clamped. Absent
+    that, full jitter over the clamped exponential window is used."""
+    if retry_after is not None and str(retry_after).isdigit():
+        return min(float(retry_after), MAX_RETRY_DELAY)
+    return random.uniform(0, min(base_delay * (2**attempt), MAX_RETRY_DELAY))
+
+
+async def _s2_get(client, url, *, max_retries=4, base_delay=1.0):
+    """GET with backoff on transient failures (S2 rate limits / 5xx / transport).
+
+    Retries on RETRYABLE_STATUS responses and httpx.TransportError up to
+    max_retries times (max_retries + 1 total GETs). Honors a numeric Retry-After
+    header on status responses (clamped to MAX_RETRY_DELAY); transport errors use
+    jittered exponential backoff. Returns the final response (caller still calls
+    raise_for_status())."""
+    response = None
+    for attempt in range(max_retries + 1):
+        try:
+            response = await client.get(url)
+        except httpx.TransportError:
+            if attempt == max_retries:
+                raise
+            await asyncio.sleep(_backoff_delay(None, base_delay, attempt))
+            continue
+        if response.status_code not in RETRYABLE_STATUS or attempt == max_retries:
             return response
         retry_after = response.headers.get("Retry-After")
-        if retry_after is not None and str(retry_after).isdigit():
-            delay = float(retry_after)
-        else:
-            delay = base_delay * (2**attempt)
-        await asyncio.sleep(delay)
-        response = await client.get(url, headers=headers or {})
+        await asyncio.sleep(_backoff_delay(retry_after, base_delay, attempt))
     return response
 
 
@@ -44,9 +69,13 @@ def _apply_edge_cap(
     references: List[Dict[str, Any]],
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], bool]:
     """Truncate edge lists to settings.CITATION_MAX_EDGES (per direction) when
-    configured. Returns (citations, references, truncated: bool)."""
+    configured. Returns (citations, references, truncated: bool).
+
+    A negative cap is treated as "no cap" (graceful handling of bad config) so a
+    negative value never produces the surprising `lst[:-n]` slice. cap == 0 is a
+    valid "return zero edges" request."""
     cap: Optional[int] = settings.CITATION_MAX_EDGES
-    if cap is None:
+    if cap is None or cap < 0:
         return citations, references, False
     truncated = len(citations) > cap or len(references) > cap
     return citations[:cap], references[:cap], truncated
@@ -61,7 +90,8 @@ citation_graph_tool = types.Tool(
         "(`limit` or `compact` set), `citation_count`/`reference_count` report "
         "edges returned in the current page; each direction has its own cursor "
         "(`pagination.citations.next` / `pagination.references.next`) to pass as "
-        "the next `offset`."
+        "the next `offset`. If an output cap is configured (CITATION_MAX_EDGES), "
+        "a `truncated` flag is added when results were capped (legacy path only)."
     ),
     inputSchema={
         "type": "object",
@@ -219,16 +249,17 @@ async def _handle_citation_graph_paginated(
             "external_ids": root_payload.get("externalIds", {}),
         }
 
-    citations, references, truncated = _apply_edge_cap(citations, references)
-
+    # NOTE: no _apply_edge_cap here. The caller-supplied `limit` already bounds
+    # this path coherently with the per-direction pagination cursors; truncating
+    # edges while `pagination.<dir>.next` still reflects S2's uncapped cursor
+    # would make a paging client silently skip edges. The output cap is applied
+    # ONLY in the legacy/unbounded path.
     result = {
         "status": "success",
         "paper": paper,
         "citation_count": len(citations),
         "reference_count": len(references),
     }
-    if truncated:
-        result["truncated"] = True
     result.update(
         {
             "citations": citations,

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -2,18 +2,55 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote
 
 import httpx
 import mcp.types as types
 from mcp.types import ToolAnnotations
 
+from ..config import Settings
+
 logger = logging.getLogger("arxiv-mcp-server")
+settings = Settings()
 
 SEMANTIC_SCHOLAR_BASE_URL = "https://api.semanticscholar.org/graph/v1/paper"
+
+
+async def _s2_get(client, url, *, headers=None, max_retries=4, base_delay=1.0):
+    """GET with exponential backoff on HTTP 429 (S2 unauthenticated rate limit).
+
+    Honors a numeric Retry-After header when present. Returns the final response
+    (caller still calls raise_for_status())."""
+    response = await client.get(url, headers=headers or {})
+    for attempt in range(max_retries):
+        if response.status_code != 429:
+            return response
+        retry_after = response.headers.get("Retry-After")
+        if retry_after is not None and str(retry_after).isdigit():
+            delay = float(retry_after)
+        else:
+            delay = base_delay * (2**attempt)
+        await asyncio.sleep(delay)
+        response = await client.get(url, headers=headers or {})
+    return response
+
+
+def _apply_edge_cap(
+    citations: List[Dict[str, Any]],
+    references: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], bool]:
+    """Truncate edge lists to settings.CITATION_MAX_EDGES (per direction) when
+    configured. Returns (citations, references, truncated: bool)."""
+    cap: Optional[int] = settings.CITATION_MAX_EDGES
+    if cap is None:
+        return citations, references, False
+    truncated = len(citations) > cap or len(references) > cap
+    return citations[:cap], references[:cap], truncated
+
 
 citation_graph_tool = types.Tool(
     name="citation_graph",
@@ -139,11 +176,11 @@ async def _handle_citation_graph_paginated(
     )
 
     async with httpx.AsyncClient(timeout=30.0) as client:
-        root_response = await client.get(root_url)
+        root_response = await _s2_get(client, root_url)
         root_response.raise_for_status()
-        citations_response = await client.get(citations_url)
+        citations_response = await _s2_get(client, citations_url)
         citations_response.raise_for_status()
-        references_response = await client.get(references_url)
+        references_response = await _s2_get(client, references_url)
         references_response.raise_for_status()
 
     root_payload = root_response.json()
@@ -182,27 +219,35 @@ async def _handle_citation_graph_paginated(
             "external_ids": root_payload.get("externalIds", {}),
         }
 
+    citations, references, truncated = _apply_edge_cap(citations, references)
+
     result = {
         "status": "success",
         "paper": paper,
         "citation_count": len(citations),
         "reference_count": len(references),
-        "citations": citations,
-        "references": references,
-        "pagination": {
-            "limit": page_limit,
-            "citations": {
-                "offset": page_offset,
-                "next": citations_payload.get("next"),
-                "returned": len(citations),
-            },
-            "references": {
-                "offset": page_offset,
-                "next": references_payload.get("next"),
-                "returned": len(references),
-            },
-        },
     }
+    if truncated:
+        result["truncated"] = True
+    result.update(
+        {
+            "citations": citations,
+            "references": references,
+            "pagination": {
+                "limit": page_limit,
+                "citations": {
+                    "offset": page_offset,
+                    "next": citations_payload.get("next"),
+                    "returned": len(citations),
+                },
+                "references": {
+                    "offset": page_offset,
+                    "next": references_payload.get("next"),
+                    "returned": len(references),
+                },
+            },
+        }
+    )
 
     if compact:
         text = json.dumps(result, separators=(",", ":"))
@@ -245,12 +290,14 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
         url = f"{SEMANTIC_SCHOLAR_BASE_URL}/{s2_paper_identifier}?fields={fields}"
 
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(url)
+            response = await _s2_get(client, url)
             response.raise_for_status()
 
         payload = response.json()
         citations = _normalize_paper_items(payload.get("citations", []))
         references = _normalize_paper_items(payload.get("references", []))
+
+        citations, references, truncated = _apply_edge_cap(citations, references)
 
         result = {
             "status": "success",
@@ -266,9 +313,11 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
             },
             "citation_count": len(citations),
             "reference_count": len(references),
-            "citations": citations,
-            "references": references,
         }
+        if truncated:
+            result["truncated"] = True
+        result["citations"] = citations
+        result["references"] = references
 
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -47,7 +47,10 @@ async def _s2_get(client, url, *, max_retries=4, base_delay=1.0):
     max_retries times (max_retries + 1 total GETs). Honors a numeric Retry-After
     header on status responses (clamped to MAX_RETRY_DELAY); transport errors use
     jittered exponential backoff. Returns the final response (caller still calls
-    raise_for_status())."""
+    raise_for_status()).
+
+    Worst-case blocking per call is bounded by max_retries * MAX_RETRY_DELAY
+    (~64s); the paginated path makes three such calls sequentially."""
     response = None
     for attempt in range(max_retries + 1):
         try:

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -20,7 +20,10 @@ citation_graph_tool = types.Tool(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     description=(
         "Return papers citing an arXiv paper and papers that it references "
-        "using Semantic Scholar's citation graph."
+        "using Semantic Scholar's citation graph. In paginated mode, "
+        "`citation_count`/`reference_count` report edges returned in the current "
+        "page; use the `pagination` block's `next` value as the `offset` for the "
+        "next page."
     ),
     inputSchema={
         "type": "object",
@@ -41,7 +44,10 @@ citation_graph_tool = types.Tool(
             "offset": {
                 "type": "integer",
                 "minimum": 0,
-                "description": "Pagination offset applied to both directions.",
+                "description": (
+                    "Pagination offset (applies only together with `limit` or "
+                    "`compact`)."
+                ),
             },
             "compact": {
                 "type": "boolean",
@@ -106,6 +112,13 @@ async def _handle_citation_graph_paginated(
     compact: bool,
 ) -> List[types.TextContent]:
     """Opt-in paginated/compact path using Semantic Scholar's dedicated endpoints."""
+    # Defense-in-depth: the schema bounds (1..1000, >=0) are enforced only by the
+    # MCP SDK validator. Coerce + clamp per-param here so the handler never trusts
+    # the input blindly. NOTE: no `limit + offset <= 1000` sum-clamp — that claim
+    # was tested against the live Semantic Scholar API and refuted.
+    page_limit = max(1, min(1000, int(page_limit)))
+    page_offset = max(0, int(page_offset))
+
     s2_paper_identifier = quote(f"ARXIV:{paper_id}")
 
     # Request order (matches the test's side_effect ordering):
@@ -210,7 +223,10 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
         offset = arguments.get("offset")
         compact = bool(arguments.get("compact", False))
 
-        if not (limit is None and offset is None and not compact):
+        # Pagination is triggered only by `limit` or `compact`. `offset` alone is
+        # a no-op here (it falls through to the legacy path, which has no paging);
+        # it is honored only as a modifier when already paginating.
+        if limit is not None or compact:
             page_limit = limit if limit is not None else 100
             page_offset = offset or 0
             return await _handle_citation_graph_paginated(

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -28,7 +28,28 @@ citation_graph_tool = types.Tool(
             "paper_id": {
                 "type": "string",
                 "description": "arXiv ID (for example: 2401.12345).",
-            }
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 1000,
+                "description": (
+                    "Max edges per direction (opt-in pagination; uses Semantic "
+                    "Scholar's paginated endpoints). Omit for legacy full output."
+                ),
+            },
+            "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Pagination offset applied to both directions.",
+            },
+            "compact": {
+                "type": "boolean",
+                "description": (
+                    "Drop author lists and nested external_ids, return minified "
+                    "id+title edges (lower token cost)."
+                ),
+            },
         },
         "required": ["paper_id"],
         "additionalProperties": False,
@@ -60,12 +81,141 @@ def _normalize_paper_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return normalized
 
 
+def _normalize_paper_items_compact(
+    items: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Normalize paper lists into compact edges (no authors/external_ids)."""
+    normalized: List[Dict[str, Any]] = []
+    for item in items:
+        external_ids = item.get("externalIds") or {}
+        normalized.append(
+            {
+                "paper_id": item.get("paperId"),
+                "arxiv_id": external_ids.get("ArXiv"),
+                "title": item.get("title", ""),
+                "year": item.get("year"),
+            }
+        )
+    return normalized
+
+
+async def _handle_citation_graph_paginated(
+    paper_id: str,
+    page_limit: int,
+    page_offset: int,
+    compact: bool,
+) -> List[types.TextContent]:
+    """Opt-in paginated/compact path using Semantic Scholar's dedicated endpoints."""
+    s2_paper_identifier = quote(f"ARXIV:{paper_id}")
+
+    # Request order (matches the test's side_effect ordering):
+    #   1. root paper metadata
+    #   2. /citations page
+    #   3. /references page
+    root_url = (
+        f"{SEMANTIC_SCHOLAR_BASE_URL}/{s2_paper_identifier}"
+        "?fields=title,year,authors,externalIds"
+    )
+    page_fields = "title,year,authors,externalIds"
+    citations_url = (
+        f"{SEMANTIC_SCHOLAR_BASE_URL}/{s2_paper_identifier}/citations"
+        f"?fields={page_fields}&limit={page_limit}&offset={page_offset}"
+    )
+    references_url = (
+        f"{SEMANTIC_SCHOLAR_BASE_URL}/{s2_paper_identifier}/references"
+        f"?fields={page_fields}&limit={page_limit}&offset={page_offset}"
+    )
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        root_response = await client.get(root_url)
+        root_response.raise_for_status()
+        citations_response = await client.get(citations_url)
+        citations_response.raise_for_status()
+        references_response = await client.get(references_url)
+        references_response.raise_for_status()
+
+    root_payload = root_response.json()
+    citations_payload = citations_response.json()
+    references_payload = references_response.json()
+
+    citation_items = [
+        entry.get("citingPaper", {}) for entry in citations_payload.get("data", [])
+    ]
+    reference_items = [
+        entry.get("citedPaper", {}) for entry in references_payload.get("data", [])
+    ]
+
+    if compact:
+        citations = _normalize_paper_items_compact(citation_items)
+        references = _normalize_paper_items_compact(reference_items)
+        root_external_ids = root_payload.get("externalIds") or {}
+        paper = {
+            "paper_id": root_payload.get("paperId"),
+            "arxiv_id": root_external_ids.get("ArXiv") or paper_id,
+            "title": root_payload.get("title", ""),
+            "year": root_payload.get("year"),
+        }
+    else:
+        citations = _normalize_paper_items(citation_items)
+        references = _normalize_paper_items(reference_items)
+        paper = {
+            "paper_id": root_payload.get("paperId"),
+            "arxiv_id": paper_id,
+            "title": root_payload.get("title", ""),
+            "year": root_payload.get("year"),
+            "authors": [
+                author.get("name", "") for author in root_payload.get("authors", [])
+            ],
+            "external_ids": root_payload.get("externalIds", {}),
+        }
+
+    result = {
+        "status": "success",
+        "paper": paper,
+        "citation_count": len(citations),
+        "reference_count": len(references),
+        "citations": citations,
+        "references": references,
+        "pagination": {
+            "limit": page_limit,
+            "citations": {
+                "offset": page_offset,
+                "next": citations_payload.get("next"),
+                "returned": len(citations),
+            },
+            "references": {
+                "offset": page_offset,
+                "next": references_payload.get("next"),
+                "returned": len(references),
+            },
+        },
+    }
+
+    if compact:
+        text = json.dumps(result, separators=(",", ":"))
+    else:
+        text = json.dumps(result, indent=2)
+
+    return [types.TextContent(type="text", text=text)]
+
+
 async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Handle citation graph lookup for a single arXiv paper ID."""
     try:
         paper_id = arguments["paper_id"].strip()
         if not paper_id:
             return [types.TextContent(type="text", text="Error: paper_id is required")]
+
+        limit = arguments.get("limit")
+        offset = arguments.get("offset")
+        compact = bool(arguments.get("compact", False))
+
+        if not (limit is None and offset is None and not compact):
+            page_limit = limit if limit is not None else 100
+            page_offset = offset or 0
+            return await _handle_citation_graph_paginated(
+                paper_id, page_limit, page_offset, compact
+            )
 
         s2_paper_identifier = quote(f"ARXIV:{paper_id}")
         fields = (

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -20,10 +20,11 @@ citation_graph_tool = types.Tool(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     description=(
         "Return papers citing an arXiv paper and papers that it references "
-        "using Semantic Scholar's citation graph. In paginated mode, "
-        "`citation_count`/`reference_count` report edges returned in the current "
-        "page; use the `pagination` block's `next` value as the `offset` for the "
-        "next page."
+        "using Semantic Scholar's citation graph. In paginated mode "
+        "(`limit` or `compact` set), `citation_count`/`reference_count` report "
+        "edges returned in the current page; each direction has its own cursor "
+        "(`pagination.citations.next` / `pagination.references.next`) to pass as "
+        "the next `offset`."
     ),
     inputSchema={
         "type": "object",
@@ -119,12 +120,10 @@ async def _handle_citation_graph_paginated(
     page_limit = max(1, min(1000, int(page_limit)))
     page_offset = max(0, int(page_offset))
 
-    s2_paper_identifier = quote(f"ARXIV:{paper_id}")
+    s2_paper_identifier = quote(f"ARXIV:{paper_id}", safe="")
 
-    # Request order (matches the test's side_effect ordering):
-    #   1. root paper metadata
-    #   2. /citations page
-    #   3. /references page
+    # Three sequential requests: root paper metadata, then the /citations and
+    # /references pages.
     root_url = (
         f"{SEMANTIC_SCHOLAR_BASE_URL}/{s2_paper_identifier}"
         "?fields=title,year,authors,externalIds"
@@ -161,10 +160,11 @@ async def _handle_citation_graph_paginated(
     if compact:
         citations = _normalize_paper_items_compact(citation_items)
         references = _normalize_paper_items_compact(reference_items)
-        root_external_ids = root_payload.get("externalIds") or {}
+        # arxiv_id echoes the input id on every path (legacy + both paginated
+        # branches) for a consistent paper.arxiv_id contract.
         paper = {
             "paper_id": root_payload.get("paperId"),
-            "arxiv_id": root_external_ids.get("ArXiv") or paper_id,
+            "arxiv_id": paper_id,
             "title": root_payload.get("title", ""),
             "year": root_payload.get("year"),
         }
@@ -221,7 +221,9 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
 
         limit = arguments.get("limit")
         offset = arguments.get("offset")
-        compact = bool(arguments.get("compact", False))
+        # Strict bool: only a JSON `true` enables compact. Guards against a
+        # truthy non-bool (e.g. the string "false") from a non-validating client.
+        compact = arguments.get("compact") is True
 
         # Pagination is triggered only by `limit` or `compact`. `offset` alone is
         # a no-op here (it falls through to the legacy path, which has no paging);
@@ -233,7 +235,7 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
                 paper_id, page_limit, page_offset, compact
             )
 
-        s2_paper_identifier = quote(f"ARXIV:{paper_id}")
+        s2_paper_identifier = quote(f"ARXIV:{paper_id}", safe="")
         fields = (
             "title,year,authors,externalIds,"
             "citations.paperId,citations.title,citations.year,citations.authors,citations.externalIds,"

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from arxiv_mcp_server.tools.citation_graph import handle_citation_graph
@@ -307,3 +308,211 @@ async def test_citation_graph_http_error():
         response = await handle_citation_graph({"paper_id": "2401.12345"})
 
     assert response[0].text.startswith("Error:")
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_offset_only_uses_legacy():
+    """`offset` alone must NOT trigger pagination (backward-compat trap, FIX A).
+
+    Asserts the legacy path: exactly ONE client.get await, indent=2 output
+    (newline present), and no `pagination` key.
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = _legacy_mock_payload()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345", "offset": 5})
+
+    text = response[0].text
+    # Legacy path makes exactly one (nested) request.
+    assert mock_client.get.await_count == 1
+    # Legacy path uses indent=2 -> newlines present in the rendered JSON.
+    assert "\n" in text
+
+    payload = json.loads(text)
+    assert "pagination" not in payload
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_compact_default_limit():
+    """`compact` with no `limit` must default the page limit to 100 (FIX A path)."""
+    root_response = MagicMock()
+    root_response.raise_for_status = MagicMock()
+    root_response.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+
+    citations_response = MagicMock()
+    citations_response.raise_for_status = MagicMock()
+    citations_response.json.return_value = {"offset": 0, "next": 100, "data": []}
+
+    references_response = MagicMock()
+    references_response.raise_for_status = MagicMock()
+    references_response.json.return_value = {"offset": 0, "data": []}
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[root_response, citations_response, references_response]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph(
+            {"paper_id": "2401.12345", "compact": True}
+        )
+
+    payload = json.loads(response[0].text)
+    assert payload["pagination"]["limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_paginated_http_error():
+    """Paginated path surfaces HTTP errors with no partial result (FIX D)."""
+    root_response = MagicMock()
+    root_response.raise_for_status = MagicMock()
+    root_response.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+
+    # The /citations response raises on raise_for_status.
+    failing_response = MagicMock()
+    failing_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "boom", request=MagicMock(), response=MagicMock()
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[root_response, failing_response])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345", "limit": 5})
+
+    text = response[0].text
+    assert text.startswith("Error:")
+    # No partial result emitted.
+    assert "pagination" not in text
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_paginated_empty_data():
+    """Empty /citations data: count 0, no crash, `next` None when absent (FIX D)."""
+    root_response = MagicMock()
+    root_response.raise_for_status = MagicMock()
+    root_response.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+
+    citations_response = MagicMock()
+    citations_response.raise_for_status = MagicMock()
+    # No `next` key -> should normalize to None.
+    citations_response.json.return_value = {"offset": 0, "data": []}
+
+    references_response = MagicMock()
+    references_response.raise_for_status = MagicMock()
+    references_response.json.return_value = {
+        "offset": 0,
+        "next": 5,
+        "data": [
+            {
+                "citedPaper": {
+                    "paperId": "ref-1",
+                    "title": "Referenced Paper",
+                    "year": 2020,
+                    "authors": [{"name": "Author C"}],
+                    "externalIds": {"ArXiv": "2001.00001"},
+                }
+            }
+        ],
+    }
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[root_response, citations_response, references_response]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345", "limit": 5})
+
+    payload = json.loads(response[0].text)
+    assert payload["citation_count"] == 0
+    assert payload["citations"] == []
+    assert payload["pagination"]["citations"]["next"] is None
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_limit_offset_clamped():
+    """Out-of-range limit/offset are clamped in code (FIX B).
+
+    limit=99999 -> 1000, offset=-5 -> 0, reflected in the request URLs.
+    """
+    root_response = MagicMock()
+    root_response.raise_for_status = MagicMock()
+    root_response.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+
+    citations_response = MagicMock()
+    citations_response.raise_for_status = MagicMock()
+    citations_response.json.return_value = {"offset": 0, "data": []}
+
+    references_response = MagicMock()
+    references_response.raise_for_status = MagicMock()
+    references_response.json.return_value = {"offset": 0, "data": []}
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[root_response, citations_response, references_response]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        await handle_citation_graph(
+            {
+                "paper_id": "2401.12345",
+                "limit": 99999,
+                "offset": -5,
+                "compact": True,
+            }
+        )
+
+    # Inspect the awaited request URLs (positional arg 0 of each client.get call).
+    awaited_urls = [call.args[0] for call in mock_client.get.call_args_list]
+    # The two paged endpoints (/citations, /references) must carry the clamped
+    # values. The root metadata request carries neither.
+    paged_urls = [u for u in awaited_urls if "limit=" in u]
+    assert paged_urls, "expected paged endpoint URLs with limit/offset"
+    for url in paged_urls:
+        assert "limit=1000" in url
+        assert "offset=0" in url

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -57,6 +57,240 @@ async def test_citation_graph_success():
     assert payload["citations"][0]["arxiv_id"] == "2501.00001"
 
 
+def _legacy_mock_payload():
+    """Shared legacy nested payload (mirrors test_citation_graph_success)."""
+    return {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+        "citations": [
+            {
+                "paperId": "citing-1",
+                "title": "Citing Paper",
+                "year": 2025,
+                "authors": [{"name": "Author B"}],
+                "externalIds": {"ArXiv": "2501.00001"},
+            }
+        ],
+        "references": [
+            {
+                "paperId": "ref-1",
+                "title": "Referenced Paper",
+                "year": 2020,
+                "authors": [{"name": "Author C"}],
+                "externalIds": {"ArXiv": "2001.00001"},
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_default_unchanged():
+    """Default call (no new params) must still take the legacy nested path.
+
+    Asserts: indent=2 output, edges include authors + external_ids, single
+    nested request (one client.get).
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = _legacy_mock_payload()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    text = response[0].text
+    # Legacy path uses indent=2 -> newlines present in the rendered JSON.
+    assert "\n" in text
+    # Legacy path makes exactly one (nested) request.
+    assert mock_client.get.await_count == 1
+
+    payload = json.loads(text)
+    assert "pagination" not in payload
+    citation_edge = payload["citations"][0]
+    assert "authors" in citation_edge
+    assert "external_ids" in citation_edge
+    assert citation_edge["arxiv_id"] == "2501.00001"
+    reference_edge = payload["references"][0]
+    assert "authors" in reference_edge
+    assert "external_ids" in reference_edge
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_compact():
+    """Compact opt-in path: minified output, stripped edges, pagination block."""
+    # Call order in the implementation: root metadata, /citations, /references.
+    root_response = MagicMock()
+    root_response.raise_for_status = MagicMock()
+    root_response.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+
+    citations_response = MagicMock()
+    citations_response.raise_for_status = MagicMock()
+    citations_response.json.return_value = {
+        "offset": 0,
+        "next": 5,
+        "data": [
+            {
+                "citingPaper": {
+                    "paperId": "citing-1",
+                    "title": "Citing Paper",
+                    "year": 2025,
+                    "authors": [{"name": "Author B"}],
+                    "externalIds": {"ArXiv": "2501.00001"},
+                }
+            }
+        ],
+    }
+
+    references_response = MagicMock()
+    references_response.raise_for_status = MagicMock()
+    references_response.json.return_value = {
+        "offset": 0,
+        "next": 5,
+        "data": [
+            {
+                "citedPaper": {
+                    "paperId": "ref-1",
+                    "title": "Referenced Paper",
+                    "year": 2020,
+                    "authors": [{"name": "Author C"}],
+                    "externalIds": {"ArXiv": "2001.00001"},
+                }
+            }
+        ],
+    }
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[root_response, citations_response, references_response]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph(
+            {"paper_id": "2401.12345", "compact": True, "limit": 5}
+        )
+
+    text = response[0].text
+    # Minified output: no newline.
+    assert "\n" not in text
+
+    payload = json.loads(text)
+    assert payload["status"] == "success"
+
+    citation_edge = payload["citations"][0]
+    assert set(citation_edge.keys()) == {"paper_id", "arxiv_id", "title", "year"}
+    assert citation_edge["arxiv_id"] == "2501.00001"
+
+    reference_edge = payload["references"][0]
+    assert set(reference_edge.keys()) == {"paper_id", "arxiv_id", "title", "year"}
+
+    # Compact root paper has no authors/external_ids.
+    assert set(payload["paper"].keys()) == {"paper_id", "arxiv_id", "title", "year"}
+
+    assert "pagination" in payload
+    assert payload["pagination"]["limit"] == 5
+    assert payload["pagination"]["citations"]["offset"] == 0
+    assert payload["pagination"]["references"]["offset"] == 0
+    assert payload["pagination"]["citations"]["next"] == 5
+    assert payload["pagination"]["citations"]["returned"] == 1
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_paginated_full():
+    """Paginated non-compact path: full edges, indent=2, offset propagated."""
+    # Call order in the implementation: root metadata, /citations, /references.
+    root_response = MagicMock()
+    root_response.raise_for_status = MagicMock()
+    root_response.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+
+    citations_response = MagicMock()
+    citations_response.raise_for_status = MagicMock()
+    citations_response.json.return_value = {
+        "offset": 5,
+        "next": 10,
+        "data": [
+            {
+                "citingPaper": {
+                    "paperId": "citing-1",
+                    "title": "Citing Paper",
+                    "year": 2025,
+                    "authors": [{"name": "Author B"}],
+                    "externalIds": {"ArXiv": "2501.00001"},
+                }
+            }
+        ],
+    }
+
+    references_response = MagicMock()
+    references_response.raise_for_status = MagicMock()
+    references_response.json.return_value = {
+        "offset": 5,
+        "data": [
+            {
+                "citedPaper": {
+                    "paperId": "ref-1",
+                    "title": "Referenced Paper",
+                    "year": 2020,
+                    "authors": [{"name": "Author C"}],
+                    "externalIds": {"ArXiv": "2001.00001"},
+                }
+            }
+        ],
+    }
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[root_response, citations_response, references_response]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph(
+            {"paper_id": "2401.12345", "limit": 5, "offset": 5}
+        )
+
+    text = response[0].text
+    # Non-compact path uses indent=2 -> newlines present.
+    assert "\n" in text
+
+    payload = json.loads(text)
+    assert payload["pagination"]["citations"]["offset"] == 5
+    assert payload["pagination"]["references"]["offset"] == 5
+    assert payload["pagination"]["limit"] == 5
+
+    citation_edge = payload["citations"][0]
+    assert "authors" in citation_edge
+    assert citation_edge["authors"] == ["Author B"]
+    assert "external_ids" in citation_edge
+
+    # next absent on last page -> None.
+    assert payload["pagination"]["references"]["next"] is None
+
+
 @pytest.mark.asyncio
 async def test_citation_graph_http_error():
     """Citation graph should surface HTTP API errors."""

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -1148,3 +1148,32 @@ async def test_citation_graph_negative_cap_ignored(monkeypatch):
     assert "truncated" not in result
     assert result["citation_count"] == 2
     assert len(result["citations"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_cap_zero(monkeypatch):
+    """A cap of 0 is a real "zero edges" request: empty lists + truncated when
+    edges existed (distinct from None/negative = no cap)."""
+    monkeypatch.setattr(citation_graph.settings, "CITATION_MAX_EDGES", 0)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = _legacy_mock_payload()  # 1 citation + 1 ref
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    result = json.loads(response[0].text)
+    assert result["citation_count"] == 0
+    assert result["reference_count"] == 0
+    assert result["citations"] == []
+    assert result["references"] == []
+    assert result["truncated"] is True

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -823,3 +823,328 @@ async def test_citation_graph_cap_unset_no_key():
         response = await handle_citation_graph({"paper_id": "2401.12345"})
 
     assert "truncated" not in json.loads(response[0].text)
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_retries_on_5xx():
+    """A transient 503 is retried; the subsequent 200 legacy payload succeeds."""
+    server_error = MagicMock()
+    server_error.status_code = 503
+    server_error.headers = {}
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.headers = {}
+    ok_response.raise_for_status = MagicMock()
+    ok_response.json.return_value = _legacy_mock_payload()
+
+    with (
+        patch("httpx.AsyncClient") as mock_client_class,
+        patch("arxiv_mcp_server.tools.citation_graph.asyncio.sleep", new=AsyncMock()),
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[server_error, ok_response])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    assert mock_client.get.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_retries_on_transport_error():
+    """A transport error (ConnectError) is retried; the next 200 succeeds."""
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.headers = {}
+    ok_response.raise_for_status = MagicMock()
+    ok_response.json.return_value = _legacy_mock_payload()
+
+    with (
+        patch("httpx.AsyncClient") as mock_client_class,
+        patch("arxiv_mcp_server.tools.citation_graph.asyncio.sleep", new=AsyncMock()),
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[httpx.ConnectError("boom"), ok_response]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    assert mock_client.get.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_retry_after_clamped():
+    """An absurd Retry-After is clamped to MAX_RETRY_DELAY, not slept literally."""
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.headers = {"Retry-After": "99999"}
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.headers = {}
+    ok_response.raise_for_status = MagicMock()
+    ok_response.json.return_value = _legacy_mock_payload()
+
+    sleep_mock = AsyncMock()
+    with (
+        patch("httpx.AsyncClient") as mock_client_class,
+        patch("arxiv_mcp_server.tools.citation_graph.asyncio.sleep", new=sleep_mock),
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[rate_limited, ok_response])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        await handle_citation_graph({"paper_id": "2401.12345"})
+
+    # Clamped to MAX_RETRY_DELAY (16.0), NOT the literal 99999.
+    sleep_mock.assert_awaited_once_with(16.0)
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_backoff_jitter():
+    """With no Retry-After, the backoff uses jittered random.uniform."""
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.headers = {}
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.headers = {}
+    ok_response.raise_for_status = MagicMock()
+    ok_response.json.return_value = _legacy_mock_payload()
+
+    sleep_mock = AsyncMock()
+    with (
+        patch("httpx.AsyncClient") as mock_client_class,
+        patch("arxiv_mcp_server.tools.citation_graph.asyncio.sleep", new=sleep_mock),
+        patch(
+            "arxiv_mcp_server.tools.citation_graph.random.uniform", return_value=0.5
+        ) as uniform_mock,
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[rate_limited, ok_response])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        await handle_citation_graph({"paper_id": "2401.12345"})
+
+    uniform_mock.assert_called()
+    sleep_mock.assert_awaited_once_with(0.5)
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_paginated_retries():
+    """The paginated path retries a 429 on a sub-request and still succeeds."""
+    root_response = MagicMock()
+    root_response.status_code = 200
+    root_response.headers = {}
+    root_response.raise_for_status = MagicMock()
+    root_response.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+
+    citations_429 = MagicMock()
+    citations_429.status_code = 429
+    citations_429.headers = {}
+
+    citations_ok = MagicMock()
+    citations_ok.status_code = 200
+    citations_ok.headers = {}
+    citations_ok.raise_for_status = MagicMock()
+    citations_ok.json.return_value = {
+        "offset": 0,
+        "next": 5,
+        "data": [
+            {
+                "citingPaper": {
+                    "paperId": "citing-1",
+                    "title": "Citing Paper",
+                    "year": 2025,
+                    "authors": [{"name": "Author B"}],
+                    "externalIds": {"ArXiv": "2501.00001"},
+                }
+            }
+        ],
+    }
+
+    references_response = MagicMock()
+    references_response.status_code = 200
+    references_response.headers = {}
+    references_response.raise_for_status = MagicMock()
+    references_response.json.return_value = {"offset": 0, "data": []}
+
+    with (
+        patch("httpx.AsyncClient") as mock_client_class,
+        patch("arxiv_mcp_server.tools.citation_graph.asyncio.sleep", new=AsyncMock()),
+    ):
+        mock_client = AsyncMock()
+        # root, citations(429), citations(200 retry), references.
+        mock_client.get = AsyncMock(
+            side_effect=[
+                root_response,
+                citations_429,
+                citations_ok,
+                references_response,
+            ]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345", "limit": 5})
+
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    assert "pagination" in payload
+    assert payload["citation_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_paginated_no_cap(monkeypatch):
+    """The output cap must NOT apply in the paginated path (cursor integrity)."""
+    monkeypatch.setattr(citation_graph.settings, "CITATION_MAX_EDGES", 1)
+
+    root_response = MagicMock()
+    root_response.status_code = 200
+    root_response.headers = {}
+    root_response.raise_for_status = MagicMock()
+    root_response.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+
+    citations_response = MagicMock()
+    citations_response.status_code = 200
+    citations_response.headers = {}
+    citations_response.raise_for_status = MagicMock()
+    citations_response.json.return_value = {
+        "offset": 0,
+        "next": 5,
+        "data": [
+            {
+                "citingPaper": {
+                    "paperId": "citing-1",
+                    "title": "Citing Paper",
+                    "year": 2025,
+                    "authors": [{"name": "Author B"}],
+                    "externalIds": {"ArXiv": "2501.00001"},
+                }
+            },
+            {
+                "citingPaper": {
+                    "paperId": "citing-2",
+                    "title": "Citing Paper 2",
+                    "year": 2025,
+                    "authors": [{"name": "Author D"}],
+                    "externalIds": {"ArXiv": "2501.00002"},
+                }
+            },
+        ],
+    }
+
+    references_response = MagicMock()
+    references_response.status_code = 200
+    references_response.headers = {}
+    references_response.raise_for_status = MagicMock()
+    references_response.json.return_value = {
+        "offset": 0,
+        "next": 5,
+        "data": [
+            {
+                "citedPaper": {
+                    "paperId": "ref-1",
+                    "title": "Referenced Paper",
+                    "year": 2020,
+                    "authors": [{"name": "Author C"}],
+                    "externalIds": {"ArXiv": "2001.00001"},
+                }
+            },
+            {
+                "citedPaper": {
+                    "paperId": "ref-2",
+                    "title": "Referenced Paper 2",
+                    "year": 2019,
+                    "authors": [{"name": "Author E"}],
+                    "externalIds": {"ArXiv": "2001.00002"},
+                }
+            },
+        ],
+    }
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[root_response, citations_response, references_response]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345", "limit": 5})
+
+    payload = json.loads(response[0].text)
+    # Cap (1) is NOT applied in the paginated path: full page returned, no flag.
+    assert "truncated" not in payload
+    assert payload["citation_count"] == 2
+    assert payload["reference_count"] == 2
+    assert len(payload["citations"]) == 2
+    assert len(payload["references"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_negative_cap_ignored(monkeypatch):
+    """A negative cap is treated as "no cap" (no negative-slice truncation)."""
+    monkeypatch.setattr(citation_graph.settings, "CITATION_MAX_EDGES", -1)
+
+    payload = _legacy_mock_payload()
+    payload["citations"].append(
+        {
+            "paperId": "citing-2",
+            "title": "Citing Paper 2",
+            "year": 2025,
+            "authors": [{"name": "Author D"}],
+            "externalIds": {"ArXiv": "2501.00002"},
+        }
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = payload
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    result = json.loads(response[0].text)
+    # Negative cap == no cap: both citations returned, no truncation flag.
+    assert "truncated" not in result
+    assert result["citation_count"] == 2
+    assert len(result["citations"]) == 2

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -123,6 +123,43 @@ async def test_citation_graph_default_unchanged():
     assert "authors" in reference_edge
     assert "external_ids" in reference_edge
 
+    # Golden byte-for-byte: pin the EXACT default output so a future change to
+    # the legacy path cannot silently alter it (backward-compat guarantee).
+    expected = {
+        "status": "success",
+        "paper": {
+            "paper_id": "root-paper",
+            "arxiv_id": "2401.12345",
+            "title": "Root Paper",
+            "year": 2024,
+            "authors": ["Author A"],
+            "external_ids": {"ArXiv": "2401.12345"},
+        },
+        "citation_count": 1,
+        "reference_count": 1,
+        "citations": [
+            {
+                "paper_id": "citing-1",
+                "title": "Citing Paper",
+                "year": 2025,
+                "authors": ["Author B"],
+                "external_ids": {"ArXiv": "2501.00001"},
+                "arxiv_id": "2501.00001",
+            }
+        ],
+        "references": [
+            {
+                "paper_id": "ref-1",
+                "title": "Referenced Paper",
+                "year": 2020,
+                "authors": ["Author C"],
+                "external_ids": {"ArXiv": "2001.00001"},
+                "arxiv_id": "2001.00001",
+            }
+        ],
+    }
+    assert text == json.dumps(expected, indent=2)
+
 
 @pytest.mark.asyncio
 async def test_citation_graph_compact():
@@ -516,3 +553,113 @@ async def test_citation_graph_limit_offset_clamped():
     for url in paged_urls:
         assert "limit=1000" in url
         assert "offset=0" in url
+
+
+def _paginated_mocks(citations_next):
+    """Build (root, citations, references) response mocks for the paginated path."""
+    root = MagicMock()
+    root.raise_for_status = MagicMock()
+    root.json.return_value = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2401.12345"},
+    }
+    citations = MagicMock()
+    citations.raise_for_status = MagicMock()
+    citations.json.return_value = {
+        "offset": 0,
+        "next": citations_next,
+        "data": [{"citingPaper": {"paperId": "c1", "title": "C", "year": 2025}}],
+    }
+    references = MagicMock()
+    references.raise_for_status = MagicMock()
+    references.json.return_value = {"offset": 0, "data": []}
+    return root, citations, references
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_pagination_next_offset_roundtrip():
+    """The `next` cursor from page 1 is usable as the `offset` for page 2.
+
+    Pins the README's documented paging loop: read pagination.citations.next,
+    feed it back as `offset`, and the next request URL carries that offset.
+    """
+    # Page 1: limit=5, offset 0 -> citations.next == 5.
+    root1, cit1, ref1 = _paginated_mocks(citations_next=5)
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[root1, cit1, ref1])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        page1 = await handle_citation_graph({"paper_id": "2401.12345", "limit": 5})
+
+    next_cursor = json.loads(page1[0].text)["pagination"]["citations"]["next"]
+    assert next_cursor == 5
+
+    # Page 2: feed next_cursor back as offset; the citations URL must carry it.
+    root2, cit2, ref2 = _paginated_mocks(citations_next=None)
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[root2, cit2, ref2])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        await handle_citation_graph(
+            {"paper_id": "2401.12345", "limit": 5, "offset": next_cursor}
+        )
+
+    citations_urls = [
+        c.args[0] for c in mock_client.get.call_args_list if "/citations" in c.args[0]
+    ]
+    assert citations_urls and f"offset={next_cursor}" in citations_urls[0]
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_old_style_id_quoted():
+    """Old-style arXiv IDs contain a slash (e.g. hep-th/9901001); it must be
+    percent-encoded so it is not treated as a URL path separator."""
+    root, cit, ref = _paginated_mocks(citations_next=None)
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[root, cit, ref])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        await handle_citation_graph({"paper_id": "hep-th/9901001", "limit": 5})
+
+    urls = [c.args[0] for c in mock_client.get.call_args_list]
+    assert urls, "expected requests to be made"
+    for u in urls:
+        # The id's slash is encoded (%2F); the raw `hep-th/9901001` never appears.
+        assert "hep-th%2F9901001" in u
+        assert "hep-th/9901001" not in u
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_compact_strict_bool():
+    """A non-bool truthy `compact` (e.g. the string "false") must NOT enable the
+    compact/paginated path — only a real JSON true does (defense-in-depth)."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = _legacy_mock_payload()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph(
+            {"paper_id": "2401.12345", "compact": "false"}
+        )
+
+    # Legacy path: exactly one request, no pagination block.
+    assert mock_client.get.await_count == 1
+    assert "pagination" not in json.loads(response[0].text)

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from arxiv_mcp_server.tools import citation_graph
 from arxiv_mcp_server.tools.citation_graph import handle_citation_graph
 
 
@@ -663,3 +664,162 @@ async def test_citation_graph_compact_strict_bool():
     # Legacy path: exactly one request, no pagination block.
     assert mock_client.get.await_count == 1
     assert "pagination" not in json.loads(response[0].text)
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_retries_on_429():
+    """A transient 429 is retried; the subsequent 200 succeeds (FIX C2)."""
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.headers = {}
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.headers = {}
+    ok_response.raise_for_status = MagicMock()
+    ok_response.json.return_value = _legacy_mock_payload()
+
+    with (
+        patch("httpx.AsyncClient") as mock_client_class,
+        patch("arxiv_mcp_server.tools.citation_graph.asyncio.sleep", new=AsyncMock()),
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[rate_limited, ok_response])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    # First call hit 429, second call returned the 200 payload.
+    assert mock_client.get.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_429_exhausted():
+    """A 429 that survives all retries surfaces as an Error envelope (FIX C2).
+
+    max_retries defaults to 4 -> 1 initial + 4 retries == 5 awaited GETs.
+    """
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.headers = {}
+    rate_limited.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "rate limited", request=MagicMock(), response=MagicMock()
+    )
+
+    with (
+        patch("httpx.AsyncClient") as mock_client_class,
+        patch("arxiv_mcp_server.tools.citation_graph.asyncio.sleep", new=AsyncMock()),
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=rate_limited)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    assert response[0].text.startswith("Error:")
+    # 1 initial GET + max_retries (4) retries == 5.
+    assert mock_client.get.await_count == 5
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_retry_after_header():
+    """A numeric Retry-After header drives the backoff delay (FIX C2)."""
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.headers = {"Retry-After": "7"}
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.headers = {}
+    ok_response.raise_for_status = MagicMock()
+    ok_response.json.return_value = _legacy_mock_payload()
+
+    sleep_mock = AsyncMock()
+    with (
+        patch("httpx.AsyncClient") as mock_client_class,
+        patch("arxiv_mcp_server.tools.citation_graph.asyncio.sleep", new=sleep_mock),
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[rate_limited, ok_response])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        await handle_citation_graph({"paper_id": "2401.12345"})
+
+    sleep_mock.assert_awaited_once_with(7.0)
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_output_cap(monkeypatch):
+    """An output cap truncates each direction and flags `truncated` (FIX C2)."""
+    monkeypatch.setattr(citation_graph.settings, "CITATION_MAX_EDGES", 1)
+
+    payload = _legacy_mock_payload()
+    payload["citations"].append(
+        {
+            "paperId": "citing-2",
+            "title": "Citing Paper 2",
+            "year": 2025,
+            "authors": [{"name": "Author D"}],
+            "externalIds": {"ArXiv": "2501.00002"},
+        }
+    )
+    payload["references"].append(
+        {
+            "paperId": "ref-2",
+            "title": "Referenced Paper 2",
+            "year": 2019,
+            "authors": [{"name": "Author E"}],
+            "externalIds": {"ArXiv": "2001.00002"},
+        }
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = payload
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    result = json.loads(response[0].text)
+    assert result["citation_count"] == 1
+    assert result["reference_count"] == 1
+    assert result["truncated"] is True
+    assert len(result["citations"]) == 1
+    assert len(result["references"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_cap_unset_no_key():
+    """With the default cap (None), no `truncated` key appears (golden contract)."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = _legacy_mock_payload()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    assert "truncated" not in json.loads(response[0].text)


### PR DESCRIPTION
## Motivation

`citation_graph` fetches a paper's references + citing papers from Semantic Scholar (S2) in a single nested call and returns full author lists + nested `externalIds` for every edge at `indent=2`. For a high-degree paper this is enormous, and the S2 nested-field form caps at 1000 edges with no way to page further. Separately, the shared unauthenticated S2 pool rate-limits aggressively (HTTP 429), so calls intermittently fail.

This PR makes the tool **token-efficient** and **reliable**, entirely through **opt-in additive parameters** — the default (no new params) output is **byte-for-byte unchanged**.

This is two concerns kept in two commits/areas (they ship together as one reviewable unit but are attributed separately, because they fix two different problems):

- **C1 — pagination + compaction** (output size / tokens-per-edge)
- **C2 — retry/backoff + optional output cap** (reliability against 429s)

## Change

### C1 — opt-in pagination + compact edges
- New optional params: `limit` (1–1000, per direction), `offset` (≥0; only meaningful with `limit`/`compact`), `compact` (bool).
- When any is set, fetch via S2's dedicated paginated endpoints `GET /paper/{id}/citations` and `/references` (`limit`/`offset`), returning a `pagination` block with a per-direction `next` cursor.
- `compact` drops author lists + nested `externalIds` and minifies the JSON.
- Identifier is fully percent-encoded (`safe=""`) so old-style IDs like `hep-th/9901001` work.
- **Default path (no params) is unchanged** (verified by a golden byte-for-byte test).

### C2 — retry/backoff + optional output cap
- `_s2_get` retries transient failures — HTTP 429 + 502/503/504 + `httpx.TransportError` — with jittered exponential backoff, honoring a numeric `Retry-After` clamped to 16 s. Wired into both the legacy and paginated paths. Worst-case blocking is bounded (`max_retries × MAX_RETRY_DELAY`).
- Optional `CITATION_MAX_EDGES` setting (default `None` = no cap) caps the returned edge lists in the legacy path and flags `truncated` only when it bites. Default config leaves output unchanged.

## Before / after (token measurement)

Method: call `citation_graph` with no params (`before`) vs `{compact: true, limit: 100}` (`after`), and count tokens of the returned text with `tiktoken/cl100k_base` (a consistent proxy; before/after ratios are tokenizer-robust). Inputs: high-degree `1706.03762` (Attention Is All You Need), low-degree `2412.16720`. Numbers are a single live-S2 run on 2026-06-17 — Semantic Scholar citation counts grow over time, so absolute figures drift; the ratio is the stable claim.

| paper | mode | edges | tokens | tokens/edge |
|-------|------|-------|--------|-------------|
| 1706.03762 | before (legacy, full) | 1041 | 163,683 | 157 |
| 1706.03762 | after pagination-only (limit=100) | 141 | 23,317 | 165 |
| 1706.03762 | **after compact (limit=100)** | 141 | **8,298** | **59** |
| 2412.16720 | before (legacy) | 39 | 7,529 | 193 |
| 2412.16720 | **after compact (limit=100)** | 39 | **2,216** | **57** |

- **Compaction** cuts tokens-per-edge ~62–71% (157→59 high; 193→57 low) — independent of edge count.
- **Pagination** bounds the absolute payload (1041→141 edges; 163,683→23,317 tokens) — per-edge cost unchanged.
- **Combined: 163,683 → 8,298 tokens (94.9% smaller)** for the high-degree paper.

## Attribution (the two fixes address two different problems)

- C1 (pagination/compaction) reduces **output size / tokens-per-edge**.
- The **429s are unauthenticated frequency rate-limiting** (an 8-call burst probe 429'd tiny-payload requests at a comparable rate to large ones — 6/8 vs 7/8 — i.e. independent of payload size), addressed by **C2's retry/backoff** — *not* by pagination. We do not claim pagination "fixes the 429s."

## Tests / compat

- `pytest -q` green; `black --check` clean. Adds tests for the default-unchanged golden output, compact/paginated shapes, clamping, retry (429/5xx/transport), Retry-After clamp, jitter, and the output cap.
- Fully backward-compatible: with no new params and default config, behavior and output are unchanged.

## Honest scope

The win is **tokens-per-edge + reliability**, not unlocking citation data for very recent preprints (S2/OpenAlex ingestion lag means those edges are thin regardless). Citation graphs pay off for older/published work.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
