### PR TITLE
fix: pin arxiv dependency and synchronize distribution

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-15-intel, macos-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish Distribution
 
 on:
   release:
@@ -12,23 +12,30 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    
-    - name: Install build dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build hatchling
-    
-    - name: Build package
-      run: python -m build
-    
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.11
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build hatchling
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI with trusted publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Install MCP Registry publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arxiv-mcp-server"
-version = "0.5.0"
+version = "0.5.1"
 description = "A flexible arXiv search and analysis service with MCP protocol support"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -27,7 +27,7 @@ authors = [
     { name = "Joseph Blazick", email = "blazickjp@amazon.com" }
 ]
 dependencies = [
-    "arxiv>=2.1.0",
+    "arxiv>=2.1.0,<4",
     "httpx>=0.24.0",
     "python-dateutil>=2.8.2",
     "pydantic>=2.8.0",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.blazickjp/arxiv-mcp-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Search arXiv papers, download full text, semantic search, citation graphs, and alerts via MCP.",
   "repository": {
     "url": "https://github.com/blazickjp/arxiv-mcp-server",
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "arxiv-mcp-server",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,26 @@
+import json
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_metadata_and_arxiv_dependency_are_synchronized():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    server = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+
+    project = pyproject["project"]
+    version = project["version"]
+    arxiv_requirement = next(
+        dependency
+        for dependency in project["dependencies"]
+        if dependency.startswith("arxiv")
+    )
+
+    assert version == "0.5.1"
+    assert server["$schema"] == (
+        "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+    )
+    assert server["version"] == version
+    assert server["packages"][0]["version"] == version
+    assert arxiv_requirement == "arxiv>=2.1.0,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "arxiv-mcp-server"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -242,7 +242,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.1" },
     { name = "aioresponses", marker = "extra == 'test'", specifier = ">=0.7.6" },
     { name = "anyio", specifier = ">=4.2.0" },
-    { name = "arxiv", specifier = ">=2.1.0" },
+    { name = "arxiv", specifier = ">=2.1.0,<4" },
     { name = "black", specifier = ">=25.1.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.3.0" },
     { name = "httpx", specifier = ">=0.24.0" },


### PR DESCRIPTION
## Summary
- constrain the upstream arxiv dependency to supported versions below 4
- bump package and registry metadata to 0.5.1
- publish PyPI and the official MCP Registry sequentially via OIDC
- replace the retired Intel MCPB runner
- add a regression test keeping package and registry metadata synchronized

## Validation
- 92 tests passed
- Black check passed
- wheel and sdist built successfully
- clean wheel install resolved arxiv 3.0.0
- official mcp-publisher validation passed
- actionlint passed
