### PR TITLE
chore: prepare release 0.6.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "arxiv-mcp-server",
   "displayName": "arXiv MCP Server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Search, download, read, and analyze arXiv papers through MCP.",
   "author": {
     "name": "Joseph Blazick"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arxiv-mcp-server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Search arXiv, read bounded full text and original LaTeX, follow citations, and monitor research topics through MCP.",
   "author": {
     "name": "Joseph Blazick",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "arxiv-mcp-server",
   "display_name": "ArXiv MCP Server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Search, download, and analyze arXiv papers via MCP.",
   "author": {
     "name": "Joseph Blazick",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arxiv-mcp-server"
-version = "0.6.2"
+version = "0.6.3"
 description = "A flexible arXiv search and analysis service with MCP protocol support"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.blazickjp/arxiv-mcp-server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Search arXiv papers, download full text, semantic search, citation graphs, and alerts via MCP.",
   "repository": {
     "url": "https://github.com/blazickjp/arxiv-mcp-server",
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "arxiv-mcp-server",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "arxiv-mcp-server"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Prepare version 0.6.3 after the cross-platform onboarding and artifact-verification improvements landed in #152.

- synchronize PyPI, MCP Registry, MCPB, Claude plugin, and Codex plugin metadata at 0.6.3
- update the lockfile's editable package version without unrelated dependency churn

## Release validation

- `171 passed, 1 skipped`
- Black clean across 52 files
- wheel and sdist build successfully
- Twine metadata validation passes
- isolated installed-wheel console-entry-point MCP smoke passes
- packed Apple Silicon MCPB smoke passes
- wheel and MCPB report server version 0.6.3
- 14 tools and 7 prompts discovered and exercised

## Publication plan

After this PR passes CI and is merged, publish GitHub release `v0.6.3`. The release-triggered workflows will repeat validation, publish PyPI and MCP Registry metadata, and build/upload Intel and Apple Silicon MCPB assets.
