### PR TITLE
chore: harden cross-platform install verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "$schema": "https://www.schemastore.org/claude-code-marketplace.json",
   "name": "arxiv-mcp",
   "description": "Claude Code integration for searching and analyzing arXiv papers.",
   "owner": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "arxiv-mcp-server",
   "displayName": "arXiv MCP Server",
   "version": "0.6.2",

--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -19,11 +19,15 @@ jobs:
       matrix:
         os: [macos-15-intel, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_tag || github.event.release.tag_name || github.sha }}
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v7
@@ -35,6 +39,35 @@ jobs:
           version: "0.11.30"
           enable-cache: true
 
+      - name: Validate release tag and checked-out commit
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          import subprocess
+          import tomllib
+
+          tag = os.environ.get("RELEASE_TAG", "").strip()
+          if not tag:
+              print("No release tag supplied; building an unattached workflow artifact")
+              raise SystemExit(0)
+
+          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          expected_tag = f"v{version}"
+          if tag != expected_tag:
+              raise SystemExit(f"Release tag {tag!r} does not match {expected_tag!r}")
+
+          head = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+          tag_commit = subprocess.check_output(["git", "rev-list", "-n", "1", tag], text=True).strip()
+          if head != tag_commit:
+              raise SystemExit(
+                  f"Checked-out commit {head} does not match {tag} commit {tag_commit}"
+              )
+          print(f"Validated {tag} at {head}")
+          PY
+
       - name: Set up Node.js 24
         uses: actions/setup-node@v7
         with:
@@ -42,6 +75,11 @@ jobs:
 
       - name: Build MCPB bundle
         run: bash scripts/build-mcpb.sh
+
+      - name: Smoke-test MCPB bundle over MCP
+        env:
+          PYTHONPATH: ${{ github.workspace }}/mcpb-build/server/vendor
+        run: python scripts/smoke_mcpb.py
 
       - name: Upload MCPB to release
         if: github.event_name == 'release' || inputs.release_tag != ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   validate-and-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 
@@ -54,29 +55,8 @@ jobs:
       - name: Validate distributions
         run: uv run --with twine twine check dist/*
 
-      - name: Smoke-test built wheel
-        run: |
-          uv venv --python 3.11 /tmp/arxiv-release-smoke
-          uv pip install --python /tmp/arxiv-release-smoke/bin/python dist/*.whl
-          /tmp/arxiv-release-smoke/bin/python - <<'PY'
-          import importlib.metadata
-          from arxiv_mcp_server.server import list_tools
-          import asyncio
-
-          version = importlib.metadata.version("arxiv-mcp-server")
-          tools = asyncio.run(list_tools())
-          names = {tool.name for tool in tools}
-          required = {
-              "search_papers",
-              "download_paper",
-              "get_paper_latex",
-              "list_paper_latex_sections",
-              "get_paper_latex_section",
-          }
-          if not required.issubset(names):
-              raise SystemExit(f"Missing tools: {sorted(required - names)}")
-          print(f"Installed arxiv-mcp-server {version} with {len(names)} tools")
-          PY
+      - name: Smoke-test built wheel over MCP
+        run: uv run python scripts/smoke_installed_wheel.py
 
       - name: Install MCP Registry publisher
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   test:
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -34,8 +35,20 @@ jobs:
       - name: Install locked test environment
         run: uv sync --locked --extra test
 
+      - name: Resolve optional extras from binary wheels
+        run: >-
+          uv pip compile pyproject.toml --extra pdf --extra pro
+          --only-binary :all:
+          --output-file "${{ runner.temp }}/arxiv-extras.txt"
+
       - name: Run tests
         run: uv run pytest --cov-report=xml
+
+      - name: Build candidate wheel
+        run: uv build --wheel --out-dir dist
+
+      - name: Smoke-test installed wheel over MCP
+        run: uv run python scripts/smoke_installed_wheel.py
 
   docker-smoke:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=arxiv-mcp-server&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22arxiv-mcp-server%22%5D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%5D%7D)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Install-D97757?style=flat-square&logo=anthropic&logoColor=white)](#claude-code)
 [![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-Install-000000?style=flat-square&logo=openai&logoColor=white)](#openai-codex)
+[![Hermes Agent](https://img.shields.io/badge/Hermes_Agent-Install-6C5CE7?style=flat-square)](#hermes-agent)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-Listed-5C5CFF?style=flat-square)](https://registry.modelcontextprotocol.io/?search=io.github.blazickjp%2Farxiv-mcp-server)
 
 An MCP server for searching arXiv, downloading papers, reading bounded full text, retrieving original LaTeX by section, following citation graphs, and maintaining research alerts.
 
@@ -29,8 +31,7 @@ The command-based integrations require [uv](https://docs.astral.sh/uv/getting-st
 Add the MCP server for all projects:
 
 ```bash
-claude mcp add --transport stdio --scope user arxiv \
-  -- uvx arxiv-mcp-server
+claude mcp add --transport stdio --scope user arxiv -- uvx arxiv-mcp-server
 ```
 
 For the richer plugin integration—which installs the MCP connection plus the bundled arXiv research skill—register this repository as a marketplace and install the plugin:
@@ -59,6 +60,15 @@ codex plugin add arxiv-mcp-server@arxiv-mcp
 
 Verify the direct MCP installation with `codex mcp get arxiv`. Codex CLI, the Codex IDE extension, and Codex in the ChatGPT desktop app share this MCP configuration.
 
+### Hermes Agent
+
+Add the server, approve the discovered tools, and test the saved connection:
+
+```bash
+hermes mcp add arxiv --command uvx --args arxiv-mcp-server
+hermes mcp test arxiv
+```
+
 ### Kiro and VS Code
 
 Use the **Add to Kiro**, **Install in VS Code**, or **Install in VS Code Insiders** button above.
@@ -80,9 +90,9 @@ macOS users can install a bundled `.mcpb` extension from the [latest GitHub rele
 
 Double-click the bundle, drag it into Claude Desktop, or open **Settings → Extensions → Advanced settings → Install Extension…**. The bundle includes the server dependencies and requires CPython 3.11.x.
 
-### Any MCP client
+### Other MCP clients
 
-Add this stdio configuration to any client that accepts standard MCP JSON:
+Add this stdio configuration to clients that accept the `mcpServers` JSON shape, such as Claude Desktop and Kiro. Other clients may use a top-level `servers` object, TOML, or their own settings UI; consult the client's MCP documentation.
 
 ```json
 {
@@ -118,6 +128,32 @@ For older papers that require PDF conversion, run the package with its PDF extra
 
 The supported package is published on PyPI. An unrelated npm package uses the same name, so do not install this server with npm, pnpm, or `npx arxiv-mcp-server`.
 
+### If an existing installation is missing newer tools
+
+`uvx` reuses cached tool environments. Force it to resolve the current PyPI release with a supported interpreter, then restart your MCP client:
+
+```bash
+uvx --python 3.11 --refresh-package arxiv-mcp-server arxiv-mcp-server
+```
+
+If your client still launches an older environment, add `"--python", "3.11"` before `"arxiv-mcp-server"` in its `args` array.
+
+### If a desktop client cannot find `uvx`
+
+Desktop applications do not always inherit the same `PATH` as your terminal. If `uvx arxiv-mcp-server` works in a terminal but the client reports that the server failed to connect, find the executable's absolute path:
+
+```bash
+# macOS and Linux
+command -v uvx
+```
+
+```powershell
+# Windows PowerShell
+(Get-Command uvx).Source
+```
+
+Replace `"command": "uvx"` with the returned absolute path, then restart the client. Keep the `args` value unchanged.
+
 ### Persistent command install
 
 To place `arxiv-mcp-server` on your `PATH` instead of launching it through `uvx`:
@@ -126,7 +162,7 @@ To place `arxiv-mcp-server` on your `PATH` instead of launching it through `uvx`
 uv tool install arxiv-mcp-server
 ```
 
-Afterward, use `"command": "arxiv-mcp-server"` and omit the package name from `args`.
+If the command is not immediately available, run `uv tool update-shell` and restart the terminal. Afterward, use `"command": "arxiv-mcp-server"` and omit the package name from `args`.
 
 ## Plugin integrations
 
@@ -248,16 +284,16 @@ Choose the install variant that matches the features you need:
 uv tool install arxiv-mcp-server
 
 # Base server plus PDF conversion
-uv tool install 'arxiv-mcp-server[pdf]'
+uv tool install "arxiv-mcp-server[pdf]"
 
 # Base server plus local semantic search
-uv tool install 'arxiv-mcp-server[pro]'
+uv tool install "arxiv-mcp-server[pro]"
 ```
 
 If the base tool is already installed, reinstall the selected variant:
 
 ```bash
-uv tool install --force 'arxiv-mcp-server[pdf]'
+uv tool install --force "arxiv-mcp-server[pdf]"
 ```
 
 The `pdf` extra installs `pymupdf4llm` and `pymupdf-layout` for papers without usable arXiv HTML. The `pro` extra adds local embedding dependencies for `semantic_search` and `reindex`; semantic search only operates on papers already downloaded to the configured storage directory.
@@ -283,6 +319,15 @@ For deployments where stdio is not practical:
 ```bash
 TRANSPORT=http HOST=127.0.0.1 PORT=8080 \
   uvx arxiv-mcp-server --storage-path /absolute/path/to/papers
+```
+
+PowerShell:
+
+```powershell
+$env:TRANSPORT = "http"
+$env:HOST = "127.0.0.1"
+$env:PORT = "8080"
+uvx arxiv-mcp-server --storage-path C:\absolute\path\to\papers
 ```
 
 Connect clients to:

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -73,7 +73,16 @@ PYEOF
 
 # Copy server source
 cp -R "$ROOT/src/arxiv_mcp_server" "$BUILD_DIR/server/arxiv_mcp_server"
-echo "Copied server source"
+"$PYTHON_BIN" - "$BUILD_DIR/server/arxiv_mcp_server/_bundle_version.py" "$VERSION" <<'PYEOF'
+from pathlib import Path
+import sys
+
+Path(sys.argv[1]).write_text(
+    f'"""Generated MCPB package version; do not edit."""\n\nVERSION = {sys.argv[2]!r}\n',
+    encoding="utf-8",
+)
+PYEOF
+echo "Copied server source and generated bundle version metadata"
 
 # Vendor the locked base and PDF-extra dependencies. Exporting from uv.lock keeps
 # the bundle aligned with the package release instead of maintaining a second

--- a/scripts/smoke_installed_wheel.py
+++ b/scripts/smoke_installed_wheel.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Build-artifact smoke test for an isolated arxiv-mcp-server wheel."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import tomllib
+from datetime import timedelta
+from typing import Mapping
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+ROOT = Path(__file__).resolve().parents[1]
+MCP_REQUEST_TIMEOUT_SECONDS = 30
+MCP_OVERALL_TIMEOUT_SECONDS = 120
+EXPECTED_TOOLS = {
+    "check_alerts",
+    "citation_graph",
+    "download_paper",
+    "export_citations",
+    "get_abstract",
+    "get_paper_latex",
+    "get_paper_latex_section",
+    "list_paper_latex_sections",
+    "list_papers",
+    "read_paper",
+    "reindex",
+    "search_papers",
+    "semantic_search",
+    "watch_topic",
+}
+PROMPT_ARGUMENTS = {
+    "compare_papers": {"paper_ids": "1706.03762, 1810.04805"},
+    "deep-paper-analysis": {"paper_id": "1706.03762"},
+    "literature-synthesis": {"paper_ids": "1706.03762, 1810.04805"},
+    "literature_review": {"topic": "attention mechanisms"},
+    "research-discovery": {"topic": "attention mechanisms"},
+    "research-question": {
+        "paper_ids": "1706.03762, 1810.04805",
+        "topic": "attention mechanisms",
+    },
+    "summarize_paper": {"paper_id": "1706.03762"},
+}
+
+
+def find_single_wheel(dist_dir: Path) -> Path:
+    """Return the one wheel in *dist_dir*, rejecting stale artifact mixtures."""
+    wheels = sorted(dist_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(
+            f"Expected exactly one wheel in {dist_dir}, found {len(wheels)}: "
+            f"{[wheel.name for wheel in wheels]}"
+        )
+    return wheels[0]
+
+
+def venv_python(venv_dir: Path, *, platform: str = os.name) -> Path:
+    """Return the Python executable path for a POSIX or Windows virtualenv."""
+    if platform == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def venv_entrypoint(venv_dir: Path, *, platform: str = os.name) -> Path:
+    """Return the installed console-script path for a POSIX or Windows virtualenv."""
+    if platform == "nt":
+        return venv_dir / "Scripts" / "arxiv-mcp-server.exe"
+    return venv_dir / "bin" / "arxiv-mcp-server"
+
+
+def clean_subprocess_env(
+    home: Path, *, source: Mapping[str, str] | None = None
+) -> dict[str, str]:
+    """Create a subprocess environment without ambient Python contamination."""
+    source = os.environ if source is None else source
+    blocked = {
+        "ALLOWED_HOSTS",
+        "ALLOWED_ORIGINS",
+        "APP_NAME",
+        "APP_VERSION",
+        "BATCH_SIZE",
+        "HOST",
+        "MAX_RESULTS",
+        "PIP_CONSTRAINT",
+        "PORT",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "REQUEST_TIMEOUT",
+        "TRANSPORT",
+        "UV_CONSTRAINT",
+        "UV_OVERRIDE",
+        "UV_REQUIRE_HASHES",
+        "VIRTUAL_ENV",
+    }
+    env = {key: value for key, value in source.items() if key not in blocked}
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env["NO_COLOR"] = "1"
+    return env
+
+
+def canonical_version() -> str:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return pyproject["project"]["version"]
+
+
+async def exercise_mcp_server(
+    parameters: StdioServerParameters, *, expected_version: str
+) -> dict[str, object]:
+    """Exercise the complete public MCP discovery and prompt surface."""
+    async with asyncio.timeout(MCP_OVERALL_TIMEOUT_SECONDS):
+        async with stdio_client(parameters) as (read_stream, write_stream):
+            async with ClientSession(
+                read_stream,
+                write_stream,
+                read_timeout_seconds=timedelta(seconds=MCP_REQUEST_TIMEOUT_SECONDS),
+            ) as session:
+                initialized = await session.initialize()
+                server_version = initialized.serverInfo.version
+                if server_version != expected_version:
+                    raise RuntimeError(
+                        f"MCP server version {server_version!r} does not match "
+                        f"expected version {expected_version!r}"
+                    )
+
+                tools = await session.list_tools()
+                tool_names = {tool.name for tool in tools.tools}
+                if tool_names != EXPECTED_TOOLS:
+                    raise RuntimeError(
+                        "MCP server exposed an unexpected tool set: "
+                        f"missing={sorted(EXPECTED_TOOLS - tool_names)}, "
+                        f"extra={sorted(tool_names - EXPECTED_TOOLS)}"
+                    )
+
+                prompts = await session.list_prompts()
+                prompt_names = {prompt.name for prompt in prompts.prompts}
+                if prompt_names != set(PROMPT_ARGUMENTS):
+                    raise RuntimeError(
+                        "MCP server exposed an unexpected prompt set: "
+                        f"missing={sorted(set(PROMPT_ARGUMENTS) - prompt_names)}, "
+                        f"extra={sorted(prompt_names - set(PROMPT_ARGUMENTS))}"
+                    )
+                prompt_lengths = {}
+                for prompt_name, arguments in PROMPT_ARGUMENTS.items():
+                    result = await session.get_prompt(prompt_name, arguments)
+                    prompt_lengths[prompt_name] = sum(
+                        len(getattr(message.content, "text", ""))
+                        for message in result.messages
+                    )
+                    if prompt_lengths[prompt_name] == 0:
+                        raise RuntimeError(f"Prompt {prompt_name!r} returned no text")
+
+                local_result = await session.call_tool("list_papers", {})
+                if local_result.isError or not local_result.content:
+                    raise RuntimeError("list_papers failed through the MCP session")
+
+    return {
+        "server_version": server_version,
+        "tools": len(tool_names),
+        "prompts": len(prompt_names),
+        "prompt_chars": prompt_lengths,
+        "list_papers_content_items": len(local_result.content),
+    }
+
+
+async def smoke_wheel(wheel: Path) -> dict[str, object]:
+    """Install *wheel* in a blank venv and exercise its real MCP interface."""
+    with tempfile.TemporaryDirectory(prefix="arxiv-wheel-smoke-") as temp:
+        temp_dir = Path(temp)
+        venv_dir = temp_dir / "venv"
+        home_dir = temp_dir / "home"
+        storage_dir = temp_dir / "papers"
+        home_dir.mkdir()
+        storage_dir.mkdir()
+        env = clean_subprocess_env(home_dir)
+
+        subprocess.run(
+            ["uv", "venv", "--python", sys.executable, str(venv_dir)],
+            check=True,
+            env=env,
+            cwd=temp_dir,
+        )
+        python = venv_python(venv_dir)
+        subprocess.run(
+            ["uv", "pip", "install", "--python", str(python), str(wheel)],
+            check=True,
+            env=env,
+            cwd=temp_dir,
+        )
+        installed_version = subprocess.check_output(
+            [
+                str(python),
+                "-c",
+                "import importlib.metadata; "
+                "print(importlib.metadata.version('arxiv-mcp-server'))",
+            ],
+            text=True,
+            env=env,
+            cwd=temp_dir,
+        ).strip()
+
+        entrypoint = venv_entrypoint(venv_dir)
+        if not entrypoint.is_file():
+            raise RuntimeError(
+                f"Installed wheel is missing console script {entrypoint}"
+            )
+        parameters = StdioServerParameters(
+            command=str(entrypoint),
+            args=[
+                "--storage-path",
+                str(storage_dir),
+            ],
+            env=env,
+            cwd=temp_dir,
+        )
+        expected_version = canonical_version()
+        if installed_version != expected_version:
+            raise RuntimeError(
+                "Version mismatch: "
+                f"project={expected_version}, installed={installed_version}"
+            )
+        protocol = await exercise_mcp_server(
+            parameters, expected_version=expected_version
+        )
+
+        return {
+            "wheel": wheel.name,
+            "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+            "platform": sys.platform,
+            "version": installed_version,
+            **protocol,
+        }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dist-dir",
+        type=Path,
+        default=ROOT / "dist",
+        help="Directory containing exactly one candidate wheel",
+    )
+    args = parser.parse_args()
+    wheel = find_single_wheel(args.dist_dir)
+    print(json.dumps(asyncio.run(smoke_wheel(wheel)), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_mcpb.py
+++ b/scripts/smoke_mcpb.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Extract and exercise the exact MCPB artifact that would be uploaded."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+import zipfile
+
+from mcp import StdioServerParameters
+
+from smoke_installed_wheel import clean_subprocess_env, exercise_mcp_server
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def find_single_mcpb(bundle_dir: Path) -> Path:
+    """Return the one packed MCPB artifact, rejecting stale artifact mixtures."""
+    artifacts = sorted(bundle_dir.glob("*.mcpb"))
+    if len(artifacts) != 1:
+        raise RuntimeError(
+            f"Expected exactly one MCPB in {bundle_dir}, found {len(artifacts)}: "
+            f"{[artifact.name for artifact in artifacts]}"
+        )
+    return artifacts[0]
+
+
+def extract_mcpb(artifact: Path, destination: Path) -> None:
+    """Validate and extract an MCPB ZIP without path traversal or symlinks."""
+    root = destination.resolve()
+    with zipfile.ZipFile(artifact) as archive:
+        if corrupt_member := archive.testzip():
+            raise RuntimeError(f"Corrupt MCPB member: {corrupt_member}")
+        for member in archive.infolist():
+            target = (destination / member.filename).resolve()
+            if not target.is_relative_to(root):
+                raise RuntimeError(
+                    f"MCPB contains unsafe archive member {member.filename!r}"
+                )
+            mode = (member.external_attr >> 16) & 0o170000
+            if mode == stat.S_IFLNK:
+                raise RuntimeError(f"MCPB contains symlink member {member.filename!r}")
+        archive.extractall(destination)
+
+
+async def smoke_mcpb(bundle_dir: Path) -> dict[str, object]:
+    artifact = find_single_mcpb(bundle_dir)
+    if sys.implementation.name != "cpython" or sys.version_info[:2] != (3, 11):
+        raise RuntimeError(
+            "MCPB smoke requires CPython 3.11.x to match the bundled ABI; "
+            f"got {sys.implementation.name} {sys.version.split()[0]}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="arxiv-mcpb-smoke-") as temp:
+        temp_dir = Path(temp)
+        unpacked_dir = temp_dir / "unpacked"
+        extract_mcpb(artifact, unpacked_dir)
+
+        manifest_path = unpacked_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        expected_version = manifest["version"]
+        expected_runtime = manifest["compatibility"]["runtimes"]["python"]
+        if expected_runtime != ">=3.11,<3.12":
+            raise RuntimeError(f"Unexpected MCPB Python runtime: {expected_runtime!r}")
+
+        source_dir = unpacked_dir / "server"
+        vendor_dir = source_dir / "vendor"
+        generated_version = source_dir / "arxiv_mcp_server" / "_bundle_version.py"
+        for required in (source_dir, vendor_dir, generated_version):
+            if not required.exists():
+                raise RuntimeError(
+                    f"Packed MCPB is missing {required.relative_to(unpacked_dir)}"
+                )
+
+        home_dir = temp_dir / "home"
+        storage_dir = temp_dir / "papers"
+        home_dir.mkdir()
+        storage_dir.mkdir()
+        env = clean_subprocess_env(home_dir)
+        env["PYTHONPATH"] = os.pathsep.join((str(source_dir), str(vendor_dir)))
+        parameters = StdioServerParameters(
+            command=sys.executable,
+            args=[
+                "-m",
+                "arxiv_mcp_server",
+                "--storage-path",
+                str(storage_dir),
+            ],
+            env=env,
+            cwd=temp_dir,
+        )
+        protocol = await exercise_mcp_server(
+            parameters, expected_version=expected_version
+        )
+
+    return {
+        "artifact": artifact.name,
+        "platform": sys.platform,
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "manifest_version": expected_version,
+        **protocol,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--bundle-dir",
+        type=Path,
+        default=ROOT / "mcpb-build",
+        help="Directory containing exactly one packed MCPB artifact",
+    )
+    args = parser.parse_args()
+    print(json.dumps(asyncio.run(smoke_mcpb(args.bundle_dir)), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/arxiv_mcp_server/config.py
+++ b/src/arxiv_mcp_server/config.py
@@ -1,15 +1,26 @@
 """Configuration settings for the arXiv MCP server."""
 
 import sys
+from importlib import import_module
 from importlib.metadata import version, PackageNotFoundError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pathlib import Path
 import logging
 
-try:
-    _PACKAGE_VERSION = version("arxiv-mcp-server")
-except PackageNotFoundError:
-    _PACKAGE_VERSION = "0.0.0"
+
+def _resolve_package_version() -> str:
+    """Resolve the bundled version first, then installed package metadata."""
+    try:
+        bundle_version = import_module("._bundle_version", package=__package__)
+    except ImportError:
+        try:
+            return version("arxiv-mcp-server")
+        except PackageNotFoundError:
+            return "0.0.0"
+    return bundle_version.VERSION
+
+
+_PACKAGE_VERSION = _resolve_package_version()
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from pathlib import Path
+from types import ModuleType
 from arxiv_mcp_server.config import Settings
 from unittest.mock import MagicMock, patch
 
@@ -141,3 +142,41 @@ def test_close_arxiv_client_releases_shared_session(monkeypatch):
 
     client._session.close.assert_called_once_with()
     assert config._arxiv_client is None
+
+
+def test_package_version_prefers_generated_bundle_version(monkeypatch):
+    from arxiv_mcp_server import config
+
+    bundle_module = ModuleType("arxiv_mcp_server._bundle_version")
+    setattr(bundle_module, "VERSION", "9.9.9")
+    monkeypatch.setitem(sys.modules, bundle_module.__name__, bundle_module)
+    monkeypatch.setattr(config, "version", lambda _name: "0.6.2")
+
+    assert config._resolve_package_version() == "9.9.9"
+
+
+def test_package_version_uses_distribution_metadata_without_bundle(monkeypatch):
+    from arxiv_mcp_server import config
+
+    def missing_bundle(_name, *, package):
+        raise ImportError(package)
+
+    monkeypatch.setattr(config, "import_module", missing_bundle)
+    monkeypatch.setattr(config, "version", lambda _name: "0.6.2")
+
+    assert config._resolve_package_version() == "0.6.2"
+
+
+def test_package_version_falls_back_without_bundle_or_distribution(monkeypatch):
+    from arxiv_mcp_server import config
+
+    def missing_bundle(_name, *, package):
+        raise ImportError(package)
+
+    def missing_distribution(_name):
+        raise config.PackageNotFoundError
+
+    monkeypatch.setattr(config, "import_module", missing_bundle)
+    monkeypatch.setattr(config, "version", missing_distribution)
+
+    assert config._resolve_package_version() == "0.0.0"

--- a/tests/test_installed_wheel_smoke.py
+++ b/tests/test_installed_wheel_smoke.py
@@ -1,0 +1,66 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "smoke_installed_wheel.py"
+SPEC = spec_from_file_location("smoke_installed_wheel", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+SMOKE = module_from_spec(SPEC)
+SPEC.loader.exec_module(SMOKE)
+clean_subprocess_env = SMOKE.clean_subprocess_env
+find_single_wheel = SMOKE.find_single_wheel
+venv_python = SMOKE.venv_python
+venv_entrypoint = SMOKE.venv_entrypoint
+
+
+def test_find_single_wheel_requires_exactly_one_candidate(tmp_path):
+    with pytest.raises(RuntimeError, match="exactly one wheel"):
+        find_single_wheel(tmp_path)
+
+    wheel = tmp_path / "arxiv_mcp_server-0.6.2-py3-none-any.whl"
+    wheel.touch()
+    assert find_single_wheel(tmp_path) == wheel
+
+    (tmp_path / "arxiv_mcp_server-0.6.3-py3-none-any.whl").touch()
+    with pytest.raises(RuntimeError, match="exactly one wheel"):
+        find_single_wheel(tmp_path)
+
+
+def test_venv_python_is_cross_platform():
+    root = Path("smoke-venv")
+    assert venv_python(root, platform="posix") == root / "bin" / "python"
+    assert venv_python(root, platform="nt") == root / "Scripts" / "python.exe"
+
+
+def test_venv_entrypoint_is_cross_platform():
+    root = Path("smoke-venv")
+    assert venv_entrypoint(root, platform="posix") == root / "bin" / "arxiv-mcp-server"
+    assert venv_entrypoint(root, platform="nt") == (
+        root / "Scripts" / "arxiv-mcp-server.exe"
+    )
+
+
+def test_clean_subprocess_env_isolates_python_and_home(tmp_path):
+    env = clean_subprocess_env(
+        tmp_path,
+        source={
+            "PATH": "/usr/bin",
+            "PYTHONPATH": "/leaky/site-packages",
+            "PYTHONHOME": "/leaky/python",
+            "VIRTUAL_ENV": "/leaky/venv",
+            "APP_VERSION": "9.9.9",
+            "TRANSPORT": "http",
+            "UV_CONSTRAINT": "/leaky/constraints.txt",
+        },
+    )
+
+    assert env["PATH"] == "/usr/bin"
+    assert env["HOME"] == str(tmp_path)
+    assert env["USERPROFILE"] == str(tmp_path)
+    assert "PYTHONPATH" not in env
+    assert "PYTHONHOME" not in env
+    assert "VIRTUAL_ENV" not in env
+    assert "APP_VERSION" not in env
+    assert "TRANSPORT" not in env
+    assert "UV_CONSTRAINT" not in env

--- a/tests/test_mcpb_smoke.py
+++ b/tests/test_mcpb_smoke.py
@@ -1,0 +1,64 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+import zipfile
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+try:
+    script = SCRIPTS / "smoke_mcpb.py"
+    spec = spec_from_file_location("smoke_mcpb", script)
+    assert spec is not None and spec.loader is not None
+    SMOKE = module_from_spec(spec)
+    spec.loader.exec_module(SMOKE)
+finally:
+    sys.path.pop(0)
+
+find_single_mcpb = SMOKE.find_single_mcpb
+extract_mcpb = SMOKE.extract_mcpb
+
+
+def test_find_single_mcpb_requires_exactly_one_candidate(tmp_path):
+    with pytest.raises(RuntimeError, match="exactly one MCPB"):
+        find_single_mcpb(tmp_path)
+
+    artifact = tmp_path / "arxiv-mcp-server-0.6.2.mcpb"
+    artifact.touch()
+    assert find_single_mcpb(tmp_path) == artifact
+
+    (tmp_path / "arxiv-mcp-server-0.6.3.mcpb").touch()
+    with pytest.raises(RuntimeError, match="exactly one MCPB"):
+        find_single_mcpb(tmp_path)
+
+
+def test_extract_mcpb_extracts_archive_contents(tmp_path):
+    artifact = tmp_path / "arxiv-mcp-server-0.6.2.mcpb"
+    with zipfile.ZipFile(artifact, "w") as archive:
+        archive.writestr("manifest.json", "{}")
+        archive.writestr(
+            "server/arxiv_mcp_server/_bundle_version.py", 'VERSION = "0.6.2"'
+        )
+
+    destination = tmp_path / "unpacked"
+    extract_mcpb(artifact, destination)
+
+    assert (destination / "manifest.json").read_text() == "{}"
+    assert (
+        "0.6.2"
+        in (
+            destination / "server" / "arxiv_mcp_server" / "_bundle_version.py"
+        ).read_text()
+    )
+
+
+def test_extract_mcpb_rejects_path_traversal(tmp_path):
+    artifact = tmp_path / "arxiv-mcp-server-0.6.2.mcpb"
+    with zipfile.ZipFile(artifact, "w") as archive:
+        archive.writestr("../outside.txt", "unexpected")
+
+    with pytest.raises(RuntimeError, match="unsafe archive member"):
+        extract_mcpb(artifact, tmp_path / "unpacked")
+
+    assert not (tmp_path / "outside.txt").exists()

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -123,8 +123,23 @@ def test_readme_exposes_supported_install_paths():
     assert "static.pepy.tech/badge/arxiv-mcp-server" in readme
     assert "claude mcp add --transport stdio --scope user arxiv" in readme
     assert "codex mcp add arxiv -- uvx arxiv-mcp-server" in readme
+    assert "hermes mcp add arxiv --command uvx --args arxiv-mcp-server" in readme
+    assert "hermes mcp test arxiv" in readme
+    assert (
+        "uvx --python 3.11 --refresh-package arxiv-mcp-server arxiv-mcp-server"
+        in readme
+    )
+    assert "command -v uvx" in readme
+    assert "Get-Command uvx" in readme
+    assert "uv tool update-shell" in readme
+    assert (
+        "registry.modelcontextprotocol.io/?search=io.github.blazickjp%2Farxiv-mcp-server"
+        in readme
+    )
     assert "claude plugin install arxiv-mcp-server@arxiv-mcp" in readme
     assert "codex plugin add arxiv-mcp-server@arxiv-mcp" in readme
+    assert '$env:TRANSPORT = "http"' in readme
+    assert "clients that accept the `mcpServers` JSON shape" in readme
     assert "Smithery" not in readme
     assert "smithery" not in readme
 
@@ -165,3 +180,50 @@ def test_readme_exposes_supported_install_paths():
     assert insiders_query["name"] == ["arxiv-mcp-server"]
     assert insiders_query["quality"] == ["insiders"]
     assert json.loads(insiders_query["config"][0]) == vscode_config
+
+
+def test_claude_manifests_reference_live_schemastore_schemas():
+    plugin = json.loads(
+        (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    marketplace = json.loads(
+        (ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+
+    assert plugin["$schema"] == (
+        "https://www.schemastore.org/claude-code-plugin-manifest.json"
+    )
+    assert marketplace["$schema"] == (
+        "https://www.schemastore.org/claude-code-marketplace.json"
+    )
+
+
+def test_mcpb_manual_release_dispatch_checks_out_and_validates_the_tag():
+    workflow = (ROOT / ".github" / "workflows" / "build-mcpb.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "ref: ${{ inputs.release_tag || github.event.release.tag_name || github.sha }}"
+        in workflow
+    )
+    assert (
+        "RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}"
+        in workflow
+    )
+    assert 'expected_tag = f"v{version}"' in workflow
+    assert (
+        'tag_commit = subprocess.check_output(["git", "rev-list", "-n", "1", tag]'
+        in workflow
+    )
+
+
+def test_workflows_bound_protocol_smoke_runtime():
+    workflows = {
+        name: (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+        for name in ("tests.yml", "publish.yml", "build-mcpb.yml")
+    }
+
+    assert "timeout-minutes: 20" in workflows["tests.yml"]
+    assert "timeout-minutes: 20" in workflows["publish.yml"]
+    assert "timeout-minutes: 30" in workflows["build-mcpb.yml"]


### PR DESCRIPTION
## Summary

- add isolated installed-wheel MCP smokes across the OS/Python CI matrix
- validate optional-extra binary resolution on macOS, Linux, and Windows
- smoke the exact packed MCPB archive with integrity and traversal checks
- fix MCPB version reporting and protect manual release-tag recovery
- add bounded MCP request/job timeouts
- improve Claude, Codex, Hermes, PowerShell, uvx, and MCP Registry onboarding
- replace broken Claude plugin schema references

## Verification

- `171 passed, 1 skipped`
- Black clean across 52 files
- workflow YAML and plugin JSON parse successfully
- `git diff --check` passes
- independent bounded review found no remaining release blockers
- isolated wheel console-entry-point smoke: 14 tools, 7 prompts, version 0.6.2
- packed Apple Silicon MCPB smoke: 14 tools, 7 prompts, version 0.6.2
- packed MCPB SHA-256: `6c27476935cbfd2984c8432e404e516482ca7fa5b6856a47276062c279e03cd3`

## Release follow-up

If the complete GitHub Actions matrix passes, prepare and publish version 0.6.3 in a separate release step.
