### PR TITLE
fix: bound download_paper/read_paper output by default

### DIFF
--- a/src/arxiv_mcp_server/tools/content.py
+++ b/src/arxiv_mcp_server/tools/content.py
@@ -2,6 +2,14 @@
 
 from typing import Any
 
+# Matches the bound already used by latex.py's list/section tools (issue #127):
+# unbounded default reads from download_paper/read_paper let one call return an
+# entire paper (measured ~111K chars / ~27.8K tokens for one real paper), so
+# every MCP client has to remember optional pagination arguments just to stay
+# inside its own context window.
+DEFAULT_MAX_CHARS = 12_000
+MAX_RETURN_CHARS = 50_000
+
 
 def _coerce_nonnegative_int(value: Any, default: int) -> int:
     """Return ``value`` as a non-negative integer, or ``default`` if absent."""
@@ -23,6 +31,34 @@ def _coerce_positive_int(value: Any) -> int | None:
     except (TypeError, ValueError):
         return None
     return parsed if parsed > 0 else None
+
+
+def bound_arguments(
+    arguments: dict[str, Any], default_max_chars: int = DEFAULT_MAX_CHARS
+) -> dict[str, Any]:
+    """Return a copy of ``arguments`` with a bounded ``max_chars`` applied.
+
+    Omitting ``max_chars`` used to mean "return the whole paper," which made
+    efficient behavior depend on every caller remembering an optional
+    argument. This applies the same bounded-by-default pattern already used
+    by the LaTeX section tools: no explicit ``max_chars`` -> capped at
+    ``default_max_chars``; an explicit value is clamped to
+    ``MAX_RETURN_CHARS``. Passing ``return_full_text: true`` opts back into
+    the old unbounded behavior for callers that need it.
+    """
+    bounded = dict(arguments)
+    if bounded.get("return_full_text") is True:
+        return bounded
+    if "max_chars" not in bounded or bounded["max_chars"] is None:
+        bounded["max_chars"] = default_max_chars
+    else:
+        try:
+            bounded["max_chars"] = min(
+                MAX_RETURN_CHARS, max(1, int(bounded["max_chars"]))
+            )
+        except (TypeError, ValueError):
+            bounded["max_chars"] = default_max_chars
+    return bounded
 
 
 def paginate_content(content: str, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -12,7 +12,7 @@ import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings, get_arxiv_client
 from ..arxiv_api import ARXIV_RATE_LIMITER, stream_pdf_to_path
-from .content import add_content_payload
+from .content import add_content_payload, bound_arguments
 from .list_papers import is_valid_arxiv_id
 import logging
 import threading
@@ -192,8 +192,10 @@ download_tool = types.Tool(
     description=(
         "Download a paper from arXiv and return its text content. "
         "Tries the HTML version first for clean extraction; falls back to "
-        "PDF conversion if HTML is unavailable. Stores the paper locally "
-        "and supports start/max_chars pagination for very large papers."
+        "PDF conversion if HTML is unavailable. Stores the paper locally. "
+        "The returned text is bounded to roughly 12,000 characters by default "
+        "so one call cannot return an unbounded paper body; use start/max_chars "
+        "to page through the rest, or return_full_text: true for the full unbounded text."
     ),
     inputSchema={
         "type": "object",
@@ -210,7 +212,11 @@ download_tool = types.Tool(
             "max_chars": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Maximum raw paper characters to return from start; omit for full content",
+                "description": "Maximum raw paper characters to return from start; omit for the bounded default (~12,000 chars)",
+            },
+            "return_full_text": {
+                "type": "boolean",
+                "description": "Set true to opt out of the bounded default and return the entire remaining paper in one call",
             },
         },
         "required": ["paper_id"],
@@ -346,7 +352,7 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
                     "source": "cache",
                 },
                 content,
-                arguments,
+                bound_arguments(arguments),
                 _CONTENT_WARNING,
             )
             return [
@@ -372,7 +378,7 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
                     "source": "html",
                 },
                 html_text,
-                arguments,
+                bound_arguments(arguments),
                 _CONTENT_WARNING,
             )
             return [
@@ -417,7 +423,7 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 "source": "pdf",
             },
             markdown,
-            arguments,
+            bound_arguments(arguments),
             _CONTENT_WARNING,
         )
         return [

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -6,7 +6,7 @@ from typing import Dict, Any, List
 import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings
-from .content import add_content_payload
+from .content import add_content_payload, bound_arguments
 
 settings = Settings()
 
@@ -21,7 +21,9 @@ read_tool = types.Tool(
     annotations=ToolAnnotations(readOnlyHint=True),
     description=(
         "Read the text content of a paper that was previously downloaded via download_paper. "
-        "Returns the paper in markdown format and supports start/max_chars pagination for large papers. "
+        "Returns the paper in markdown format, bounded to roughly 12,000 characters by default "
+        "so one call cannot return an unbounded paper body; use start/max_chars to page through "
+        "the rest, or return_full_text: true to opt into the full unbounded text. "
         "Will fail with a clear error if the paper has not been downloaded yet — call download_paper first. "
         "Workflow: search_papers -> download_paper -> read_paper."
     ),
@@ -40,7 +42,11 @@ read_tool = types.Tool(
             "max_chars": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Maximum raw paper characters to return from start; omit for full content",
+                "description": "Maximum raw paper characters to return from start; omit for the bounded default (~12,000 chars)",
+            },
+            "return_full_text": {
+                "type": "boolean",
+                "description": "Set true to opt out of the bounded default and return the entire remaining paper in one call",
             },
         },
         "required": ["paper_id"],
@@ -84,7 +90,7 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
                 "paper_id": paper_id,
             },
             content,
-            arguments,
+            bound_arguments(arguments),
             _CONTENT_WARNING,
         )
 


### PR DESCRIPTION
Omitting `max_chars` on `download_paper` / `read_paper` currently returns the entire paper in one call — I measured ~111K chars (~27.8K tokens) for a single real paper. Every MCP client has to remember an optional pagination argument just to stay inside its own context window.

This applies the same bounded-by-default pattern the LaTeX section tools (`get_paper_latex_section` etc.) already use, related to #127:

- No explicit `max_chars` -> defaults to ~12,000 chars instead of unbounded.
- An explicit `max_chars` is clamped to a hard cap of 50,000.
- New `return_full_text: true` flag opts back into the old unbounded behavior for callers that genuinely need the whole paper in one shot.

Touches `content.py` (new `bound_arguments` helper + constants), `download.py`, and `read_paper.py` (both now call it before pagination and document the new default/flag in their tool descriptions).

Happy to adjust the default/cap numbers or naming if you had something else in mind for #127.