### PR TITLE
fix: support reverse proxies on loopback ports

### DIFF
--- a/src/arxiv_mcp_server/server.py
+++ b/src/arxiv_mcp_server/server.py
@@ -158,7 +158,7 @@ def _transport_security_settings() -> TransportSecuritySettings:
     allowed_hosts = {
         host,
         f"{host}:{port}",
-        *(f"{h}:{port}" for h in loopback_hosts),
+        *(f"{h}:*" for h in loopback_hosts),
         *loopback_hosts,
     }
     allowed_hosts.update(_csv_settings(settings.ALLOWED_HOSTS))
@@ -167,6 +167,11 @@ def _transport_security_settings() -> TransportSecuritySettings:
     allowed_origins = {
         f"http://{origin_host}:{port}" for origin_host in origin_hosts
     } | {f"https://{origin_host}:{port}" for origin_host in origin_hosts}
+    allowed_origins.update(
+        f"{scheme}://{loopback}:*"
+        for scheme in ("http", "https")
+        for loopback in loopback_hosts
+    )
     allowed_origins.update(_csv_settings(settings.ALLOWED_ORIGINS))
 
     return TransportSecuritySettings(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from mcp.server.transport_security import TransportSecurityMiddleware
+
 from arxiv_mcp_server import server as server_module
 from arxiv_mcp_server.config import Settings
 
@@ -81,8 +83,8 @@ async def test_streamable_http_uses_configured_host_port():
     assert manager_kwargs["json_response"] is False
     security_settings = manager_kwargs["security_settings"]
     assert security_settings.enable_dns_rebinding_protection is True
-    assert "127.0.0.1:8765" in security_settings.allowed_hosts
-    assert "localhost:8765" in security_settings.allowed_hosts
+    assert "127.0.0.1:*" in security_settings.allowed_hosts
+    assert "localhost:*" in security_settings.allowed_hosts
     config_class.assert_called_once()
     _, config_kwargs = config_class.call_args
     assert config_kwargs["host"] == "127.0.0.1"
@@ -105,13 +107,30 @@ def test_transport_security_allows_loopback_and_configured_hosts():
 
     assert security_settings.enable_dns_rebinding_protection is True
     assert "0.0.0.0:9000" in security_settings.allowed_hosts
-    assert "127.0.0.1:9000" in security_settings.allowed_hosts
-    assert "localhost:9000" in security_settings.allowed_hosts
+    assert "127.0.0.1:*" in security_settings.allowed_hosts
+    assert "localhost:*" in security_settings.allowed_hosts
     assert "arxiv.example.com" in security_settings.allowed_hosts
     assert "arxiv.example.com:443" in security_settings.allowed_hosts
     assert "http://127.0.0.1:9000" in security_settings.allowed_origins
     assert "http://localhost:9000" in security_settings.allowed_origins
     assert "https://arxiv.example.com" in security_settings.allowed_origins
+
+
+def test_transport_security_accepts_reverse_proxy_loopback_ports():
+    """A loopback proxy may preserve its own port in the Host header."""
+    settings = Settings(HOST="127.0.0.1", PORT=8000)
+    with patch.object(server_module, "settings", settings):
+        middleware = TransportSecurityMiddleware(
+            server_module._transport_security_settings()
+        )
+
+    assert middleware._validate_host("localhost:8443")
+    assert middleware._validate_host("127.0.0.1:9000")
+    assert middleware._validate_host("[::1]:3000")
+    assert not middleware._validate_host("localhost.attacker.example:8443")
+    assert middleware._validate_origin("http://localhost:8443")
+    assert middleware._validate_origin("https://127.0.0.1:9000")
+    assert not middleware._validate_origin("https://localhost.attacker.example:8443")
 
 
 def test_http_defaults_bind_to_localhost():


### PR DESCRIPTION
## Summary
- allow wildcard ports for loopback Host headers
- allow wildcard ports for loopback browser Origin headers
- preserve DNS rebinding protection for lookalike external hostnames
- add behavior tests for localhost, IPv4, IPv6, and malicious suffixes

## Validation
- 9 transport tests passed
- Black passed

Supersedes #120 with Origin coverage in addition to Host coverage.
