### PR TITLE
fix: cap mcp below 2.0.0 and release v0.6.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "arxiv-mcp-server",
   "displayName": "arXiv MCP Server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Search, download, read, and analyze arXiv papers through MCP.",
   "author": {
     "name": "Joseph Blazick"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arxiv-mcp-server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Search arXiv, read bounded full text and original LaTeX, follow citations, and monitor research topics through MCP.",
   "author": {
     "name": "Joseph Blazick",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "arxiv-mcp-server",
   "display_name": "ArXiv MCP Server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Search, download, and analyze arXiv papers via MCP.",
   "author": {
     "name": "Joseph Blazick",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arxiv-mcp-server"
-version = "0.6.1"
+version = "0.6.2"
 description = "A flexible arXiv search and analysis service with MCP protocol support"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -32,7 +32,7 @@ dependencies = [
     "httpx>=0.24.0",
     "python-dateutil>=2.8.2",
     "pydantic>=2.8.0",
-    "mcp>=1.27.0",
+    "mcp>=1.27.0,<2.0.0",
     "aiohttp>=3.9.1",
     "python-dotenv>=1.0.0",
     "pydantic-settings>=2.1.0",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.blazickjp/arxiv-mcp-server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Search arXiv papers, download full text, semantic search, citation graphs, and alerts via MCP.",
   "repository": {
     "url": "https://github.com/blazickjp/arxiv-mcp-server",
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "arxiv-mcp-server",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -93,6 +93,30 @@ def test_release_metadata_and_arxiv_dependency_are_synchronized():
     assert arxiv_requirement == "arxiv>=2.1.0"
 
 
+def test_mcp_dependency_excludes_incompatible_major_release():
+    """mcp 2.0.0 removed the low-level ``Server`` registration decorators.
+
+    ``server.py`` registers handlers with ``@server.list_prompts()`` and
+    friends, which raise ``AttributeError`` at import time under 2.x. The
+    requirement must stay below 2.0.0 until those call sites are migrated to
+    the ``add_request_handler`` API.
+    """
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
+
+    mcp_requirement = next(
+        dependency
+        for dependency in pyproject["project"]["dependencies"]
+        if re.match(r"^mcp\b", dependency)
+    )
+    assert mcp_requirement == "mcp>=1.27.0,<2.0.0"
+
+    locked_mcp = next(
+        package for package in lock["package"] if package["name"] == "mcp"
+    )
+    assert tuple(int(part) for part in locked_mcp["version"].split(".")[:1]) < (2,)
+
+
 def test_readme_exposes_supported_install_paths():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "arxiv-mcp-server"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -244,7 +244,7 @@ requires-dist = [
     { name = "arxiv", specifier = ">=2.1.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.3.0" },
     { name = "httpx", specifier = ">=0.24.0" },
-    { name = "mcp", specifier = ">=1.27.0" },
+    { name = "mcp", specifier = ">=1.27.0,<2.0.0" },
     { name = "numpy", marker = "extra == 'pro'", specifier = ">=1.26.0" },
     { name = "pydantic", specifier = ">=2.8.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },


### PR DESCRIPTION
Fixes #144.

## Problem

`mcp` 2.0.0 shipped on 2026-07-28 and removed the registration decorators from the low-level `Server` class:

```
MISSING list_prompts / get_prompt / list_tools / call_tool / list_resources / read_resource
```

`server.py` registers every handler through those decorators, so importing the package under 2.x fails at module import time:

```
AttributeError: 'Server' object has no attribute 'list_prompts'
```

The dependency was declared as an open-ended `mcp>=1.27.0`, so any install that does not go through `uv.lock` resolved to 2.0.0 and crashed on startup. `uv.lock` pins 1.27.0, which is why CI and local checkouts stayed green while `uvx arxiv-mcp-server` and `pip install arxiv-mcp-server` were broken for end users.

Note that the symptom in #144 (`ModuleNotFoundError: No module named 'mcp.server.fastmcp'`) does not match this codebase — there is no FastMCP usage anywhere here, and all six `mcp.*` import paths still resolve under 2.0.0. The breakage is the decorator removal, not the module move.

## Change

- Constrain the requirement to `mcp>=1.27.0,<2.0.0`.
- Bump to 0.6.2 across `pyproject.toml`, `server.json`, `manifest.json`, `.codex-plugin/plugin.json`, and `.claude-plugin/plugin.json`.
- Update the two corresponding lines in `uv.lock`.

## Test

Added `test_mcp_dependency_excludes_incompatible_major_release` to `tests/test_release_metadata.py`, written first and confirmed failing against the old unbounded requirement. It asserts both the requirement string and that the lock stays on mcp 1.x, so widening the pin cannot silently reopen this.

## Verification

- Full suite: 158 passed, 1 skipped. `black --check` clean. `uv lock --check` consistent.
- A fresh isolated install off the built package now resolves mcp 1.29.0 — the newest compatible 1.x, not the 1.27.0 floor — imports cleanly, and constructs the `server` object. That is the exact path from #144.

## Scope

This unbreaks installs; it does not make the project work on mcp 2.x. The project is now pinned to a superseded major version, so this buys time rather than resolving the incompatibility. The follow-up is migrating the six decorator call sites in `server.py` to the `add_request_handler` API that 2.x exposes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Js211qS8qirAL28meRbgFn)_