### PR TITLE
feat(export_citations): add RIS and CSL-JSON output formats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ The server registers 14 tools:
 - Full text: `download_paper`, `list_papers`, `read_paper`
 - Original source: `get_paper_latex`, `list_paper_latex_sections`, `get_paper_latex_section`
 - Graphs and monitoring: `citation_graph`, `watch_topic`, `check_alerts`
-- Citation export: `export_citations`
+- Citation export: `export_citations` (BibTeX, RIS, CSL-JSON via `format`)
 - Optional local embeddings: `semantic_search`, `reindex`
 
 Keep tool schemas, package exports, server registration, dispatch, tests, and README documentation synchronized when changing the tool surface.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The server currently exposes 14 tools.
 | `list_paper_latex_sections` | Return a paginated LaTeX outline | Supports `start` and `max_sections` |
 | `get_paper_latex_section` | Read one bounded LaTeX section | Select by outline ID or exact title |
 | `citation_graph` | Fetch references and citing papers | Remote Semantic Scholar API |
-| `export_citations` | Export BibTeX for one or more arXiv IDs | Authoritative arXiv metadata |
+| `export_citations` | Export citations (BibTeX, RIS, CSL-JSON) for one or more arXiv IDs | Authoritative arXiv metadata |
 | `watch_topic` | Save or update an arXiv topic watch | Stored locally |
 | `check_alerts` | Check saved watches for new papers | Returns papers since the last check |
 | `semantic_search` | Search downloaded papers by semantic similarity | Requires `[pro]` |

--- a/src/arxiv_mcp_server/tools/export_citations.py
+++ b/src/arxiv_mcp_server/tools/export_citations.py
@@ -1,9 +1,12 @@
 """Export BibTeX citations for arXiv papers using authoritative arXiv metadata.
 
-Scoped per maintainer request in issue #41: BibTeX only (RIS/CSL-JSON are follow-up
-work), one ``export_citations`` tool over one or more validated arXiv IDs, metadata
+Scoped per maintainer request in issue #41: one ``export_citations`` tool over one or
+more validated arXiv IDs, metadata
 taken from the arXiv API (never model-generated), version suffixes preserved where the
 caller supplies them, deterministic citation keys, and no heavy formatting dependency.
+
+BibTeX shipped first (#135); RIS and CSL-JSON follow here behind a ``format`` argument,
+sharing the same fetch, validation and per-paper status contract.
 """
 
 import json
@@ -23,6 +26,16 @@ logger = logging.getLogger("arxiv-mcp-server")
 
 # Bound the response so a single call cannot fan out without limit.
 MAX_IDS = 50
+
+# Rendering formats. "bibtex" stays the default so existing callers are unaffected.
+FORMATS = ("bibtex", "ris", "csl-json")
+DEFAULT_FORMAT = "bibtex"
+# Payload key that carries the rendered citations, per format.
+_PAYLOAD_KEY = {"bibtex": "bibtex", "ris": "ris", "csl-json": "csl"}
+
+# Every arXiv paper carries a DataCite DOI derived from its identifier; verified to
+# resolve for both new-style ("2401.12345") and legacy ("hep-ph/9901234") IDs.
+ARXIV_DOI_PREFIX = "10.48550/arXiv."
 
 _VERSION_SUFFIX = re.compile(r"v\d+$", re.IGNORECASE)
 
@@ -134,6 +147,110 @@ def _render_entry(key: str, paper: Dict[str, Any], requested_id: str) -> str:
     return f"@misc{{{key},\n{body}\n}}"
 
 
+def _arxiv_doi(requested_id: str) -> str:
+    """DataCite DOI for an arXiv paper, derived from the bare identifier."""
+    return f"{ARXIV_DOI_PREFIX}{_base_id(requested_id)}"
+
+
+def _one_line(text: str) -> str:
+    """Collapse whitespace: RIS is a line-oriented format, tags cannot wrap."""
+    return " ".join(text.split())
+
+
+# Corporate authors must not be split into given/family — CSL carries them literally.
+_CORPORATE_MARKERS = ("collaboration", "collaborations", "consortium", "team")
+
+
+def _split_name(author: str) -> tuple:
+    """Split a display name into (family, given) for CSL.
+
+    arXiv gives names as free text in "Given Middle Family" order, so the last token is
+    the family name. Single-token names and corporate authors ("LIGO Scientific
+    Collaboration") return ("", "") — the caller then emits a CSL ``literal`` name,
+    which is how such authors are represented rather than as person names.
+    """
+    parts = author.split()
+    if len(parts) < 2:
+        return ("", "")
+    if any(part.lower().strip(".,") in _CORPORATE_MARKERS for part in parts):
+        return ("", "")
+    return (parts[-1], " ".join(parts[:-1]))
+
+
+def _render_ris(key: str, paper: Dict[str, Any], requested_id: str) -> str:
+    """Render one RIS record.
+
+    ``TY  - GEN`` (generic) is used rather than ``JOUR``: an arXiv entry is a preprint,
+    not a journal article, and RIS has no preprint type. Two spaces before the hyphen
+    are part of the format, not padding.
+    """
+    lines: List[str] = ["TY  - GEN"]
+    for author in paper.get("authors") or []:
+        lines.append(f"AU  - {_one_line(author)}")
+    title = paper.get("title", "")
+    if title:
+        lines.append(f"TI  - {_one_line(title)}")
+    year = _year_of(paper.get("published", ""))
+    if year:
+        lines.append(f"PY  - {year}")
+    published = paper.get("published", "")
+    if len(published) >= 10 and published[4] == "-" and published[7] == "-":
+        lines.append(f"DA  - {published[:4]}/{published[5:7]}/{published[8:10]}")
+    for category in paper.get("categories") or []:
+        lines.append(f"KW  - {category}")
+    lines.append("PB  - arXiv")
+    lines.append(f"DO  - {_arxiv_doi(requested_id)}")
+    lines.append(f"UR  - https://arxiv.org/abs/{requested_id}")
+    lines.append(f"ID  - {key}")
+    lines.append("ER  - ")
+    return "\n".join(lines)
+
+
+def _render_csl(key: str, paper: Dict[str, Any], requested_id: str) -> Dict[str, Any]:
+    """Render one CSL-JSON item.
+
+    CSL has no ``preprint`` item type — the schema's 45 types offer ``article``,
+    ``article-journal``, ``manuscript`` and ``report``. ``article`` plus
+    ``publisher: arXiv`` and ``genre: preprint`` is the closest faithful mapping.
+    """
+    item: Dict[str, Any] = {"id": key, "type": "article", "genre": "preprint"}
+    title = paper.get("title", "")
+    if title:
+        item["title"] = _one_line(title)
+    authors = []
+    for author in paper.get("authors") or []:
+        family, given = _split_name(author)
+        authors.append(
+            {"family": family, "given": given} if family else {"literal": author}
+        )
+    if authors:
+        item["author"] = authors
+    published = paper.get("published", "")
+    year = _year_of(published)
+    if year:
+        date_parts: List[int] = [int(year)]
+        if len(published) >= 10 and published[4] == "-" and published[7] == "-":
+            date_parts += [int(published[5:7]), int(published[8:10])]
+        item["issued"] = {"date-parts": [date_parts]}
+    categories = paper.get("categories") or []
+    if categories:
+        item["categories"] = list(categories)
+    item["publisher"] = "arXiv"
+    item["number"] = requested_id
+    item["DOI"] = _arxiv_doi(requested_id)
+    item["URL"] = f"https://arxiv.org/abs/{requested_id}"
+    return item
+
+
+def _render(fmt: str, key: str, paper: Dict[str, Any], requested_id: str):
+    """Dispatch to the renderer for *fmt*."""
+    if fmt == "ris":
+        return _render_ris(key, paper, requested_id)
+    if fmt == "csl-json":
+        return _render_csl(key, paper, requested_id)
+    return _render_entry(key, paper, requested_id)
+
+
 async def _fetch_metadata(ids: List[str]) -> Dict[str, Dict[str, Any]]:
     """Fetch authoritative metadata for *ids* in one arXiv API request.
 
@@ -158,11 +275,11 @@ export_citations_tool = types.Tool(
     name="export_citations",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     description=(
-        "Export BibTeX citations for one or more arXiv papers using authoritative arXiv "
+        "Export citations for one or more arXiv papers using authoritative arXiv "
         "metadata (title, authors, year, primary category), never model-generated fields. "
-        "Version suffixes (e.g. '2401.12345v2') are preserved and citation keys are "
-        "deterministic. Returns the rendered BibTeX plus per-paper status/error. "
-        "BibTeX only; RIS/CSL-JSON are not yet supported."
+        "Formats: BibTeX (default), RIS, CSL-JSON. Version suffixes (e.g. '2401.12345v2') "
+        "are preserved, citation keys are deterministic, and each paper carries its own "
+        "status/error alongside the rendered citation."
     ),
     inputSchema={
         "type": "object",
@@ -176,7 +293,16 @@ export_citations_tool = types.Tool(
                     "arXiv IDs, new-style ('2401.12345', optionally versioned "
                     "'2401.12345v2') or legacy ('hep-ph/9901234')."
                 ),
-            }
+            },
+            "format": {
+                "type": "string",
+                "enum": list(FORMATS),
+                "default": DEFAULT_FORMAT,
+                "description": (
+                    "Citation format: 'bibtex' (default), 'ris', or 'csl-json'. "
+                    "CSL-JSON is returned as structured items, the others as text."
+                ),
+            },
         },
         "required": ["paper_ids"],
         "additionalProperties": False,
@@ -194,6 +320,14 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
             return _error("paper_ids must be a non-empty list of arXiv IDs")
         if len(raw_ids) > MAX_IDS:
             return _error(f"too many IDs: {len(raw_ids)} (max {MAX_IDS})")
+
+        fmt = arguments.get("format", DEFAULT_FORMAT)
+        if not isinstance(fmt, str) or fmt.lower() not in FORMATS:
+            return _error(
+                f"unsupported format: {fmt!r} (expected one of {', '.join(FORMATS)})"
+            )
+        fmt = fmt.lower()
+        payload_key = _PAYLOAD_KEY[fmt]
 
         valid_ids = [
             pid.strip()
@@ -237,7 +371,7 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
                     "paper_id": candidate,
                     "status": "success",
                     "key": key,
-                    "bibtex": _render_entry(key, paper, candidate),
+                    payload_key: _render(fmt, key, paper, candidate),
                 }
             )
 
@@ -249,10 +383,12 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
         # tests/test_mcp_tool_error_semantics.py. The JSON body — including
         # per-paper diagnostics — is preserved in the error content.
         overall = "success" if not failed else ("partial" if succeeded else "error")
+        rendered = [r[payload_key] for r in succeeded]
+        combined = rendered if fmt == "csl-json" else "\n\n".join(rendered)
         payload = {
             "status": overall,
-            "format": "bibtex",
-            "bibtex": "\n\n".join(r["bibtex"] for r in succeeded),
+            "format": fmt,
+            payload_key: combined,
             "results": results,
             "count": {
                 "requested": len(raw_ids),

--- a/tests/tools/test_export_citations.py
+++ b/tests/tools/test_export_citations.py
@@ -302,3 +302,127 @@ async def test_tool_registered_in_server():
     tools = {tool.name: tool for tool in await list_tools()}
     assert "export_citations" in tools
     assert tools["export_citations"].inputSchema["additionalProperties"] is False
+
+
+# --------------------------------------------------------------------------- #
+# RIS and CSL-JSON (follow-up to #41: formats scoped out of the first PR)      #
+# --------------------------------------------------------------------------- #
+
+
+def test_arxiv_doi_derived_from_bare_id():
+    # The version suffix belongs to the citation, not to the DOI.
+    assert ec._arxiv_doi("2401.12345v2") == "10.48550/arXiv.2401.12345"
+    assert ec._arxiv_doi("hep-ph/9901234") == "10.48550/arXiv.hep-ph/9901234"
+
+
+def test_one_line_collapses_wrapped_metadata():
+    assert ec._one_line("Attention\n  Is All\tYou Need") == "Attention Is All You Need"
+
+
+def test_split_name_family_and_given():
+    assert ec._split_name("Ashish Vaswani") == ("Vaswani", "Ashish")
+    assert ec._split_name("Jean-Luc de la Fontaine") == ("Fontaine", "Jean-Luc de la")
+    assert ec._split_name("Collaboration") == ("", "")
+    # Corporate authors are not people: they must not be split into given/family.
+    assert ec._split_name("LIGO Scientific Collaboration") == ("", "")
+
+
+@pytest.mark.asyncio
+async def test_ris_record_structure(monkeypatch):
+    _stub_metadata(
+        monkeypatch,
+        [_paper("2401.00001", "Deep Nets", ["Ada Lovelace", "Alan Turing"])],
+    )
+    payload = await _run({"paper_ids": ["2401.00001"], "format": "ris"})
+
+    assert payload["status"] == "success"
+    assert payload["format"] == "ris"
+    record = payload["ris"]
+    lines = record.split("\n")
+    assert lines[0] == "TY  - GEN"
+    assert lines[-1] == "ER  - "
+    assert "AU  - Ada Lovelace" in lines
+    assert "AU  - Alan Turing" in lines
+    assert "TI  - Deep Nets" in lines
+    assert "PY  - 2024" in lines
+    assert "DA  - 2024/01/15" in lines
+    assert "PB  - arXiv" in lines
+    assert "DO  - 10.48550/arXiv.2401.00001" in lines
+    assert "UR  - https://arxiv.org/abs/2401.00001" in lines
+    assert f"ID  - {payload['results'][0]['key']}" in lines
+    # Every line is a tag line; nothing wrapped across lines.
+    assert all(line[:2].isalpha() and line[2:6] == "  - " for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_ris_preserves_requested_version_in_url_only(monkeypatch):
+    _stub_metadata(monkeypatch, [_paper("2401.00002", "Versioned", ["Grace Hopper"])])
+    payload = await _run({"paper_ids": ["2401.00002v3"], "format": "ris"})
+
+    assert "UR  - https://arxiv.org/abs/2401.00002v3" in payload["ris"]
+    assert "DO  - 10.48550/arXiv.2401.00002" in payload["ris"]
+
+
+@pytest.mark.asyncio
+async def test_csl_json_items(monkeypatch):
+    _stub_metadata(
+        monkeypatch,
+        [
+            _paper(
+                "2401.00003",
+                "On Categories\nand Functors",
+                ["Emmy Noether", "LIGO Collaboration"],
+                categories=("math.CT", "cs.LO"),
+            )
+        ],
+    )
+    payload = await _run({"paper_ids": ["2401.00003"], "format": "csl-json"})
+
+    assert payload["format"] == "csl-json"
+    items = payload["csl"]
+    assert isinstance(items, list) and len(items) == 1
+    item = items[0]
+    # CSL has no "preprint" item type; "article" + genre is the faithful mapping.
+    assert item["type"] == "article"
+    assert item["genre"] == "preprint"
+    assert item["title"] == "On Categories and Functors"
+    assert item["author"][0] == {"family": "Noether", "given": "Emmy"}
+    assert item["author"][1] == {"literal": "LIGO Collaboration"}
+    assert item["issued"] == {"date-parts": [[2024, 1, 15]]}
+    assert item["DOI"] == "10.48550/arXiv.2401.00003"
+    assert item["URL"] == "https://arxiv.org/abs/2401.00003"
+    assert item["publisher"] == "arXiv"
+    assert item["categories"] == ["math.CT", "cs.LO"]
+    assert item["id"] == payload["results"][0]["key"]
+
+
+@pytest.mark.asyncio
+async def test_default_format_stays_bibtex(monkeypatch):
+    _stub_metadata(monkeypatch, [_paper("2401.00004", "Unchanged", ["Ada Lovelace"])])
+    payload = await _run({"paper_ids": ["2401.00004"]})
+
+    assert payload["format"] == "bibtex"
+    assert payload["bibtex"].startswith("@misc{")
+    assert "ris" not in payload and "csl" not in payload
+
+
+@pytest.mark.asyncio
+async def test_unsupported_format_is_rejected(monkeypatch):
+    _stub_metadata(monkeypatch, [_paper("2401.00005", "Nope", ["Ada Lovelace"])])
+    payload = await _run({"paper_ids": ["2401.00005"], "format": "endnote"})
+
+    assert payload["status"] == "error"
+    assert "unsupported format" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_partial_batch_keeps_per_paper_status_in_ris(monkeypatch):
+    _stub_metadata(monkeypatch, [_paper("2401.00006", "Present", ["Ada Lovelace"])])
+    payload = await _run(
+        {"paper_ids": ["2401.00006", "2401.99999", "not-an-id"], "format": "ris"}
+    )
+
+    assert payload["status"] == "partial"
+    assert payload["count"] == {"requested": 3, "succeeded": 1, "failed": 2}
+    statuses = [r["status"] for r in payload["results"]]
+    assert statuses == ["success", "error", "error"]


### PR DESCRIPTION
Follow-up to #41 and #135: the two formats scoped out of the first PR, behind a `format` argument that defaults to `bibtex`, so existing callers see byte-identical output.

## What changed

`export_citations` now takes `format`: `bibtex` (default), `ris`, `csl-json`. Fetch, ID validation, citation keys, per-paper status reporting and the not-found convention are shared; only rendering differs.

## Decisions worth reviewing

- **CSL item type.** CSL has no `preprint` type — the schema's 45 types offer `article`, `article-journal`, `manuscript`, `report`. Items are emitted as `type: "article"` with `genre: "preprint"` and `publisher: "arXiv"`.
- **DOIs are derived**, not omitted: `10.48550/arXiv.<bare id>`. Verified to resolve for new-style (`1706.03762`) and legacy (`hep-th/9802150`) identifiers. The version suffix the caller supplied stays in the URL; the DOI uses the bare ID.
- **RIS type** is `TY  - GEN` with `PB  - arXiv`, since RIS has no preprint type either.
- **Corporate authors** ("LIGO Scientific Collaboration") emit a CSL `literal` name rather than being split into given/family.
- **Abstracts are omitted.** The Atom parser prefixes them with the internal `[EXTERNAL CONTENT] ` marker; shipping that inside a citation record would be wrong, and stripping a server-internal marker felt like the wrong place to do it.

## Tests

12 new tests covering RIS record structure and tag-line shape, version-suffix handling, CSL item fields and date-parts, corporate-author fallback, format dispatch, back-compat of the default, and rejection of unknown formats.

```
$ pytest -q
166 passed, 1 skipped
$ black --check src/arxiv_mcp_server/tools/export_citations.py tests/tools/test_export_citations.py
2 files would be left unchanged
```

Live check against the arXiv API (`1706.03762`):

```
TY  - GEN
AU  - Ashish Vaswani
...
PY  - 2017
DA  - 2017/06/12
PB  - arXiv
DO  - 10.48550/arXiv.1706.03762
UR  - https://arxiv.org/abs/1706.03762
ID  - vaswani2017attention
ER  - 
```

Duplicate IDs in one call — the small fix left out of #135 — stays out of this PR too, and will come separately.

Written by Aleksei Rybnikov with Lorenz (Claude Code); commits carry both.