### PR TITLE
feat: add HTTP /healthz probe for cloud deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ Connect clients to:
 }
 ```
 
+Cloud and load-balancer probes should GET `http://<host>:<port>/healthz`. It returns `200` with body `ok` once the HTTP server is listening. There is no separate `/ready` check: if the process is up, it is ready. The stdio transport has no HTTP endpoints.
+
 The server binds to `127.0.0.1` by default and enables MCP DNS-rebinding protection. If a reverse proxy exposes the server, keep the process on a private interface and provide authentication and network controls upstream. Use `ALLOWED_HOSTS` and `ALLOWED_ORIGINS` for the host and origin values forwarded by the proxy.
 
 ## Configuration

--- a/src/arxiv_mcp_server/server.py
+++ b/src/arxiv_mcp_server/server.py
@@ -17,7 +17,8 @@ from mcp.server.stdio import stdio_server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.server.transport_security import TransportSecuritySettings
 from starlette.applications import Starlette
-from starlette.routing import Mount
+from starlette.responses import PlainTextResponse
+from starlette.routing import Mount, Route
 from .config import Settings, close_arxiv_client
 from .tools import (
     handle_search,
@@ -208,6 +209,21 @@ async def _run_stdio() -> None:
         await server.run(streams[0], streams[1], _initialization_options())
 
 
+async def _healthz(_request):
+    """Liveness probe for HTTP deploys. Process up means ready."""
+    return PlainTextResponse("ok")
+
+
+def _build_http_app(session_manager) -> Starlette:
+    """HTTP app: MCP mount plus a deploy probe. stdio does not use this."""
+    return Starlette(
+        routes=[
+            Route("/healthz", _healthz, methods=["GET"]),
+            Mount("/mcp", app=session_manager.handle_request),
+        ]
+    )
+
+
 async def _run_streamable_http() -> None:
     """Run the MCP server over Streamable HTTP."""
     session_manager = StreamableHTTPSessionManager(
@@ -216,9 +232,7 @@ async def _run_streamable_http() -> None:
         json_response=False,
         security_settings=_transport_security_settings(),
     )
-    starlette_app = Starlette(
-        routes=[Mount("/mcp", app=session_manager.handle_request)]
-    )
+    starlette_app = _build_http_app(session_manager)
     config = uvicorn.Config(
         starlette_app,
         host=settings.HOST,

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -139,3 +139,18 @@ def test_http_defaults_bind_to_localhost():
     assert settings.TRANSPORT == "stdio"
     assert settings.HOST == "127.0.0.1"
     assert settings.PORT == 8000
+
+
+def test_http_app_exposes_healthz():
+    """HTTP deploys can probe /healthz without speaking MCP."""
+    from starlette.testclient import TestClient
+
+    session_manager = MagicMock()
+    session_manager.handle_request = AsyncMock()
+    app = server_module._build_http_app(session_manager)
+
+    with TestClient(app) as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.text == "ok"


### PR DESCRIPTION
## Summary
- Add `GET /healthz` on the Streamable HTTP app so cloud probes can tell the process is up.
- stdio is unchanged. No separate `/ready` — listening means ready.
- Document the probe in the README.

Closes #151

## Test plan
- [x] `uv run pytest tests/test_transport.py` (10 passed, including `test_http_app_exposes_healthz`)
- [x] `uv run black --check` on the touched Python files
- [ ] CI on this PR