### PR TITLE
fix: build Intel macOS MCPB bundles

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing GitHub release tag to upload bundles to (optional)"
+        required: false
+        type: string
 
 jobs:
   build-mcpb:
@@ -39,13 +44,15 @@ jobs:
         run: bash scripts/build-mcpb.sh
 
       - name: Upload MCPB to release
-        if: github.event_name == 'release'
-        run: gh release upload "${{ github.event.release.tag_name }}" mcpb-build/*.mcpb --clobber
+        if: github.event_name == 'release' || inputs.release_tag != ''
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.release_tag }}"
+          gh release upload "$TAG" mcpb-build/*.mcpb --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload MCPB artifact
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag == ''
         uses: actions/upload-artifact@v7
         with:
           name: arxiv-mcp-server-mcpb-${{ matrix.os }}

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -88,11 +88,53 @@ uv export \
   --no-emit-project \
   --format requirements-txt \
   --output-file "$REQUIREMENTS_FILE"
-"$PYTHON_BIN" -m pip install \
-  --target "$BUILD_DIR/server/vendor" \
-  --no-user \
-  --quiet \
-  --requirement "$REQUIREMENTS_FILE"
+
+PIP_ARGS=(
+  --target "$BUILD_DIR/server/vendor"
+  --no-user
+  --quiet
+)
+
+if [[ "$(uname -m)" == "x86_64" ]]; then
+  # onnxruntime 1.24.x no longer publishes Intel macOS wheels. Keep the bundle
+  # on the last CPython 3.11 Intel build while installing the remaining locked
+  # dependency closure without re-resolving transitive requirements.
+  "$PYTHON_BIN" - "$REQUIREMENTS_FILE" <<'PYEOF'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+lines = path.read_text().splitlines(keepends=True)
+out = []
+skipping = False
+found = False
+for line in lines:
+    if not skipping and line.startswith("onnxruntime=="):
+        skipping = True
+        found = True
+    if skipping:
+        if not line.rstrip().endswith("\\"):
+            skipping = False
+        continue
+    out.append(line)
+if not found:
+    raise SystemExit("Could not find locked onnxruntime requirement")
+path.write_text("".join(out))
+PYEOF
+  ONNXRUNTIME_REQUIREMENT="$BUILD_DIR/onnxruntime-intel.txt"
+  printf '%s\n' \
+    'onnxruntime==1.23.2 --hash=sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612' \
+    > "$ONNXRUNTIME_REQUIREMENT"
+  "$PYTHON_BIN" -m pip install "${PIP_ARGS[@]}" \
+    --requirement "$ONNXRUNTIME_REQUIREMENT"
+  "$PYTHON_BIN" -m pip install "${PIP_ARGS[@]}" \
+    --no-deps \
+    --requirement "$REQUIREMENTS_FILE"
+  rm -f "$ONNXRUNTIME_REQUIREMENT"
+else
+  "$PYTHON_BIN" -m pip install "${PIP_ARGS[@]}" \
+    --requirement "$REQUIREMENTS_FILE"
+fi
 rm -f "$REQUIREMENTS_FILE"
 echo "Dependencies vendored"
 


### PR DESCRIPTION
## Summary

- use the last available CPython 3.11 Intel macOS onnxruntime wheel when vendoring the PDF extra
- preserve the lock-derived dependency closure and pinned wheel hash
- allow a manual MCPB workflow run to upload repaired bundles to an existing release

## Root cause

onnxruntime 1.24.1 publishes Apple Silicon macOS wheels but no Intel macOS wheel. The v0.6.0 Intel MCPB job therefore failed while the Apple Silicon job passed.

## Validation

- Apple Silicon MCPB rebuild and protocol smoke passed
- Intel requirements transformation verified locally
- bash syntax, actionlint, pre-commit, metadata test, and diff checks passed
- final Intel build is verified on the macos-15-intel CI runner