### PR TITLE
Accept any loopback port in DNS-rebinding host allow-list

### DIFF
--- a/src/arxiv_mcp_server/server.py
+++ b/src/arxiv_mcp_server/server.py
@@ -158,7 +158,7 @@ def _transport_security_settings() -> TransportSecuritySettings:
     allowed_hosts = {
         host,
         f"{host}:{port}",
-        *(f"{h}:{port}" for h in loopback_hosts),
+        *(f"{h}:*" for h in loopback_hosts),
         *loopback_hosts,
     }
     allowed_hosts.update(_csv_settings(settings.ALLOWED_HOSTS))

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -82,7 +82,7 @@ async def test_streamable_http_uses_configured_host_port():
     security_settings = manager_kwargs["security_settings"]
     assert security_settings.enable_dns_rebinding_protection is True
     assert "127.0.0.1:8765" in security_settings.allowed_hosts
-    assert "localhost:8765" in security_settings.allowed_hosts
+    assert "localhost:*" in security_settings.allowed_hosts
     config_class.assert_called_once()
     _, config_kwargs = config_class.call_args
     assert config_kwargs["host"] == "127.0.0.1"
@@ -105,8 +105,8 @@ def test_transport_security_allows_loopback_and_configured_hosts():
 
     assert security_settings.enable_dns_rebinding_protection is True
     assert "0.0.0.0:9000" in security_settings.allowed_hosts
-    assert "127.0.0.1:9000" in security_settings.allowed_hosts
-    assert "localhost:9000" in security_settings.allowed_hosts
+    assert "127.0.0.1:*" in security_settings.allowed_hosts
+    assert "localhost:*" in security_settings.allowed_hosts
     assert "arxiv.example.com" in security_settings.allowed_hosts
     assert "arxiv.example.com:443" in security_settings.allowed_hosts
     assert "http://127.0.0.1:9000" in security_settings.allowed_origins


### PR DESCRIPTION
_transport_security_settings() pins loopback hosts to the backend's own port ({host}:{port}), which rejects otherwise-valid requests whose Host header carries a *different* loopback port. This breaks the common reverse-proxy setup: nginx forwards to the backend with a Host like localhost:8443 (the proxy's listen port), which differs from the port the server binds, and the request is refused with an invalid-host error.

Allow any port on loopback hosts ({h}:*) instead. DNS-rebinding protection keys on the host, not the port — a loopback address is loopback regardless of port — so this preserves the exact same protection (non-loopback Host headers are still rejected) while removing the false rejection, and avoids hardcoding ALLOWED_HOSTS for every deployment sitting behind a proxy.