### PR TITLE
fix: compatibility with arxiv Python package v4.0.0

### DIFF
--- a/src/arxiv_mcp_server/resources/papers.py
+++ b/src/arxiv_mcp_server/resources/papers.py
@@ -37,7 +37,15 @@ class PaperManager:
 
         try:
             paper = next(self.client.results(arxiv.Search(id_list=[paper_id])))
-            paper.download_pdf(dirpath=self.storage_path, filename=paper_pdf_path)
+            # arxiv v4: download_pdf() removed; download via httpx using canonical URL
+            import httpx
+            pdf_url = f"https://arxiv.org/pdf/{paper.get_short_id()}.pdf"
+            with httpx.Client(timeout=120, follow_redirects=True) as client:
+                with client.stream("GET", pdf_url) as response:
+                    response.raise_for_status()
+                    with open(paper_pdf_path, "wb") as out:
+                        for chunk in response.iter_bytes(chunk_size=256 * 1024):
+                            out.write(chunk)
             markdown = pymupdf4llm.to_markdown(paper_pdf_path, show_progress=False)
 
             async with aiofiles.open(paper_md_path, "w", encoding="utf-8") as f:

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -236,10 +236,8 @@ def _download_arxiv_pdf_to_path(paper: arxiv.Result, pdf_path: Path) -> None:
         120 seconds so large PDFs on slower links are less likely to fail
         prematurely. Data is written in 256 KiB chunks to bound memory use.
     """
-    if paper.pdf_url is None:
-        raise ValueError("No PDF URL available for this arXiv result")
-
-    pdf_url = paper.pdf_url
+    # arxiv v4: pdf_url property removed; construct canonical PDF URL from short ID
+    pdf_url = f"https://arxiv.org/pdf/{paper.get_short_id()}.pdf"
     read_timeout = max(120.0, float(settings.REQUEST_TIMEOUT))
     timeout = httpx.Timeout(
         connect=30.0,

--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -426,7 +426,7 @@ def _process_paper(paper: arxiv.Result) -> Dict[str, Any]:
         "abstract": "[EXTERNAL CONTENT] " + paper.summary,
         "categories": paper.categories,
         "published": paper.published.isoformat(),
-        "url": paper.pdf_url,
+        "url": f"https://arxiv.org/pdf/{paper.get_short_id()}.pdf",
         "resource_uri": f"arxiv://{paper.get_short_id()}",
     }
 


### PR DESCRIPTION
## Problem

`arxiv` Python package v4.0.0 removed `Result.pdf_url` and `Result.download_pdf()`, breaking PDF downloads for all papers that lack HTML versions (typically papers published before ~2024).

Error: `'Result' object has no attribute 'download_pdf'`

Also tracked in issue #114.

## Changes

Three files, 12 lines changed:

| File | Change |
|------|--------|
| `tools/download.py` | Replace `paper.pdf_url` with canonical `https://arxiv.org/pdf/{short_id}.pdf` |
| `tools/search.py` | Same — fix paper URL in search results |
| `resources/papers.py` | Replace `paper.download_pdf()` with httpx streaming download |

## Root cause

arxiv Python library v4.0.0 removed:
- `Result.pdf_url` property → use `Result.get_short_id()` to construct canonical URL
- `Result.download_pdf()` method → use httpx streaming (already used by `_download_arxiv_pdf_to_path`)

The `_download_arxiv_pdf_to_path()` function in `download.py` already used httpx streaming to avoid incomplete downloads (issue #98), so `papers.py` was the only place still calling `download_pdf()` directly.

## Testing

- Verified PDF download + markdown conversion for `2308.04079` (3DGS paper, no HTML version)
- All existing HTML downloads continue to work
- Search results correctly populate PDF URLs