### PR TITLE
fix: harden LaTeX archive manifests

### DIFF
--- a/src/arxiv_mcp_server/tools/latex.py
+++ b/src/arxiv_mcp_server/tools/latex.py
@@ -31,13 +31,15 @@ settings = Settings()
 
 MAX_ARCHIVE_BYTES = 50 * 1024 * 1024
 MAX_ARCHIVE_MEMBERS = 2_000
+MAX_ARCHIVE_PATH_BYTES = 512
+MAX_ARCHIVE_PATH_DEPTH = 20
 MAX_MEMBER_BYTES = 10 * 1024 * 1024
 MAX_TOTAL_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
 MAX_TEX_FILES = 500
 MAX_TOTAL_TEX_BYTES = 50 * 1024 * 1024
 MAX_INCLUDE_DEPTH = 20
 DEFAULT_MAX_CHARS = 12_000
-MAX_RETURN_CHARS = 100_000
+MAX_RETURN_CHARS = 50_000
 
 _CONTENT_WARNING = (
     "[UNTRUSTED EXTERNAL CONTENT — arXiv LaTeX source. "
@@ -151,10 +153,26 @@ def _download_source_archive(paper_id: str) -> bytes:
 
 def _safe_member_name(name: str) -> str:
     normalized = name.replace("\\", "/")
+    if "\x00" in normalized:
+        raise UnsafeSourceArchiveError(f"NUL byte in source archive path: {name!r}")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    normalized = normalized.rstrip("/")
+    if len(normalized.encode("utf-8")) > MAX_ARCHIVE_PATH_BYTES:
+        raise SourceArchiveLimitError(
+            f"source archive path length exceeds limit: {name}"
+        )
+    raw_parts = normalized.split("/")
+    if len(raw_parts) > MAX_ARCHIVE_PATH_DEPTH:
+        raise SourceArchiveLimitError(
+            f"source archive path depth exceeds limit: {name}"
+        )
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise UnsafeSourceArchiveError(f"unsafe path in source archive: {name}")
     path = PurePosixPath(normalized)
     if path.is_absolute() or ".." in path.parts or not path.name:
         raise UnsafeSourceArchiveError(f"unsafe path in source archive: {name}")
-    return posixpath.normpath(normalized).lstrip("./")
+    return posixpath.normpath(normalized)
 
 
 def _read_plain_gzip(data: bytes) -> dict[str, str]:
@@ -183,6 +201,7 @@ def _extract_tex_files(data: bytes) -> dict[str, str]:
         return _read_plain_gzip(data)
 
     files: dict[str, str] = {}
+    normalized_members: set[str] = set()
     total_uncompressed = 0
     total_tex = 0
     with archive:
@@ -199,7 +218,16 @@ def _extract_tex_files(data: bytes) -> dict[str, str]:
                 # Real arXiv archives may contain an explicit root directory entry.
                 continue
             safe_name = _safe_member_name(member.name)
-            if not member.isfile():
+            if safe_name in normalized_members:
+                raise UnsafeSourceArchiveError(
+                    f"duplicate normalized path in source archive: {safe_name}"
+                )
+            normalized_members.add(safe_name)
+            if not member.isfile() and not member.isdir():
+                raise UnsafeSourceArchiveError(
+                    f"unsupported member type in source archive: {member.name}"
+                )
+            if member.isdir():
                 continue
             if member.size < 0 or member.size > MAX_TOTAL_UNCOMPRESSED_BYTES:
                 raise SourceArchiveLimitError(

--- a/tests/tools/test_latex.py
+++ b/tests/tools/test_latex.py
@@ -40,6 +40,43 @@ def test_extract_tex_files_rejects_path_traversal():
         latex._extract_tex_files(archive)
 
 
+def test_safe_member_name_rejects_nul_long_and_deep_paths():
+    with pytest.raises(latex.UnsafeSourceArchiveError, match="NUL"):
+        latex._safe_member_name("bad\x00name.tex")
+    with pytest.raises(latex.SourceArchiveLimitError, match="path length"):
+        latex._safe_member_name("a" * (latex.MAX_ARCHIVE_PATH_BYTES + 1) + ".tex")
+    deep = "/".join(["d"] * (latex.MAX_ARCHIVE_PATH_DEPTH + 1)) + "/main.tex"
+    with pytest.raises(latex.SourceArchiveLimitError, match="path depth"):
+        latex._safe_member_name(deep)
+
+
+def test_extract_tex_files_rejects_duplicate_normalized_paths():
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for name, content in (("main.tex", b"first"), ("./main.tex", b"second")):
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+
+    with pytest.raises(latex.UnsafeSourceArchiveError, match="duplicate"):
+        latex._extract_tex_files(buffer.getvalue())
+
+
+def test_extract_tex_files_rejects_unsupported_special_members():
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        fifo = tarfile.TarInfo("pipe")
+        fifo.type = tarfile.FIFOTYPE
+        archive.addfile(fifo)
+        content = b"\\documentclass{article}"
+        member = tarfile.TarInfo("main.tex")
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+
+    with pytest.raises(latex.UnsafeSourceArchiveError, match="unsupported"):
+        latex._extract_tex_files(buffer.getvalue())
+
+
 def test_extract_tex_files_rejects_links():
     archive = _tar_bytes(
         {"main.tex": b"\\documentclass{article}"},


### PR DESCRIPTION
## Summary

Follow-up hardening from the independent design review of PR #132:

- Reject NUL-bearing, overlong, over-deep, empty-component, and dot-component archive paths
- Reject duplicate normalized archive paths instead of silently overwriting them
- Reject FIFO/device/unsupported archive member types
- Continue accepting the explicit `.` root directory used by genuine legacy arXiv archives
- Reduce the explicit LaTeX output ceiling from 100,000 to 50,000 characters

## Verification

- Test-first regression cases failed before implementation and now pass
- `uv run pytest -q` — 127 passed
- `uv run black --check src tests` — passed
- Real source regression:
  - `1706.03762`: 10 TeX files, `ms.tex`, 27 sections
  - `hep-th/9901001v3`: 1 TeX file, `imamura2.tex`, 5 sections
