### PR TITLE
Add export_citations tool for BibTeX export (Closes #41)

### DIFF
--- a/src/arxiv_mcp_server/server.py
+++ b/src/arxiv_mcp_server/server.py
@@ -34,6 +34,8 @@ from .tools import (
     reindex_tool,
     handle_citation_graph,
     citation_graph_tool,
+    handle_export_citations,
+    export_citations_tool,
     handle_watch_topic,
     watch_topic_tool,
     handle_check_alerts,
@@ -81,6 +83,7 @@ async def list_tools() -> List[types.Tool]:
         semantic_search_tool,
         reindex_tool,
         citation_graph_tool,
+        export_citations_tool,
         watch_topic_tool,
         check_alerts_tool,
         get_paper_latex_tool,
@@ -126,6 +129,8 @@ async def call_tool(name: str, arguments: Dict[str, Any]) -> List[types.TextCont
             result = await handle_reindex(arguments)
         elif name == "citation_graph":
             result = await handle_citation_graph(arguments)
+        elif name == "export_citations":
+            result = await handle_export_citations(arguments)
         elif name == "watch_topic":
             result = await handle_watch_topic(arguments)
         elif name == "check_alerts":

--- a/src/arxiv_mcp_server/tools/__init__.py
+++ b/src/arxiv_mcp_server/tools/__init__.py
@@ -12,6 +12,7 @@ from .semantic_search import (
     handle_reindex,
 )
 from .citation_graph import citation_graph_tool, handle_citation_graph
+from .export_citations import export_citations_tool, handle_export_citations
 from .alerts import (
     watch_topic_tool,
     handle_watch_topic,
@@ -44,6 +45,8 @@ __all__ = [
     "handle_reindex",
     "citation_graph_tool",
     "handle_citation_graph",
+    "export_citations_tool",
+    "handle_export_citations",
     "watch_topic_tool",
     "handle_watch_topic",
     "check_alerts_tool",

--- a/src/arxiv_mcp_server/tools/export_citations.py
+++ b/src/arxiv_mcp_server/tools/export_citations.py
@@ -1,0 +1,230 @@
+"""Export BibTeX citations for arXiv papers using authoritative arXiv metadata.
+
+Scoped per maintainer request in issue #41: BibTeX only (RIS/CSL-JSON are follow-up
+work), one ``export_citations`` tool over one or more validated arXiv IDs, metadata
+taken from the arXiv API (never model-generated), version suffixes preserved where the
+caller supplies them, deterministic citation keys, and no heavy formatting dependency.
+"""
+
+import json
+import logging
+import re
+import unicodedata
+from typing import Any, Dict, List, Optional
+
+import httpx
+import mcp.types as types
+from mcp.types import ToolAnnotations
+
+from .list_papers import is_valid_arxiv_id
+from .search import ARXIV_API_URL, _parse_arxiv_atom_response, _rate_limited_get
+
+logger = logging.getLogger("arxiv-mcp-server")
+
+# Bound the response so a single call cannot fan out without limit.
+MAX_IDS = 50
+
+_VERSION_SUFFIX = re.compile(r"v\d+$", re.IGNORECASE)
+
+# BibTeX special characters, escaped in field values. Backslash is handled via a
+# sentinel so the backslashes we introduce here are not re-escaped.
+_BIBTEX_REPLACEMENTS = [
+    ("&", r"\&"),
+    ("%", r"\%"),
+    ("$", r"\$"),
+    ("#", r"\#"),
+    ("_", r"\_"),
+    ("{", r"\{"),
+    ("}", r"\}"),
+    ("~", r"\textasciitilde{}"),
+    ("^", r"\textasciicircum{}"),
+]
+
+
+def _bibtex_escape(text: str) -> str:
+    """Escape characters that are special in BibTeX field values."""
+    if not text:
+        return ""
+    out = text.replace("\\", "\x00")
+    for char, repl in _BIBTEX_REPLACEMENTS:
+        out = out.replace(char, repl)
+    return out.replace("\x00", r"\textbackslash{}")
+
+
+def _ascii_token(value: str) -> str:
+    """Fold *value* to lowercase ASCII alphanumerics (deterministic, accent-safe)."""
+    folded = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"[^a-z0-9]", "", folded.lower())
+
+
+def _base_id(paper_id: str) -> str:
+    """Strip a trailing version suffix, keeping the bare arXiv identifier."""
+    return _VERSION_SUFFIX.sub("", paper_id)
+
+
+def _year_of(published: str) -> str:
+    """Extract a four-digit year from an arXiv ``published`` timestamp."""
+    return published[:4] if published[:4].isdigit() else ""
+
+
+def _citation_key(authors: List[str], year: str, title: str) -> str:
+    """Deterministic key: first-author surname + year + first title word.
+
+    Falls back to whatever parts are available so a key is always produced.
+    """
+    surname = ""
+    if authors and authors[0].split():
+        surname = _ascii_token(authors[0].split()[-1])
+    title_word = ""
+    for word in title.split():
+        token = _ascii_token(word)
+        if token:
+            title_word = token
+            break
+    key = f"{surname}{year}{title_word}"
+    return key or "arxiv"
+
+
+def _render_entry(key: str, paper: Dict[str, Any], requested_id: str) -> str:
+    """Render a single ``@misc`` BibTeX entry from authoritative arXiv metadata."""
+    fields: List[tuple] = []
+    title = paper.get("title", "")
+    if title:
+        fields.append(("title", _bibtex_escape(title)))
+    authors = paper.get("authors") or []
+    if authors:
+        fields.append(("author", " and ".join(_bibtex_escape(a) for a in authors)))
+    year = _year_of(paper.get("published", ""))
+    if year:
+        fields.append(("year", year))
+    # Preserve the version suffix the caller supplied; otherwise the bare ID.
+    fields.append(("eprint", requested_id))
+    fields.append(("archivePrefix", "arXiv"))
+    categories = paper.get("categories") or []
+    if categories:
+        fields.append(("primaryClass", categories[0]))
+    fields.append(("url", f"https://arxiv.org/abs/{requested_id}"))
+
+    body = ",\n".join(f"  {name} = {{{value}}}" for name, value in fields)
+    return f"@misc{{{key},\n{body}\n}}"
+
+
+async def _fetch_metadata(ids: List[str]) -> Dict[str, Dict[str, Any]]:
+    """Fetch authoritative metadata for *ids* in one arXiv API request.
+
+    Returns a mapping of bare arXiv ID -> parsed metadata dict.
+    """
+    url = f"{ARXIV_API_URL}?id_list={','.join(ids)}&max_results={len(ids)}"
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await _rate_limited_get(client, url)
+    papers = _parse_arxiv_atom_response(response.text)
+    return {paper["id"]: paper for paper in papers if paper.get("id")}
+
+
+def _error(message: str) -> List[types.TextContent]:
+    return [types.TextContent(type="text", text=json.dumps({"status": "error", "message": message}))]
+
+
+export_citations_tool = types.Tool(
+    name="export_citations",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    description=(
+        "Export BibTeX citations for one or more arXiv papers using authoritative arXiv "
+        "metadata (title, authors, year, primary category), never model-generated fields. "
+        "Version suffixes (e.g. '2401.12345v2') are preserved and citation keys are "
+        "deterministic. Returns the rendered BibTeX plus per-paper status/error. "
+        "BibTeX only; RIS/CSL-JSON are not yet supported."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "paper_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+                "maxItems": MAX_IDS,
+                "description": (
+                    "arXiv IDs, new-style ('2401.12345', optionally versioned "
+                    "'2401.12345v2') or legacy ('hep-ph/9901234')."
+                ),
+            }
+        },
+        "required": ["paper_ids"],
+        "additionalProperties": False,
+    },
+)
+
+
+async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextContent]:
+    """Build BibTeX for the requested arXiv IDs with per-paper status reporting."""
+    try:
+        raw_ids = arguments.get("paper_ids")
+        if isinstance(raw_ids, str):
+            raw_ids = [raw_ids]
+        if not isinstance(raw_ids, list) or not raw_ids:
+            return _error("paper_ids must be a non-empty list of arXiv IDs")
+        if len(raw_ids) > MAX_IDS:
+            return _error(f"too many IDs: {len(raw_ids)} (max {MAX_IDS})")
+
+        valid_ids = [
+            pid.strip()
+            for pid in raw_ids
+            if isinstance(pid, str) and is_valid_arxiv_id(pid.strip())
+        ]
+        metadata = await _fetch_metadata(valid_ids) if valid_ids else {}
+
+        results: List[Dict[str, Any]] = []
+        used_keys: set = set()
+        for pid in raw_ids:
+            candidate = pid.strip() if isinstance(pid, str) else ""
+            if not candidate or not is_valid_arxiv_id(candidate):
+                results.append(
+                    {"paper_id": pid, "status": "error", "error": "invalid arXiv ID format"}
+                )
+                continue
+            paper = metadata.get(_base_id(candidate))
+            if not paper:
+                results.append(
+                    {"paper_id": candidate, "status": "error", "error": "not found on arXiv"}
+                )
+                continue
+            base_key = _citation_key(
+                paper.get("authors") or [],
+                _year_of(paper.get("published", "")),
+                paper.get("title", ""),
+            )
+            key, suffix = base_key, 0
+            while key in used_keys:  # deterministic disambiguation within the batch
+                suffix += 1
+                key = f"{base_key}{chr(ord('a') + suffix - 1)}"
+            used_keys.add(key)
+            results.append(
+                {
+                    "paper_id": candidate,
+                    "status": "success",
+                    "key": key,
+                    "bibtex": _render_entry(key, paper, candidate),
+                }
+            )
+
+        succeeded = [r for r in results if r["status"] == "success"]
+        failed = [r for r in results if r["status"] != "success"]
+        overall = "success" if not failed else ("partial" if succeeded else "error")
+        payload = {
+            "status": overall,
+            "format": "bibtex",
+            "bibtex": "\n\n".join(r["bibtex"] for r in succeeded),
+            "results": results,
+            "count": {
+                "requested": len(raw_ids),
+                "succeeded": len(succeeded),
+                "failed": len(failed),
+            },
+        }
+        return [types.TextContent(type="text", text=json.dumps(payload, indent=2))]
+
+    except RuntimeError as exc:  # rate limit / timeout surfaced by _rate_limited_get
+        return _error(str(exc))
+    except Exception as exc:  # noqa: BLE001 - report, don't crash the server
+        logger.error(f"export_citations error: {exc}")
+        return _error(str(exc))

--- a/tests/tools/test_export_citations.py
+++ b/tests/tools/test_export_citations.py
@@ -1,0 +1,218 @@
+"""Tests for the export_citations (BibTeX) tool — issue #41.
+
+Network is mocked: handle_export_citations is exercised with a stubbed
+_fetch_metadata so the citation logic is tested deterministically.
+"""
+
+import json
+
+import pytest
+
+from arxiv_mcp_server.tools import export_citations as ec
+
+
+def _paper(pid, title, authors, published="2024-01-15T00:00:00Z", categories=("cs.AI",)):
+    return {
+        "id": pid,
+        "title": title,
+        "authors": list(authors),
+        "abstract": "[EXTERNAL CONTENT] x",
+        "categories": list(categories),
+        "published": published,
+        "url": f"https://arxiv.org/pdf/{pid}",
+        "resource_uri": f"arxiv://{pid}",
+    }
+
+
+def _stub_metadata(monkeypatch, papers, recorder=None):
+    """Patch _fetch_metadata to return canned metadata keyed by bare ID."""
+
+    async def _fake(ids):
+        # Mirror the real fetch: arXiv metadata is keyed by the *bare* ID
+        # (the Atom parser strips version suffixes), regardless of the version
+        # the caller queried with.
+        if recorder is not None:
+            recorder.extend(ids)
+        bases = {ec._base_id(i) for i in ids}
+        return {p["id"]: p for p in papers if p["id"] in bases}
+
+    monkeypatch.setattr(ec, "_fetch_metadata", _fake)
+
+
+async def _run(arguments):
+    result = await ec.handle_export_citations(arguments)
+    assert len(result) == 1 and result[0].type == "text"
+    return json.loads(result[0].text)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers                                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_bibtex_escape_special_characters():
+    assert ec._bibtex_escape("Cost & Effect 50% #1 a_b") == r"Cost \& Effect 50\% \#1 a\_b"
+    assert ec._bibtex_escape("a{b}c") == r"a\{b\}c"
+    assert ec._bibtex_escape(r"back\slash") == r"back\textbackslash{}slash"
+    assert ec._bibtex_escape("tilde~caret^") == r"tilde\textasciitilde{}caret\textasciicircum{}"
+
+
+def test_citation_key_is_deterministic():
+    authors = ["Ada Lovelace", "Alan Turing"]
+    k1 = ec._citation_key(authors, "1936", "On Computable Numbers")
+    k2 = ec._citation_key(authors, "1936", "On Computable Numbers")
+    assert k1 == k2 == "lovelace1936on"
+
+
+def test_citation_key_folds_accents_and_falls_back():
+    assert ec._citation_key(["Erdős Pál"], "1949", "Prime Gaps") == "pal1949prime"
+    assert ec._citation_key([], "", "") == "arxiv"
+
+
+def test_base_id_strips_version_only():
+    assert ec._base_id("2401.12345v2") == "2401.12345"
+    assert ec._base_id("2401.12345") == "2401.12345"
+    assert ec._base_id("hep-ph/9901234v3") == "hep-ph/9901234"
+
+
+# --------------------------------------------------------------------------- #
+# Tool behaviour                                                              #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_multiple_authors_joined_with_and(monkeypatch):
+    _stub_metadata(
+        monkeypatch,
+        [_paper("2401.00001", "A Study", ["Ada Lovelace", "Alan Turing", "Grace Hopper"])],
+    )
+    payload = await _run({"paper_ids": ["2401.00001"]})
+    assert payload["status"] == "success"
+    assert "author = {Ada Lovelace and Alan Turing and Grace Hopper}" in payload["bibtex"]
+
+
+@pytest.mark.asyncio
+async def test_escaped_bibtex_characters(monkeypatch):
+    _stub_metadata(
+        monkeypatch,
+        [_paper("2401.00002", "Cost & Effect: 50% of #1 in a_b", ["Jane Q. Smith"])],
+    )
+    payload = await _run({"paper_ids": ["2401.00002"]})
+    entry = payload["results"][0]["bibtex"]
+    assert r"title = {Cost \& Effect: 50\% of \#1 in a\_b}" in entry
+
+
+@pytest.mark.asyncio
+async def test_missing_optional_fields(monkeypatch):
+    # No categories and no usable year -> those fields omitted, entry still valid.
+    _stub_metadata(
+        monkeypatch,
+        [_paper("2401.00003", "No Extras", ["Solo Author"], published="", categories=[])],
+    )
+    payload = await _run({"paper_ids": ["2401.00003"]})
+    entry = payload["results"][0]["bibtex"]
+    assert "primaryClass" not in entry
+    assert "year" not in entry
+    assert "eprint = {2401.00003}" in entry
+    assert "archivePrefix = {arXiv}" in entry
+
+
+@pytest.mark.asyncio
+async def test_versioned_id_preserved_in_eprint_and_url(monkeypatch):
+    _stub_metadata(monkeypatch, [_paper("2401.00004", "Versioned", ["A B"])])
+    payload = await _run({"paper_ids": ["2401.00004v2"]})
+    entry = payload["results"][0]["bibtex"]
+    assert "eprint = {2401.00004v2}" in entry
+    assert "url = {https://arxiv.org/abs/2401.00004v2}" in entry
+
+
+@pytest.mark.asyncio
+async def test_legacy_id(monkeypatch):
+    _stub_metadata(
+        monkeypatch,
+        [_paper("hep-ph/9901234", "Legacy Paper", ["Old Author"], published="1999-01-01T00:00:00Z")],
+    )
+    payload = await _run({"paper_ids": ["hep-ph/9901234"]})
+    result = payload["results"][0]
+    assert result["status"] == "success"
+    assert result["key"] == "author1999legacy"
+    assert "eprint = {hep-ph/9901234}" in result["bibtex"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_id_not_fetched(monkeypatch):
+    requested = []
+    _stub_metadata(monkeypatch, [_paper("2401.00001", "Valid", ["A B"])], recorder=requested)
+    payload = await _run({"paper_ids": ["not-an-id", "2401.00001"]})
+    assert requested == ["2401.00001"]  # invalid ID never hit the network
+    statuses = {r["paper_id"]: r["status"] for r in payload["results"]}
+    assert statuses["not-an-id"] == "error"
+    assert statuses["2401.00001"] == "success"
+    assert payload["status"] == "partial"
+
+
+@pytest.mark.asyncio
+async def test_not_found_on_arxiv(monkeypatch):
+    _stub_metadata(monkeypatch, [])  # well-formed but arXiv returns nothing
+    payload = await _run({"paper_ids": ["2401.99999"]})
+    assert payload["status"] == "error"
+    assert payload["results"][0]["error"] == "not found on arXiv"
+
+
+@pytest.mark.asyncio
+async def test_multiple_paper_output_mixed(monkeypatch):
+    _stub_metadata(
+        monkeypatch,
+        [
+            _paper("2401.00001", "First", ["Ann Lee"]),
+            _paper("2401.00002", "Second", ["Bob Ng"]),
+        ],
+    )
+    payload = await _run({"paper_ids": ["2401.00001", "bad id", "2401.00002", "2401.77777"]})
+    assert payload["count"] == {"requested": 4, "succeeded": 2, "failed": 2}
+    assert payload["status"] == "partial"
+    # Rendered BibTeX contains exactly the two successful entries.
+    assert payload["bibtex"].count("@misc{") == 2
+    # Results preserve request order.
+    assert [r["paper_id"] for r in payload["results"]] == [
+        "2401.00001",
+        "bad id",
+        "2401.00002",
+        "2401.77777",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_keys_disambiguated(monkeypatch):
+    # Same surname + year + first title word -> keys must stay unique & deterministic.
+    _stub_metadata(
+        monkeypatch,
+        [
+            _paper("2401.00001", "Networks Rise", ["Sam Ford"]),
+            _paper("2401.00002", "Networks Fall", ["Sam Ford"]),
+        ],
+    )
+    payload = await _run({"paper_ids": ["2401.00001", "2401.00002"]})
+    keys = [r["key"] for r in payload["results"]]
+    assert keys == ["ford2024networks", "ford2024networksa"]
+    assert len(set(keys)) == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_input_is_error(monkeypatch):
+    _stub_metadata(monkeypatch, [])
+    payload = await _run({"paper_ids": []})
+    assert payload["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_too_many_ids_rejected(monkeypatch):
+    _stub_metadata(monkeypatch, [])
+    payload = await _run({"paper_ids": [f"2401.{i:05d}" for i in range(ec.MAX_IDS + 1)]})
+    assert payload["status"] == "error"
+    assert "max" in payload["message"]
+
+
+def test_tool_registered_in_server():
+    from arxiv_mcp_server.tools import export_citations_tool, handle_export_citations
+
+    assert export_citations_tool.name == "export_citations"
+    assert callable(handle_export_citations)


### PR DESCRIPTION
## Summary
Adds an `export_citations` tool that exports BibTeX for one or more arXiv papers,
scoped exactly to the constraints you laid out in #41.

**Closes #41**

## What it does
- New `export_citations` tool taking `paper_ids` — one or more validated arXiv IDs
  (new-style `2401.12345`, versioned `2401.12345v2`, or legacy `hep-ph/9901234`).
- Renders BibTeX `@misc` entries from **authoritative arXiv metadata** (title, authors,
  year, primary category) — never model-generated fields.
- **BibTeX only** in this PR; RIS/CSL-JSON left for follow-up work.
- **Deterministic citation keys** (first-author surname + year + first title word),
  ASCII/accent-folded, disambiguated within a batch (`smith2020`, `smith2020a`, …).
- **Preserves caller-supplied version suffixes** in `eprint` and `url`.
- **Bounded, machine-readable response**: rendered BibTeX plus per-paper status/error
  and success/failure counts. Capped at 50 IDs per call.

## Design notes (matching your constraints)
- Reuses `is_valid_arxiv_id` and the existing arXiv Atom fetch/parse
  (`_rate_limited_get`, `_parse_arxiv_atom_response`, `ARXIV_API_URL`).
- **No new dependency** — BibTeX escaping and rendering are hand-rolled (~230 lines incl. tests-facing helpers).
- Invalid IDs are rejected before any network call; a single batched `id_list` request
  fetches all valid IDs.

## Tests
16 new tests, all passing; full suite **149 passed, 1 skipped**. Coverage: multiple
authors, escaped BibTeX characters (`& % $ # _ { } ~ ^ \`), missing optional fields,
versioned + legacy IDs, invalid IDs, not-found, multi-paper output, deterministic keys,
in-batch key disambiguation, input bounds.

```
$ python -m pytest tests/tools/test_export_citations.py -q
................                                                          [100%]
16 passed
```

## Example (live arXiv)
```
export_citations(paper_ids=["1706.03762", "hep-th/9711200v3"])
```
```bibtex
@misc{vaswani2017attention,
  title = {Attention Is All You Need},
  author = {Ashish Vaswani and Noam Shazeer and Niki Parmar and Jakob Uszkoreit and Llion Jones and Aidan N. Gomez and Lukasz Kaiser and Illia Polosukhin},
  year = {2017},
  eprint = {1706.03762},
  archivePrefix = {arXiv},
  primaryClass = {cs.CL},
  url = {https://arxiv.org/abs/1706.03762}
}

@misc{maldacena1997the,
  title = {The Large N Limit of Superconformal Field Theories and Supergravity},
  author = {Juan M. Maldacena},
  year = {1997},
  eprint = {hep-th/9711200v3},
  archivePrefix = {arXiv},
  primaryClass = {hep-th},
  url = {https://arxiv.org/abs/hep-th/9711200v3}
}
```

## Disclosure
Implemented with Claude Code (Opus 4.8). I read, understand, and own everything
submitted here.
