### PR TITLE
ci: publish PyPI releases with repository token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Publish to PyPI with trusted publishing
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Install MCP Registry publisher
         run: |


### PR DESCRIPTION
## Summary
- use the configured repository-scoped PyPI token for package publishing
- retain GitHub OIDC for official MCP Registry publishing

This replaces the unconfigured PyPI Trusted Publisher path that failed during the v0.5.1 release.

## Validation
- actionlint passed
- v0.5.1 was manually published with the same token and verified on PyPI
