### PR TITLE
fix: strip arXiv HTML chrome and duplicated math

### DIFF
--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -131,42 +131,155 @@ settings = Settings()
 
 
 class _ArticleTextExtractor(HTMLParser):
-    """Extract readable text from an arXiv HTML paper page.
+    """Extract readable paper text from an arXiv HTML page.
 
     Strategy:
-      - Ignore content inside <script>, <style>, <nav>, <header>, <footer> tags.
-      - Collect text from everywhere else, with minimal whitespace cleanup.
+      - Prefer ``<article>`` body text when present so site chrome outside
+        the paper is dropped (banners, report-issue dialog, watermarks).
+      - Skip script/style/nav/header/footer plus arXiv UI widgets.
+      - Skip author-note chrome (Thanks/ORCID/affiliation/email blocks).
+      - Keep math once: prefer ``alttext``, otherwise MathML without TeX
+        ``<annotation>`` duplicates.
     """
 
-    SKIP_TAGS = {"script", "style", "nav", "header", "footer", "aside"}
+    SKIP_TAGS = {
+        "script",
+        "style",
+        "head",
+        "nav",
+        "header",
+        "footer",
+        "aside",
+        "dialog",
+        "form",
+        "noscript",
+        "template",
+        "button",
+        "input",
+        "select",
+        "textarea",
+        "label",
+        "annotation",
+        "annotation-xml",
+    }
+    SKIP_CLASSES = {
+        "ds-announcement",
+        "arxiv-html-header",
+        "ds-site-footer",
+        "infobox",
+        "ltx_author_notes",
+        "ltx_contact",
+        "sr-only",
+        "ltx_page_logo",
+        "html-header-logo",
+    }
+    SKIP_IDS = {
+        "modal-form",
+        "announcement-banner",
+        "infobox",
+        "watermark-tr",
+    }
+    VOID_TAGS = {
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
 
     def __init__(self):
         super().__init__()
         self._skip_depth: int = 0
-        self._chunks: list[str] = []
+        self._skip_stack: list[bool] = []
+        self._article_depth: int = 0
+        self._article_chunks: list[str] = []
+        self._body_chunks: list[str] = []
+
+    def _should_skip(self, tag: str, attr_map: dict[str, str]) -> bool:
+        if tag in self.SKIP_TAGS:
+            return True
+        classes = set((attr_map.get("class") or "").split())
+        if classes & self.SKIP_CLASSES:
+            return True
+        elem_id = attr_map.get("id") or ""
+        return elem_id in self.SKIP_IDS
+
+    def _emit(self, text: str) -> None:
+        if self._skip_depth or not text:
+            return
+        if self._article_depth > 0:
+            self._article_chunks.append(text)
+        else:
+            self._body_chunks.append(text)
 
     def handle_starttag(self, tag: str, attrs):
-        if tag in self.SKIP_TAGS:
+        attr_map = dict(attrs)
+        if tag == "article":
+            self._article_depth += 1
+
+        # Void elements have no children. Incrementing skip_depth for
+        # <input> etc. and never seeing an end tag left the rest of the
+        # document, including <article>, permanently skipped.
+        if tag in self.VOID_TAGS:
+            return
+
+        skip = self._should_skip(tag, attr_map)
+        if tag == "math":
+            alttext = (attr_map.get("alttext") or "").strip()
+            if alttext:
+                # Emit TeX/alt once and ignore MathML + annotation children.
+                self._emit(alttext)
+                skip = True
+
+        if skip:
             self._skip_depth += 1
+        self._skip_stack.append(skip)
 
     def handle_endtag(self, tag: str):
-        if tag in self.SKIP_TAGS and self._skip_depth > 0:
-            self._skip_depth -= 1
+        if self._skip_stack and self._skip_stack.pop():
+            self._skip_depth = max(0, self._skip_depth - 1)
+        if tag == "article" and self._article_depth > 0:
+            self._article_depth -= 1
+
+    def handle_startendtag(self, tag: str, attrs):
+        if tag in self.VOID_TAGS:
+            return
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
 
     def handle_data(self, data: str):
-        if self._skip_depth == 0:
-            stripped = data.strip()
-            if stripped:
-                self._chunks.append(stripped)
+        self._emit(data.strip())
 
     def get_text(self) -> str:
-        return "\n".join(self._chunks)
+        chunks = self._article_chunks or self._body_chunks
+        return "\n".join(chunks)
+
+
+def _extract_article_fragment(html: str) -> str | None:
+    """Return the first <article>…</article> slice when present."""
+    lower = html.lower()
+    start = lower.find("<article")
+    if start < 0:
+        return None
+    end = lower.find("</article>", start)
+    if end < 0:
+        return html[start:]
+    return html[start : end + len("</article>")]
 
 
 def _html_to_text(html: str) -> str:
-    """Parse raw HTML and return cleaned plain text."""
+    """Parse raw HTML and return cleaned paper text."""
     parser = _ArticleTextExtractor()
-    parser.feed(html)
+    parser.feed(_extract_article_fragment(html) or html)
     return parser.get_text()
 
 

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -267,6 +267,116 @@ def test_html_to_text_extracts_article_text():
     assert "Footer" not in text
 
 
+ARXIV_CHROME_FIXTURE = """
+<html>
+  <head><title>Attention Is All You Need</title></head>
+  <body>
+    <dialog id="modal-form">
+      <form>
+        <h5>Report GitHub Issue</h5>
+        <label>Title:</label>
+        <input id="form_title" name="form_title" placeholder="Enter title">
+        <p>Content selection saved. Describe the issue below:</p>
+        <label>Description:</label>
+      </form>
+    </dialog>
+    <div class="ds-announcement" id="announcement-banner">
+      <span>arXiv is now an independent nonprofit!</span>
+      <a>Learn more</a>
+      <button aria-label="Dismiss announcement">×</button>
+    </div>
+    <header class="arxiv-html-header">
+      <span class="sr-only">Back to arXiv</span>
+    </header>
+    <nav>Why HTML?</nav>
+    <div class="infobox" id="infobox">
+      <div id="watermark-tr">arXiv:1706.03762v7 [cs.CL] 02 Aug 2023</div>
+    </div>
+    <article class="ltx_document">
+      <h1 class="ltx_title">Attention Is All You Need</h1>
+      <div class="ltx_authors">
+        <span class="ltx_personname">Ashish Vaswani</span>
+        <span class="ltx_author_notes">
+          <span class="ltx_contact ltx_role_thanks">
+            <span class="ltx_contact_name">Thanks:</span>
+            ORCID: 0009-0009-0452-9407
+          </span>
+          <span class="ltx_contact ltx_role_affiliation">
+            <span class="ltx_contact_name">Affiliation:</span> Google Brain
+          </span>
+          <span class="ltx_contact ltx_role_email">
+            <span class="ltx_contact_name">Email:</span> avaswani@google.com
+          </span>
+        </span>
+      </div>
+      <p>Paper body sentence about attention.</p>
+    </article>
+  </body>
+</html>
+"""
+
+ARXIV_MATH_FIXTURE = """
+<html>
+  <body>
+    <article>
+      <p>measured decode is
+        <math class="ltx_Math" alttext="0.44" display="inline">
+          <semantics>
+            <mn>0.44</mn>
+            <annotation encoding="application/x-tex">0.44</annotation>
+          </semantics>
+        </math>
+        tok/s warm, reuse is
+        <math class="ltx_Math" alttext="2.0\\times" display="inline">
+          <semantics>
+            <mrow><mn>2.0</mn><mo>×</mo></mrow>
+            <annotation encoding="application/x-tex">2.0\\times</annotation>
+          </semantics>
+        </math>
+        chance.</p>
+    </article>
+  </body>
+</html>
+"""
+
+
+def test_html_to_text_strips_arxiv_site_chrome():
+    """Site chrome, report dialog, and author-note widgets must not leak."""
+    text = _html_to_text(ARXIV_CHROME_FIXTURE)
+    assert "Paper body sentence about attention." in text
+    assert "Ashish Vaswani" in text
+    assert text.count("Attention Is All You Need") == 1
+    leaked = [
+        "Content selection saved",
+        "Describe the issue below",
+        "arXiv is now an independent nonprofit",
+        "Learn more",
+        "Title:",
+        "Description:",
+        "Thanks:",
+        "ORCID",
+        "Affiliation:",
+        "Email:",
+        "Report GitHub Issue",
+        "Back to arXiv",
+        "Why HTML?",
+        "arXiv:1706.03762",
+    ]
+    for snippet in leaked:
+        assert snippet not in text, snippet
+
+
+def test_html_to_text_keeps_math_once():
+    """MathML + TeX annotation must not be concatenated as 0.44 0.44."""
+    text = _html_to_text(ARXIV_MATH_FIXTURE)
+    assert "measured decode is" in text
+    assert "tok/s warm" in text
+    assert text.count("0.44") == 1
+    assert "2.0\\times" in text
+    assert text.count("2.0\\times") == 1
+    assert "2.0×" not in text
+
+
 # ---------------------------------------------------------------------------
 # Integration-style handler tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- HTML `download_paper` was dumping arXiv site chrome (`dialog`, announcements, ORCID/affiliation blocks) and emitting math twice (MathML + TeX annotation).
- Parse the first `<article>`, skip chrome, emit `alttext` once, and treat void tags as childless so skip-depth cannot swallow the paper.

Closes #158

## Test plan
- [x] `uv run pytest tests/tools/test_download.py --no-cov` (20 passed)
- [x] Live HTML smoke: `1706.03762` and `2608.18261` — chrome gone, `0.44` / `2.0\\times` once
- [ ] CI