### PR TITLE
fix: share arxiv API rate limiting

### DIFF
--- a/src/arxiv_mcp_server/arxiv_api.py
+++ b/src/arxiv_mcp_server/arxiv_api.py
@@ -1,9 +1,63 @@
 """Shared compatibility helpers for the upstream arxiv package."""
 
+import asyncio
 from pathlib import Path
-from typing import Protocol
+import threading
+import time
+from typing import Awaitable, Callable, Protocol, TypeVar
 
 import httpx
+
+T = TypeVar("T")
+
+
+class ArxivRateLimiter:
+    """Serialize and space arXiv API requests across sync and async callers."""
+
+    def __init__(
+        self,
+        min_interval: float = 3.0,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        sync_sleep: Callable[[float], None] = time.sleep,
+        async_sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self.min_interval = min_interval
+        self._clock = clock
+        self._sync_sleep = sync_sleep
+        self._async_sleep = async_sleep
+        self._lock = threading.Lock()
+        self._last_started: float | None = None
+
+    def _remaining_delay(self) -> float:
+        if self._last_started is None:
+            return 0.0
+        return max(0.0, self.min_interval - (self._clock() - self._last_started))
+
+    def run_sync(self, operation: Callable[[], T]) -> T:
+        """Run a blocking operation inside the shared request gate."""
+        with self._lock:
+            delay = self._remaining_delay()
+            if delay:
+                self._sync_sleep(delay)
+            self._last_started = self._clock()
+            return operation()
+
+    async def run_async(self, operation: Callable[[], Awaitable[T]]) -> T:
+        """Run an async operation inside the same gate used by sync callers."""
+        while not self._lock.acquire(blocking=False):
+            await asyncio.sleep(0.01)
+        try:
+            delay = self._remaining_delay()
+            if delay:
+                await self._async_sleep(delay)
+            self._last_started = self._clock()
+            return await operation()
+        finally:
+            self._lock.release()
+
+
+ARXIV_RATE_LIMITER = ArxivRateLimiter()
 
 
 class ArxivResult(Protocol):

--- a/src/arxiv_mcp_server/config.py
+++ b/src/arxiv_mcp_server/config.py
@@ -17,19 +17,18 @@ logger = logging.getLogger(__name__)
 _arxiv_client = None
 
 
-def get_arxiv_client(page_size: int = 100):
-    """Return a shared arxiv.Client instance, creating it on first call.
+def get_arxiv_client():
+    """Return the process-wide arxiv.Client, creating it on first use.
 
-    The arxiv Python client fetches pages using its own page_size setting. If
-    left at the library default of 100, even a small max_results request causes
-    an upstream API URL with max_results=100. Keep the client page size aligned
-    with the requested result count so small searches make small API requests.
+    Callers that need a particular page size must set it while holding the
+    shared arXiv request gate. This preserves one requests.Session without
+    allowing concurrent searches to race over client configuration.
     """
     global _arxiv_client
-    if _arxiv_client is None or getattr(_arxiv_client, "page_size", None) != page_size:
+    if _arxiv_client is None:
         import arxiv
 
-        _arxiv_client = arxiv.Client(page_size=page_size)
+        _arxiv_client = arxiv.Client()
     return _arxiv_client
 
 

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -11,7 +11,7 @@ from typing import Dict, Any, List
 import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings, get_arxiv_client
-from ..arxiv_api import stream_pdf_to_path
+from ..arxiv_api import ARXIV_RATE_LIMITER, stream_pdf_to_path
 from .content import add_content_payload
 import logging
 
@@ -240,7 +240,9 @@ def _fetch_pdf_content(paper_id: str) -> tuple[str, arxiv.Result]:
 
     client = get_arxiv_client()
     try:
-        paper = next(client.results(arxiv.Search(id_list=[paper_id])))
+        paper = ARXIV_RATE_LIMITER.run_sync(
+            lambda: next(client.results(arxiv.Search(id_list=[paper_id])))
+        )
     except StopIteration:
         raise PaperNotFoundError(f"Paper {paper_id} not found on arXiv")
 

--- a/src/arxiv_mcp_server/tools/get_abstract.py
+++ b/src/arxiv_mcp_server/tools/get_abstract.py
@@ -2,19 +2,12 @@
 
 import json
 import logging
-import time
 from typing import Any, Dict, List
 
 import mcp.types as types
 from mcp.types import ToolAnnotations
 
-from .search import (
-    _rate_limited_get,
-    ARXIV_HEADERS,
-    ARXIV_API_URL,
-    _MIN_REQUEST_INTERVAL,
-    _last_request_time,
-)
+from .search import _rate_limited_get, ARXIV_API_URL
 import httpx
 import xml.etree.ElementTree as ET
 

--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -5,7 +5,6 @@ import json
 import logging
 import httpx
 import asyncio
-import time
 import xml.etree.ElementTree as ET
 from typing import Dict, Any, List, Optional
 from datetime import datetime, timezone
@@ -13,58 +12,45 @@ from dateutil import parser
 import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings, get_arxiv_client
-from ..arxiv_api import canonical_pdf_url
+from ..arxiv_api import ARXIV_RATE_LIMITER, canonical_pdf_url
 
 logger = logging.getLogger("arxiv-mcp-server")
 settings = Settings()
 
-# Module-level rate limiter: arXiv asks for >= 3s between requests
-_last_request_time: float = 0.0
-_request_lock = asyncio.Lock()
-_MIN_REQUEST_INTERVAL = 3.0  # seconds
-
 ARXIV_HEADERS = {
-    "User-Agent": "arxiv-mcp-server/0.4.1 (https://github.com/blazickjp/arxiv-mcp-server; research tool)"
+    "User-Agent": (
+        f"{settings.APP_NAME}/{settings.APP_VERSION} "
+        "(https://github.com/blazickjp/arxiv-mcp-server; research tool)"
+    )
 }
 
 
 async def _rate_limited_get(client: httpx.AsyncClient, url: str) -> httpx.Response:
-    """Make a GET request respecting arXiv's rate limit policy.
+    """Make an HTTP request through the process-wide arXiv request gate."""
 
-    Enforces a minimum 3s gap between requests (arXiv's documented guideline).
-    Fails fast on 429/503 — retrying while rate-limited only extends the ban.
-    One retry on timeout only.
-    """
-    global _last_request_time
+    async def request() -> httpx.Response:
+        for attempt in range(2):  # one retry on timeout only
+            try:
+                response = await client.get(url, headers=ARXIV_HEADERS)
+                if response.status_code in (429, 503):
+                    logger.warning(
+                        "arXiv rate limited (%s); not retrying", response.status_code
+                    )
+                    raise RuntimeError(
+                        f"arXiv is rate limiting this IP (HTTP {response.status_code}). "
+                        "Please wait 60 seconds before retrying."
+                    )
+                response.raise_for_status()
+                return response
+            except httpx.TimeoutException:
+                if attempt == 0:
+                    logger.warning("arXiv request timed out, retrying once")
+                    await asyncio.sleep(5.0)
+                else:
+                    raise
+        raise RuntimeError("arXiv request timed out after retry")
 
-    # Enforce minimum interval before sending
-    async with _request_lock:
-        elapsed = time.monotonic() - _last_request_time
-        if elapsed < _MIN_REQUEST_INTERVAL:
-            await asyncio.sleep(_MIN_REQUEST_INTERVAL - elapsed)
-        _last_request_time = time.monotonic()
-
-    for attempt in range(2):  # one retry on timeout only
-        try:
-            response = await client.get(url, headers=ARXIV_HEADERS)
-            if response.status_code in (429, 503):
-                logger.warning(
-                    f"arXiv rate limited ({response.status_code}) — backing off, not retrying"
-                )
-                raise RuntimeError(
-                    f"arXiv is rate limiting this IP (HTTP {response.status_code}). "
-                    "Please wait 60 seconds before retrying."
-                )
-            response.raise_for_status()
-            return response
-        except httpx.TimeoutException:
-            if attempt == 0:
-                logger.warning("arXiv request timed out, retrying once")
-                await asyncio.sleep(5.0)
-            else:
-                raise
-
-    raise RuntimeError("arXiv request timed out after retry")
+    return await ARXIV_RATE_LIMITER.run_async(request)
 
 
 # arXiv API endpoint for raw queries (bypasses arxiv package URL encoding issues)
@@ -502,7 +488,7 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 return [types.TextContent(type="text", text=f"Error: {str(e)}")]
 
         # For non-date queries, use the shared arxiv client (lazy, avoids eager import overhead)
-        client = get_arxiv_client(page_size=max_results)
+        client = get_arxiv_client()
 
         # Build query components
         query_parts = []
@@ -546,18 +532,19 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
             sort_by=sort_criterion,
         )
 
-        # Respect rate limit before request
-        elapsed = time.monotonic() - _last_request_time
-        if elapsed < _MIN_REQUEST_INTERVAL:
-            await asyncio.sleep(_MIN_REQUEST_INTERVAL - elapsed)
-
-        # Process results — fail fast on rate limit, don't hammer the API
-        results = []
-        try:
+        def fetch_results() -> List[Dict[str, Any]]:
+            client.page_size = max_results
+            results = []
             for paper in client.results(search):
                 if len(results) >= max_results:
                     break
                 results.append(_process_paper(paper))
+            return results
+
+        try:
+            results = await asyncio.to_thread(
+                ARXIV_RATE_LIMITER.run_sync, fetch_results
+            )
         except arxiv.ArxivError as e:
             if "429" in str(e) or "rate" in str(e).lower() or "503" in str(e):
                 logger.warning(f"arXiv rate limited — not retrying: {e}")

--- a/src/arxiv_mcp_server/tools/semantic_search.py
+++ b/src/arxiv_mcp_server/tools/semantic_search.py
@@ -14,7 +14,8 @@ import arxiv
 import mcp.types as types
 from mcp.types import ToolAnnotations
 
-from ..config import Settings
+from ..config import Settings, get_arxiv_client
+from ..arxiv_api import ARXIV_RATE_LIMITER
 from .list_papers import is_valid_arxiv_id
 
 try:
@@ -122,7 +123,8 @@ def _connect() -> sqlite3.Connection:
     """Open SQLite connection and ensure schema exists."""
     conn = sqlite3.connect(_db_path())
     conn.row_factory = sqlite3.Row
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS semantic_index (
             paper_id TEXT PRIMARY KEY,
             title TEXT NOT NULL,
@@ -134,7 +136,8 @@ def _connect() -> sqlite3.Connection:
             embedding_dim INTEGER NOT NULL,
             updated_at TEXT NOT NULL
         )
-        """)
+        """
+    )
     conn.commit()
     return conn
 
@@ -208,8 +211,10 @@ def _upsert_index_record(
 def index_paper_by_id(paper_id: str) -> bool:
     """Fetch arXiv metadata by ID and add/update it in the semantic index."""
     try:
-        client = arxiv.Client()
-        paper = next(client.results(arxiv.Search(id_list=[paper_id])))
+        client = get_arxiv_client()
+        paper = ARXIV_RATE_LIMITER.run_sync(
+            lambda: next(client.results(arxiv.Search(id_list=[paper_id])))
+        )
     except StopIteration:
         logger.warning("Could not index paper %s: not found on arXiv", paper_id)
         return False

--- a/tests/test_arxiv_api.py
+++ b/tests/test_arxiv_api.py
@@ -1,0 +1,78 @@
+"""Concurrency tests for the process-wide arXiv request limiter."""
+
+import asyncio
+import time
+
+import pytest
+
+from arxiv_mcp_server.arxiv_api import ArxivRateLimiter
+
+
+@pytest.mark.asyncio
+async def test_async_requests_are_serialized():
+    limiter = ArxivRateLimiter(min_interval=0.0)
+    active = 0
+    max_active = 0
+
+    async def request():
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+
+    await asyncio.gather(limiter.run_async(request), limiter.run_async(request))
+
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_async_request_starts_are_spaced_with_fake_clock():
+    now = 0.0
+    started = []
+
+    async def advance_clock(delay: float) -> None:
+        nonlocal now
+        now += delay
+
+    limiter = ArxivRateLimiter(
+        min_interval=3.0,
+        clock=lambda: now,
+        async_sleep=advance_clock,
+    )
+
+    async def request():
+        started.append(now)
+
+    await limiter.run_async(request)
+    await limiter.run_async(request)
+
+    assert started == [0.0, 3.0]
+
+
+@pytest.mark.asyncio
+async def test_sync_and_async_requests_share_the_same_gate():
+    limiter = ArxivRateLimiter(min_interval=0.0)
+    active = 0
+    max_active = 0
+
+    def sync_request():
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        time.sleep(0.01)
+        active -= 1
+
+    async def async_request():
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+
+    await asyncio.gather(
+        asyncio.to_thread(limiter.run_sync, sync_request),
+        limiter.run_async(async_request),
+    )
+
+    assert max_active == 1

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -4,11 +4,22 @@ import pytest
 import json
 from unittest.mock import patch, MagicMock, AsyncMock
 from arxiv_mcp_server.tools import handle_search
+from arxiv_mcp_server.tools import search as search_module
 from arxiv_mcp_server.tools.search import (
     _validate_categories,
     _raw_arxiv_search,
     _parse_arxiv_atom_response,
 )
+
+
+@pytest.fixture(autouse=True)
+def disable_request_spacing_for_search_unit_tests(monkeypatch):
+    """Keep search tests fast and isolate the process-wide client."""
+    from arxiv_mcp_server import config
+
+    monkeypatch.setattr(search_module.ARXIV_RATE_LIMITER, "min_interval", 0.0)
+    monkeypatch.setattr(search_module.ARXIV_RATE_LIMITER, "_last_started", 0.0)
+    monkeypatch.setattr(config, "_arxiv_client", None)
 
 
 @pytest.mark.asyncio
@@ -24,6 +35,21 @@ async def test_basic_search(mock_client):
         assert paper["id"] == "2103.12345"
         assert paper["title"] == "Test Paper"
         assert "resource_uri" in paper
+
+
+@pytest.mark.asyncio
+async def test_package_search_uses_process_wide_rate_limiter(mock_client, mocker):
+    """The arxiv package path must share the same gate as raw API requests."""
+    mocker.patch.object(search_module, "get_arxiv_client", return_value=mock_client)
+    run_sync = mocker.patch.object(
+        search_module.ARXIV_RATE_LIMITER,
+        "run_sync",
+        side_effect=lambda operation: operation(),
+    )
+
+    await handle_search({"query": "test query", "max_results": 1})
+
+    run_sync.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -223,18 +249,27 @@ async def test_search_max_results_limiting(mock_client):
 
 
 @pytest.mark.asyncio
-async def test_search_client_page_size_matches_requested_max_results(
-    mock_client, monkeypatch
+async def test_search_reuses_client_and_updates_page_size_inside_gate(
+    mock_client, mock_paper, monkeypatch
 ):
-    """Use the requested max_results as the arxiv client page size."""
+    """Varying result limits must reuse one client without stale page sizes."""
     from arxiv_mcp_server import config
 
     monkeypatch.setattr(config, "_arxiv_client", None)
+    observed_page_sizes = []
 
+    def results(_search):
+        observed_page_sizes.append(mock_client.page_size)
+        return [mock_paper]
+
+    mock_client.page_size = 100
+    mock_client.results.side_effect = results
     with patch("arxiv.Client", return_value=mock_client) as mock_client_class:
-        await handle_search({"query": "test", "max_results": 5})
+        await handle_search({"query": "first", "max_results": 5})
+        await handle_search({"query": "second", "max_results": 7})
 
-    mock_client_class.assert_called_once_with(page_size=5)
+    mock_client_class.assert_called_once_with()
+    assert observed_page_sizes == [5, 7]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add one process-wide request gate shared by sync and async arXiv API callers
- serialize requests and enforce the documented three-second interval
- move blocking arxiv package searches off the event loop
- route raw search, abstract lookup, PDF metadata fallback, and semantic indexing through the gate
- generate the User-Agent from package settings instead of a stale hard-coded version

## Validation
- 96 full-suite tests passed
- concurrency tests prove async/async and sync/async requests cannot overlap and are spaced
- repository pre-commit Black hook passed

Focused replacement for the rate-limiter portion of #107; intentionally excludes its unrelated download redesign.
