### PR TITLE
Add badge for mcp-customs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_94%2F100-brightgreen)](https://github.com/mcpcustoms/mcp-customs)
+[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_94%2F100-brightgreen)](https://mcpcustoms.github.io/?server=arxiv-mcp-server))
 [![PyPI Version](https://img.shields.io/pypi/v/arxiv-mcp-server.svg)](https://pypi.org/project/arxiv-mcp-server/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/arxiv-mcp-server.svg)](https://pypi.org/project/arxiv-mcp-server/)
 [![GitHub Stars](https://img.shields.io/github/stars/blazickjp/arxiv-mcp-server?style=flat)](https://github.com/blazickjp/arxiv-mcp-server/stargazers)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_94%2F100-brightgreen)](https://mcpcustoms.github.io/?server=arxiv-mcp-server))
+[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_94%2F100-brightgreen)](https://mcpcustoms.github.io/?server=arxiv-mcp-server)
 [![PyPI Version](https://img.shields.io/pypi/v/arxiv-mcp-server.svg)](https://pypi.org/project/arxiv-mcp-server/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/arxiv-mcp-server.svg)](https://pypi.org/project/arxiv-mcp-server/)
 [![GitHub Stars](https://img.shields.io/github/stars/blazickjp/arxiv-mcp-server?style=flat)](https://github.com/blazickjp/arxiv-mcp-server/stargazers)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_94%2F100-brightgreen)](https://github.com/mcpcustoms/mcp-customs)
 [![PyPI Version](https://img.shields.io/pypi/v/arxiv-mcp-server.svg)](https://pypi.org/project/arxiv-mcp-server/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/arxiv-mcp-server.svg)](https://pypi.org/project/arxiv-mcp-server/)
 [![GitHub Stars](https://img.shields.io/github/stars/blazickjp/arxiv-mcp-server?style=flat)](https://github.com/blazickjp/arxiv-mcp-server/stargazers)


### PR DESCRIPTION
Ran your server through mcp-customs (https://github.com/mcpcustoms/mcp-customs), a free offline scanner I built that checks MCP servers for common security risks before install. It came back clean — 94/100.

Wrote up the full methodology (and where the tool got things wrong on other servers) here: https://dev.to/mcpcustoms/we-scanned-12-popular-mcp-servers-the-most-interesting-finding-was-our-own-false-positives-kcf

Adding the badge is obviously optional — totally fine to close this if you'd rather not, no hard feelings either way.