### PR TITLE
fix: bound LaTeX processing and outlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,9 +321,11 @@ result = await call_tool("get_paper_latex", {
     "paper_id": "2401.12345"
 })
 
-# Inspect the compact section outline
+# Inspect a bounded page of the compact section outline
 outline = await call_tool("list_paper_latex_sections", {
-    "paper_id": "2401.12345"
+    "paper_id": "2401.12345",
+    "start": 0,
+    "max_sections": 100
 })
 
 # Read one section by returned ID or exact title
@@ -334,7 +336,7 @@ section = await call_tool("get_paper_latex_section", {
 })
 ```
 
-The source processor validates arXiv IDs, rejects archive traversal and link entries, enforces compressed/expanded/file-count limits, resolves local `\\input`/`\\include` directives with bounded recursion, and caches the flattened result atomically. Some papers do not publish TeX source; those calls return a structured availability error.
+The source processor validates arXiv IDs, streams archive headers while enforcing member and expanded-size limits, rejects traversal, links, duplicate paths, and special-file entries, and caps aggregate include expansion. It ignores commented headings/includes, paginates outlines, bounds section titles and identifiers, and caches versioned validated results atomically. Some papers do not publish TeX source; those calls return a structured availability error.
 
 
 ## 📝 Research Prompts

--- a/src/arxiv_mcp_server/tools/latex.py
+++ b/src/arxiv_mcp_server/tools/latex.py
@@ -37,7 +37,15 @@ MAX_MEMBER_BYTES = 10 * 1024 * 1024
 MAX_TOTAL_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
 MAX_TEX_FILES = 500
 MAX_TOTAL_TEX_BYTES = 50 * 1024 * 1024
+MAX_FLATTENED_CHARS = 50 * 1024 * 1024
 MAX_INCLUDE_DEPTH = 20
+MAX_SECTION_COUNT = 10_000
+MAX_SECTION_TITLE_CHARS = 200
+DEFAULT_MAX_SECTIONS = 100
+MAX_RETURNED_SECTIONS = 200
+CACHE_FORMAT_VERSION = 1
+MAX_PAPER_ID_CHARS = 40
+MAX_SECTION_ID_CHARS = 200
 DEFAULT_MAX_CHARS = 12_000
 MAX_RETURN_CHARS = 50_000
 
@@ -94,6 +102,8 @@ def _normalized_paper_id(arguments: dict[str, Any]) -> str | None:
     if not isinstance(value, str):
         return None
     paper_id = value.strip()
+    if len(paper_id) > MAX_PAPER_ID_CHARS:
+        return None
     return paper_id if is_valid_arxiv_id(paper_id) else None
 
 
@@ -194,72 +204,86 @@ def _read_plain_gzip(data: bytes) -> dict[str, str]:
 
 
 def _extract_tex_files(data: bytes) -> dict[str, str]:
-    """Read TeX members without extracting archive paths to the filesystem."""
-    try:
-        archive = tarfile.open(fileobj=io.BytesIO(data), mode="r:*")
-    except tarfile.ReadError:
-        return _read_plain_gzip(data)
-
+    """Stream TeX members without extracting archive paths to the filesystem."""
+    member_count = 0
     files: dict[str, str] = {}
     normalized_members: set[str] = set()
     total_uncompressed = 0
     total_tex = 0
-    with archive:
-        members = archive.getmembers()
-        if len(members) > MAX_ARCHIVE_MEMBERS:
-            raise SourceArchiveLimitError("source archive contains too many members")
-        for member in members:
-            if member.issym() or member.islnk():
-                raise UnsafeSourceArchiveError(
-                    f"link entry is not allowed in source archive: {member.name}"
-                )
-            normalized_name = member.name.replace("\\", "/")
-            if member.isdir() and posixpath.normpath(normalized_name) == ".":
-                # Real arXiv archives may contain an explicit root directory entry.
-                continue
-            safe_name = _safe_member_name(member.name)
-            if safe_name in normalized_members:
-                raise UnsafeSourceArchiveError(
-                    f"duplicate normalized path in source archive: {safe_name}"
-                )
-            normalized_members.add(safe_name)
-            if not member.isfile() and not member.isdir():
-                raise UnsafeSourceArchiveError(
-                    f"unsupported member type in source archive: {member.name}"
-                )
-            if member.isdir():
-                continue
-            if member.size < 0 or member.size > MAX_TOTAL_UNCOMPRESSED_BYTES:
-                raise SourceArchiveLimitError(
-                    f"source archive member exceeds expanded safety limit: {member.name}"
-                )
-            total_uncompressed += member.size
-            if total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
-                raise SourceArchiveLimitError(
-                    "source archive expanded size exceeds safety limit"
-                )
-            if not safe_name.lower().endswith(".tex"):
-                continue
-            if member.size > MAX_MEMBER_BYTES:
-                raise SourceArchiveLimitError(
-                    f"TeX source member exceeds safety limit: {member.name}"
-                )
-            if len(files) >= MAX_TEX_FILES:
-                raise SourceArchiveLimitError(
-                    "source archive contains too many TeX files"
-                )
-            total_tex += member.size
-            if total_tex > MAX_TOTAL_TEX_BYTES:
-                raise SourceArchiveLimitError("total TeX source exceeds safety limit")
-            stream = archive.extractfile(member)
-            if stream is None:
-                continue
-            raw = stream.read(MAX_MEMBER_BYTES + 1)
-            if len(raw) > MAX_MEMBER_BYTES:
-                raise SourceArchiveLimitError(
-                    f"source archive member exceeds safety limit: {member.name}"
-                )
-            files[safe_name] = raw.decode("utf-8", errors="replace")
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(data), mode="r|*")
+    except tarfile.ReadError:
+        return _read_plain_gzip(data)
+
+    try:
+        with archive:
+            for member in archive:
+                member_count += 1
+                if member_count > MAX_ARCHIVE_MEMBERS:
+                    raise SourceArchiveLimitError(
+                        "source archive contains too many members"
+                    )
+                if member.issym() or member.islnk():
+                    raise UnsafeSourceArchiveError(
+                        f"link entry is not allowed in source archive: {member.name}"
+                    )
+                normalized_name = member.name.replace("\\", "/")
+                if member.isdir() and posixpath.normpath(normalized_name) == ".":
+                    # Real arXiv archives may contain an explicit root directory entry.
+                    continue
+                safe_name = _safe_member_name(member.name)
+                if safe_name in normalized_members:
+                    raise UnsafeSourceArchiveError(
+                        f"duplicate normalized path in source archive: {safe_name}"
+                    )
+                normalized_members.add(safe_name)
+                if not member.isfile() and not member.isdir():
+                    raise UnsafeSourceArchiveError(
+                        f"unsupported member type in source archive: {member.name}"
+                    )
+                if member.isdir():
+                    continue
+                if member.size < 0 or member.size > MAX_TOTAL_UNCOMPRESSED_BYTES:
+                    raise SourceArchiveLimitError(
+                        f"source archive member exceeds expanded safety limit: {member.name}"
+                    )
+                total_uncompressed += member.size
+                if total_uncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES:
+                    raise SourceArchiveLimitError(
+                        "source archive expanded size exceeds safety limit"
+                    )
+                if not safe_name.lower().endswith(".tex"):
+                    continue
+                if member.size > MAX_MEMBER_BYTES:
+                    raise SourceArchiveLimitError(
+                        f"TeX source member exceeds safety limit: {member.name}"
+                    )
+                if len(files) >= MAX_TEX_FILES:
+                    raise SourceArchiveLimitError(
+                        "source archive contains too many TeX files"
+                    )
+                total_tex += member.size
+                if total_tex > MAX_TOTAL_TEX_BYTES:
+                    raise SourceArchiveLimitError(
+                        "total TeX source exceeds safety limit"
+                    )
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise LatexSourceError(
+                        f"could not read TeX source member: {member.name}"
+                    )
+                raw = stream.read(MAX_MEMBER_BYTES + 1)
+                if len(raw) > MAX_MEMBER_BYTES:
+                    raise SourceArchiveLimitError(
+                        f"source archive member exceeds safety limit: {member.name}"
+                    )
+                files[safe_name] = raw.decode("utf-8", errors="replace")
+    except tarfile.ReadError as exc:
+        if member_count == 0:
+            return _read_plain_gzip(data)
+        raise LatexSourceError(
+            "arXiv source archive is malformed or truncated"
+        ) from exc
     if not files:
         raise LatexSourceError("arXiv source archive contains no TeX files")
     return files
@@ -290,37 +314,75 @@ def _resolve_include(current_file: str, requested: str) -> str | None:
     return candidate
 
 
-def _flatten_source(files: dict[str, str]) -> tuple[str, str]:
-    """Select the main document and inline safe local input/include directives."""
-    main_file = max(files, key=lambda name: _main_file_score(name, files[name]))
+def _mask_tex_comments(source: str) -> str:
+    """Replace TeX comments with spaces while preserving offsets and newlines."""
+    masked: list[str] = []
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if char == "%":
+            backslashes = 0
+            cursor = index - 1
+            while cursor >= 0 and source[cursor] == "\\":
+                backslashes += 1
+                cursor -= 1
+            if backslashes % 2 == 0:
+                while index < len(source) and source[index] not in "\r\n":
+                    masked.append(" ")
+                    index += 1
+                continue
+        masked.append(char)
+        index += 1
+    return "".join(masked)
 
-    def expand(name: str, stack: tuple[str, ...], depth: int) -> str:
+
+def _flatten_source(files: dict[str, str]) -> tuple[str, str]:
+    """Select the main document and inline local includes within a hard budget."""
+    main_file = max(files, key=lambda name: _main_file_score(name, files[name]))
+    output: list[str] = []
+    output_chars = 0
+
+    def emit(value: str) -> None:
+        nonlocal output_chars
+        output_chars += len(value)
+        if output_chars > MAX_FLATTENED_CHARS:
+            raise SourceArchiveLimitError("flattened LaTeX source exceeds safety limit")
+        output.append(value)
+
+    def expand(name: str, stack: tuple[str, ...], depth: int) -> None:
         text = files.get(name, "")
         if depth >= MAX_INCLUDE_DEPTH:
-            return text
-
-        def replacement(match: re.Match[str]) -> str:
+            emit(text)
+            return
+        masked = _mask_tex_comments(text)
+        cursor = 0
+        for match in _INCLUDE_RE.finditer(masked):
+            emit(text[cursor : match.start()])
             target = _resolve_include(name, match.group(1))
-            if target is None or target not in files or target in stack:
-                return ""
-            return expand(target, (*stack, target), depth + 1)
+            if target is not None and target in files and target not in stack:
+                expand(target, (*stack, target), depth + 1)
+            cursor = match.end()
+        emit(text[cursor:])
 
-        return _INCLUDE_RE.sub(replacement, text)
-
-    return expand(main_file, (main_file,), 0), main_file
+    expand(main_file, (main_file,), 0)
+    return "".join(output), main_file
 
 
 def _parse_sections(source: str) -> list[LatexSection]:
     raw: list[tuple[int, str, str, int]] = []
     levels = {"section": 1, "subsection": 2, "subsubsection": 3}
     counters = [0, 0, 0]
-    for match in _SECTION_RE.finditer(source):
+    masked = _mask_tex_comments(source)
+    for match in _SECTION_RE.finditer(masked):
+        if len(raw) >= MAX_SECTION_COUNT:
+            raise SourceArchiveLimitError("LaTeX source contains too many sections")
         level = levels[match.group(1)]
         counters[level - 1] += 1
         for index in range(level, 3):
             counters[index] = 0
         section_id = ".".join(str(value) for value in counters[:level])
         title = re.sub(r"\s+", " ", match.group(2)).strip()
+        title = title[:MAX_SECTION_TITLE_CHARS]
         raw.append((level, section_id, title, match.start()))
 
     sections: list[LatexSection] = []
@@ -360,11 +422,22 @@ def _load_cached_source(paper_id: str) -> LatexSource | None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-        return LatexSource(
-            content=str(payload["content"]),
-            main_file=str(payload["main_file"]),
-            source_files=int(payload["source_files"]),
-        )
+        content = payload["content"]
+        main_file = payload["main_file"]
+        source_files = payload["source_files"]
+        if payload.get("cache_format") != CACHE_FORMAT_VERSION:
+            raise ValueError("stale cache format")
+        if not isinstance(content, str) or len(content) > MAX_FLATTENED_CHARS:
+            raise ValueError("invalid cached content")
+        if not isinstance(main_file, str) or not main_file or len(main_file) > 512:
+            raise ValueError("invalid cached main file")
+        if (
+            not isinstance(source_files, int)
+            or isinstance(source_files, bool)
+            or not 1 <= source_files <= MAX_TEX_FILES
+        ):
+            raise ValueError("invalid cached source count")
+        return LatexSource(content, main_file, source_files)
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
         path.unlink(missing_ok=True)
         return None
@@ -381,6 +454,7 @@ def _write_cached_source(paper_id: str, source: LatexSource) -> None:
         staging.write_text(
             json.dumps(
                 {
+                    "cache_format": CACHE_FORMAT_VERSION,
                     "content": source.content,
                     "main_file": source.main_file,
                     "source_files": source.source_files,
@@ -452,7 +526,20 @@ list_paper_latex_sections_tool = types.Tool(
     description="Return a compact outline of headings from original LaTeX source.",
     inputSchema={
         "type": "object",
-        "properties": {"paper_id": _paper_id_property()},
+        "properties": {
+            "paper_id": _paper_id_property(),
+            "start": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Zero-based section index (default 0)",
+            },
+            "max_sections": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_RETURNED_SECTIONS,
+                "description": f"Maximum headings to return (default {DEFAULT_MAX_SECTIONS})",
+            },
+        },
         "required": ["paper_id"],
         "additionalProperties": False,
     },
@@ -512,7 +599,7 @@ async def handle_get_paper_latex(
         return _error(str(exc), paper_id)
     except Exception as exc:
         logger.exception("LaTeX source retrieval failed for %s", paper_id)
-        return _error(f"LaTeX source retrieval failed: {exc}", paper_id)
+        return _error("LaTeX source retrieval failed", paper_id)
 
 
 async def handle_list_paper_latex_sections(
@@ -524,13 +611,31 @@ async def handle_list_paper_latex_sections(
     try:
         source = await asyncio.to_thread(_load_source, paper_id)
         sections = _parse_sections(source.content)
+        try:
+            start = max(0, int(arguments.get("start", 0)))
+        except (TypeError, ValueError):
+            start = 0
+        try:
+            max_sections = min(
+                MAX_RETURNED_SECTIONS,
+                max(1, int(arguments.get("max_sections", DEFAULT_MAX_SECTIONS))),
+            )
+        except (TypeError, ValueError):
+            max_sections = DEFAULT_MAX_SECTIONS
+        page = sections[start : start + max_sections]
+        next_start = start + len(page)
         payload = {
             "status": "success",
             "paper_id": paper_id,
             "main_file": source.main_file,
+            "total_sections": len(sections),
+            "start": start,
+            "returned_sections": len(page),
+            "next_start": next_start if next_start < len(sections) else None,
+            "is_truncated": next_start < len(sections),
             "sections": [
                 {"id": item.section_id, "level": item.level, "title": item.title}
-                for item in sections
+                for item in page
             ],
         }
         return [types.TextContent(type="text", text=json.dumps(payload, indent=2))]
@@ -543,7 +648,7 @@ async def handle_list_paper_latex_sections(
         return _error(str(exc), paper_id)
     except Exception as exc:
         logger.exception("LaTeX outline retrieval failed for %s", paper_id)
-        return _error(f"LaTeX outline retrieval failed: {exc}", paper_id)
+        return _error("LaTeX outline retrieval failed", paper_id)
 
 
 async def handle_get_paper_latex_section(
@@ -555,6 +660,8 @@ async def handle_get_paper_latex_section(
     section_id = arguments.get("section_id")
     if not isinstance(section_id, str) or not section_id.strip():
         return _error("section_id is required", paper_id)
+    if len(section_id) > MAX_SECTION_ID_CHARS:
+        return _error(f"section_id exceeds {MAX_SECTION_ID_CHARS} characters", paper_id)
     try:
         source = await asyncio.to_thread(_load_source, paper_id)
         sections = _parse_sections(source.content)
@@ -595,4 +702,4 @@ async def handle_get_paper_latex_section(
         return _error(str(exc), paper_id)
     except Exception as exc:
         logger.exception("LaTeX section retrieval failed for %s", paper_id)
-        return _error(f"LaTeX section retrieval failed: {exc}", paper_id)
+        return _error("LaTeX section retrieval failed", paper_id)

--- a/tests/tools/test_latex.py
+++ b/tests/tools/test_latex.py
@@ -120,6 +120,51 @@ def test_extract_tex_files_supports_plain_gzip():
     assert files == {"main.tex": source.decode()}
 
 
+def test_load_cached_source_rejects_stale_format_and_oversized_content(
+    monkeypatch, tmp_path
+):
+    cache = tmp_path / "paper.json"
+    monkeypatch.setattr(latex, "_cache_path", lambda _paper_id: cache)
+    monkeypatch.setattr(latex, "MAX_FLATTENED_CHARS", 10)
+
+    cache.write_text(
+        json.dumps(
+            {
+                "cache_format": latex.CACHE_FORMAT_VERSION - 1,
+                "content": "safe",
+                "main_file": "main.tex",
+                "source_files": 1,
+            }
+        )
+    )
+    assert latex._load_cached_source("2401.00001") is None
+    assert not cache.exists()
+
+    cache.write_text(
+        json.dumps(
+            {
+                "cache_format": latex.CACHE_FORMAT_VERSION,
+                "content": "x" * (latex.MAX_FLATTENED_CHARS + 1),
+                "main_file": "main.tex",
+                "source_files": 1,
+            }
+        )
+    )
+    assert latex._load_cached_source("2401.00001") is None
+    assert not cache.exists()
+
+
+def test_write_cached_source_records_format_version(monkeypatch, tmp_path):
+    cache = tmp_path / "paper.json"
+    monkeypatch.setattr(latex, "_cache_path", lambda _paper_id: cache)
+
+    latex._write_cached_source(
+        "2401.00001", latex.LatexSource("content", "main.tex", 1)
+    )
+
+    assert json.loads(cache.read_text())["cache_format"] == latex.CACHE_FORMAT_VERSION
+
+
 def test_flatten_source_selects_main_document_and_resolves_inputs():
     files = {
         "notes.tex": "scratch",
@@ -182,6 +227,50 @@ Numbers.
     assert "\\section{Results}" not in latex._extract_section(source, sections, "1")
 
 
+def test_extract_tex_files_streams_members_without_getmembers(monkeypatch):
+    archive = _tar_bytes({"main.tex": b"\\documentclass{article}"})
+
+    def forbidden(_self):
+        raise AssertionError("getmembers must not scan the complete archive")
+
+    monkeypatch.setattr(tarfile.TarFile, "getmembers", forbidden)
+
+    assert latex._extract_tex_files(archive)["main.tex"] == "\\documentclass{article}"
+
+
+def test_extract_tex_files_enforces_member_count_during_iteration(monkeypatch):
+    monkeypatch.setattr(latex, "MAX_ARCHIVE_MEMBERS", 2)
+    archive = _tar_bytes(
+        {
+            "one.txt": b"1",
+            "two.txt": b"2",
+            "main.tex": b"\\documentclass{article}",
+        }
+    )
+
+    with pytest.raises(latex.SourceArchiveLimitError, match="too many members"):
+        latex._extract_tex_files(archive)
+
+
+def test_flatten_source_enforces_aggregate_output_budget(monkeypatch):
+    monkeypatch.setattr(latex, "MAX_FLATTENED_CHARS", 40)
+    files = {
+        "main.tex": "\\documentclass{article}\n" + "\\input{child}\n" * 10,
+        "child.tex": "0123456789",
+    }
+
+    with pytest.raises(latex.SourceArchiveLimitError, match="flattened"):
+        latex._flatten_source(files)
+
+
+def test_parse_sections_ignores_commented_headings():
+    source = "% \\section{Fake}\n\\section{Real}\nText"
+
+    sections = latex._parse_sections(source)
+
+    assert [(item.section_id, item.title) for item in sections] == [("1", "Real")]
+
+
 def test_download_archive_aborts_when_stream_exceeds_limit(monkeypatch):
     monkeypatch.setattr(latex, "MAX_ARCHIVE_BYTES", 5)
     response = MagicMock()
@@ -222,6 +311,19 @@ async def test_get_latex_rejects_invalid_id_before_loading(monkeypatch):
 
     assert payload["status"] == "error"
     assert "invalid arXiv ID" in payload["message"]
+    load.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_latex_rejects_overlong_legacy_id_before_loading(monkeypatch):
+    load = MagicMock()
+    monkeypatch.setattr(latex, "_load_source", load)
+    paper_id = f"{'a' * 100}/9901001"
+
+    payload = _payload(await latex.handle_get_paper_latex({"paper_id": paper_id}))
+
+    assert payload["status"] == "error"
+    assert payload["message"] == "invalid arXiv ID"
     load.assert_not_called()
 
 
@@ -289,6 +391,29 @@ async def test_list_latex_sections_is_compact(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_latex_sections_is_paginated_and_bounded(monkeypatch):
+    source = "\n".join(f"\\section{{Section {index}}}\nText" for index in range(6))
+    monkeypatch.setattr(
+        latex,
+        "_load_source",
+        lambda _paper_id: latex.LatexSource(source, "main.tex", 1),
+    )
+
+    payload = _payload(
+        await latex.handle_list_paper_latex_sections(
+            {"paper_id": "2401.00001", "start": 1, "max_sections": 2}
+        )
+    )
+
+    assert payload["total_sections"] == 6
+    assert payload["start"] == 1
+    assert payload["returned_sections"] == 2
+    assert payload["next_start"] == 3
+    assert payload["is_truncated"] is True
+    assert [item["id"] for item in payload["sections"]] == ["2", "3"]
+
+
+@pytest.mark.asyncio
 async def test_get_latex_section_supports_bounded_continuation(monkeypatch):
     source = "\\section{Intro}\nabcdefghij\n\\section{Next}\nnope"
     monkeypatch.setattr(
@@ -316,6 +441,24 @@ async def test_get_latex_section_supports_bounded_continuation(monkeypatch):
     assert first["is_truncated"] is True
     assert second["is_truncated"] is False
     assert "Next" not in first["content"] + second["content"]
+
+
+@pytest.mark.asyncio
+async def test_get_latex_section_rejects_overlong_identifier_without_echo(monkeypatch):
+    load = MagicMock()
+    monkeypatch.setattr(latex, "_load_source", load)
+    section_id = "x" * 1_000_000
+
+    payload = _payload(
+        await latex.handle_get_paper_latex_section(
+            {"paper_id": "2401.00001", "section_id": section_id}
+        )
+    )
+
+    assert payload["status"] == "error"
+    assert payload["message"] == "section_id exceeds 200 characters"
+    assert len(json.dumps(payload)) < 500
+    load.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Resolves the blocking findings from the independent security/context review of the LaTeX feature:

- Stream tar members with `r|*` and enforce member/expanded limits while headers are consumed; remove `getmembers()` pre-scan
- Enforce a hard aggregate flattened-source budget during recursive include expansion
- Paginate section outlines with bounded title lengths, defaults, and hard maximums
- Enforce paper-ID and section-ID lengths in handlers rather than relying on client-side schema validation
- Ignore commented section/include commands while preserving source offsets
- Version and validate cached source records, invalidating stale or oversized entries
- Stop exposing raw generic exception strings in MCP errors

## Verification

- Test-first regressions reproduced all four blocking review findings before implementation
- `uv run pytest -q` — 136 passed
- `uv run black --check src tests` — passed
- Real source regression:
  - `1706.03762`: modern multi-file source, `ms.tex`, 23 real headings after comment filtering
  - `hep-th/9901001v3`: legacy single-file source, `imamura2.tex`, 5 headings
- Real MCP stdio smoke:
  - all three tools discovered
  - outline `start=1,max_sections=2` returned exactly two headings plus continuation metadata
  - section response respected `max_chars=1200`
