### PR TITLE
fix: retry Semantic Scholar 429s and bound citation_graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Keep tool schemas, package exports, server registration, dispatch, tests, and RE
 - `PORT`
 - `ALLOWED_HOSTS`
 - `ALLOWED_ORIGINS`
+- `SEMANTIC_SCHOLAR_API_KEY`
 
 Paper storage is selected with the `--storage-path` command-line option and defaults to `~/.arxiv-mcp-server/papers`.
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The server currently exposes 14 tools.
 | `get_paper_latex` | Retrieve bounded author-submitted LaTeX | Remote arXiv source archive |
 | `list_paper_latex_sections` | Return a paginated LaTeX outline | Supports `start` and `max_sections` |
 | `get_paper_latex_section` | Read one bounded LaTeX section | Select by outline ID or exact title |
-| `citation_graph` | Fetch references and citing papers | Remote Semantic Scholar API |
+| `citation_graph` | Fetch references and citing papers | Remote Semantic Scholar API; optional `SEMANTIC_SCHOLAR_API_KEY` |
 | `export_citations` | Export BibTeX for one or more arXiv IDs | Authoritative arXiv metadata |
 | `watch_topic` | Save or update an arXiv topic watch | Stored locally |
 | `check_alerts` | Check saved watches for new papers | Returns papers since the last check |
@@ -359,6 +359,7 @@ The server binds to `127.0.0.1` by default and enables MCP DNS-rebinding protect
 | `PORT` | `8000` | HTTP bind port |
 | `ALLOWED_HOSTS` | empty | Additional accepted HTTP Host values |
 | `ALLOWED_ORIGINS` | empty | Additional accepted HTTP Origin values |
+| `SEMANTIC_SCHOLAR_API_KEY` | empty | Optional Semantic Scholar API key for `citation_graph` |
 
 Environment variable names are case-insensitive through Pydantic settings. `--storage-path` is a command-line option rather than an environment setting.
 

--- a/src/arxiv_mcp_server/config.py
+++ b/src/arxiv_mcp_server/config.py
@@ -101,6 +101,7 @@ class Settings(BaseSettings):
     PORT: int = 8000
     ALLOWED_HOSTS: str = ""
     ALLOWED_ORIGINS: str = ""
+    SEMANTIC_SCHOLAR_API_KEY: str = ""
     model_config = SettingsConfigDict(extra="allow")
 
     @property

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any, Dict, List
@@ -11,16 +12,33 @@ import httpx
 import mcp.types as types
 from mcp.types import ToolAnnotations
 
-logger = logging.getLogger("arxiv-mcp-server")
+from ..config import Settings
 
-SEMANTIC_SCHOLAR_BASE_URL = "https://api.semanticscholar.org/graph/v1/paper"
+logger = logging.getLogger("arxiv-mcp-server")
+settings = Settings()
+
+SEMANTIC_SCHOLAR_API_URL = "https://api.semanticscholar.org/graph/v1"
+DEFAULT_MAX_CITATIONS = 50
+MAX_CITATIONS_CAP = 200
+PAPER_FIELDS = "title,year,authors,externalIds,citationCount,referenceCount"
+# Neighbors omit externalIds — that field set is expensive on Attention-scale
+# papers and is the usual cause of unauthenticated 429s.
+NEIGHBOR_FIELDS = "paperId,title,year,authors"
+RATE_LIMIT_MESSAGE = (
+    "Semantic Scholar rate-limited; set SEMANTIC_SCHOLAR_API_KEY or try again later"
+)
+_MAX_RETRIES = 3
+_INITIAL_BACKOFF_SECONDS = 1.0
+_MAX_BACKOFF_SECONDS = 30.0
 
 citation_graph_tool = types.Tool(
     name="citation_graph",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     description=(
         "Return papers citing an arXiv paper and papers that it references "
-        "using Semantic Scholar's citation graph."
+        "using Semantic Scholar's citation graph. Results are bounded "
+        "(default 50) to stay within the unauthenticated quota; set "
+        "SEMANTIC_SCHOLAR_API_KEY for a higher limit."
     ),
     inputSchema={
         "type": "object",
@@ -28,12 +46,25 @@ citation_graph_tool = types.Tool(
             "paper_id": {
                 "type": "string",
                 "description": "arXiv ID (for example: 2401.12345).",
-            }
+            },
+            "max_citations": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_CITATIONS_CAP,
+                "description": (
+                    "Maximum citations and references to return "
+                    f"(default {DEFAULT_MAX_CITATIONS})."
+                ),
+            },
         },
         "required": ["paper_id"],
         "additionalProperties": False,
     },
 )
+
+
+class SemanticScholarRateLimitError(Exception):
+    """Raised when Semantic Scholar keeps returning HTTP 429."""
 
 
 def _normalize_paper_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -60,6 +91,69 @@ def _normalize_paper_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return normalized
 
 
+def _s2_headers() -> Dict[str, str]:
+    """Build Semantic Scholar request headers, including an optional API key."""
+    headers = {
+        "User-Agent": (
+            f"{settings.APP_NAME}/{settings.APP_VERSION} "
+            "(https://github.com/blazickjp/arxiv-mcp-server; research tool)"
+        )
+    }
+    api_key = (settings.SEMANTIC_SCHOLAR_API_KEY or "").strip()
+    if api_key:
+        headers["x-api-key"] = api_key
+    return headers
+
+
+def _backoff_seconds(attempt: int, retry_after: str | None) -> float:
+    """Exponential backoff, honoring a numeric Retry-After when present."""
+    delay = min(_INITIAL_BACKOFF_SECONDS * (2**attempt), _MAX_BACKOFF_SECONDS)
+    if retry_after:
+        try:
+            delay = min(max(delay, float(retry_after)), _MAX_BACKOFF_SECONDS)
+        except ValueError:
+            pass
+    return delay
+
+
+async def _s2_get(
+    client: httpx.AsyncClient, url: str, params: Dict[str, Any] | None = None
+) -> httpx.Response:
+    """GET a Semantic Scholar URL, retrying with backoff on HTTP 429."""
+    for attempt in range(_MAX_RETRIES + 1):
+        response = await client.get(url, params=params, headers=_s2_headers())
+        if response.status_code != 429:
+            response.raise_for_status()
+            return response
+        if attempt == _MAX_RETRIES:
+            break
+        wait = _backoff_seconds(attempt, response.headers.get("Retry-After"))
+        logger.warning("Semantic Scholar 429 on %s; retrying in %.1fs", url, wait)
+        await asyncio.sleep(wait)
+    raise SemanticScholarRateLimitError(RATE_LIMIT_MESSAGE)
+
+
+def _neighbor_papers(payload: Dict[str, Any], wrapper_key: str) -> List[Dict[str, Any]]:
+    """Unwrap citation/reference endpoint rows into paper objects."""
+    papers: List[Dict[str, Any]] = []
+    for row in payload.get("data") or []:
+        paper = row.get(wrapper_key) if isinstance(row, dict) else None
+        if isinstance(paper, dict):
+            papers.append(paper)
+    return papers
+
+
+def _bound_max_citations(value: Any) -> int:
+    """Clamp the caller-supplied neighbor bound to the documented range."""
+    if value is None:
+        return DEFAULT_MAX_CITATIONS
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_CITATIONS
+    return max(1, min(parsed, MAX_CITATIONS_CAP))
+
+
 async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Handle citation graph lookup for a single arXiv paper ID."""
     try:
@@ -67,22 +161,25 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
         if not paper_id:
             return [types.TextContent(type="text", text="Error: paper_id is required")]
 
-        s2_paper_identifier = quote(f"ARXIV:{paper_id}")
-        fields = (
-            "title,year,authors,externalIds,"
-            "citations.paperId,citations.title,citations.year,citations.authors,citations.externalIds,"
-            "references.paperId,references.title,references.year,references.authors,references.externalIds"
-        )
-
-        url = f"{SEMANTIC_SCHOLAR_BASE_URL}/{s2_paper_identifier}?fields={fields}"
+        limit = _bound_max_citations(arguments.get("max_citations"))
+        s2_paper_identifier = quote(f"ARXIV:{paper_id}", safe=":")
+        paper_url = f"{SEMANTIC_SCHOLAR_API_URL}/paper/{s2_paper_identifier}"
+        citations_url = f"{paper_url}/citations"
+        references_url = f"{paper_url}/references"
+        neighbor_params = {"fields": NEIGHBOR_FIELDS, "limit": limit}
 
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(url)
-            response.raise_for_status()
+            paper_response = await _s2_get(client, paper_url, {"fields": PAPER_FIELDS})
+            citations_response = await _s2_get(client, citations_url, neighbor_params)
+            references_response = await _s2_get(client, references_url, neighbor_params)
 
-        payload = response.json()
-        citations = _normalize_paper_items(payload.get("citations", []))
-        references = _normalize_paper_items(payload.get("references", []))
+        payload = paper_response.json()
+        citations = _normalize_paper_items(
+            _neighbor_papers(citations_response.json(), "citingPaper")
+        )
+        references = _normalize_paper_items(
+            _neighbor_papers(references_response.json(), "citedPaper")
+        )
 
         result = {
             "status": "success",
@@ -94,17 +191,26 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
                 "authors": [
                     author.get("name", "") for author in payload.get("authors", [])
                 ],
-                "external_ids": payload.get("externalIds", {}),
+                "external_ids": payload.get("externalIds") or {},
             },
             "citation_count": len(citations),
             "reference_count": len(references),
+            "citation_total": payload.get("citationCount"),
+            "reference_total": payload.get("referenceCount"),
+            "max_citations": limit,
             "citations": citations,
             "references": references,
         }
 
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
+    except SemanticScholarRateLimitError as exc:
+        logger.error("Semantic Scholar rate limited: %s", exc)
+        return [types.TextContent(type="text", text=f"Error: {RATE_LIMIT_MESSAGE}")]
     except httpx.HTTPStatusError as exc:
+        if exc.response is not None and exc.response.status_code == 429:
+            logger.error("Semantic Scholar rate limited: %s", exc)
+            return [types.TextContent(type="text", text=f"Error: {RATE_LIMIT_MESSAGE}")]
         logger.error("Semantic Scholar HTTP error: %s", exc)
         return [
             types.TextContent(

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -3,73 +3,176 @@
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
+from arxiv_mcp_server.tools import citation_graph as citation_graph_module
 from arxiv_mcp_server.tools.citation_graph import handle_citation_graph
 
+PAPER_PAYLOAD = {
+    "paperId": "root-paper",
+    "title": "Root Paper",
+    "year": 2024,
+    "authors": [{"name": "Author A"}],
+    "externalIds": {"ArXiv": "2401.12345"},
+    "citationCount": 12,
+    "referenceCount": 3,
+}
 
-@pytest.mark.asyncio
-async def test_citation_graph_success():
-    """Citation graph should return citations and references with normalized fields."""
-    mock_payload = {
-        "paperId": "root-paper",
-        "title": "Root Paper",
-        "year": 2024,
-        "authors": [{"name": "Author A"}],
-        "externalIds": {"ArXiv": "2401.12345"},
-        "citations": [
-            {
+CITATIONS_PAYLOAD = {
+    "data": [
+        {
+            "citingPaper": {
                 "paperId": "citing-1",
                 "title": "Citing Paper",
                 "year": 2025,
                 "authors": [{"name": "Author B"}],
                 "externalIds": {"ArXiv": "2501.00001"},
             }
-        ],
-        "references": [
-            {
+        }
+    ]
+}
+
+REFERENCES_PAYLOAD = {
+    "data": [
+        {
+            "citedPaper": {
                 "paperId": "ref-1",
                 "title": "Referenced Paper",
                 "year": 2020,
                 "authors": [{"name": "Author C"}],
                 "externalIds": {"ArXiv": "2001.00001"},
             }
-        ],
-    }
+        }
+    ]
+}
 
-    mock_response = MagicMock()
-    mock_response.raise_for_status = MagicMock()
-    mock_response.json.return_value = mock_payload
 
-    with patch("httpx.AsyncClient") as mock_client_class:
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
+def _json_response(payload, status_code=200, headers=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.json.return_value = payload
+    if status_code >= 400 and status_code != 429:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=response
+        )
+    else:
+        response.raise_for_status = MagicMock()
+    return response
 
+
+def _mock_async_client(responses):
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=list(responses))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
+def _success_responses():
+    return [
+        _json_response(PAPER_PAYLOAD),
+        _json_response(CITATIONS_PAYLOAD),
+        _json_response(REFERENCES_PAYLOAD),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_success():
+    """Citation graph should return citations and references with normalized fields."""
+    mock_client = _mock_async_client(_success_responses())
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         response = await handle_citation_graph({"paper_id": "2401.12345"})
 
     payload = json.loads(response[0].text)
     assert payload["status"] == "success"
     assert payload["citation_count"] == 1
     assert payload["reference_count"] == 1
+    assert payload["citation_total"] == 12
+    assert payload["max_citations"] == 50
     assert payload["citations"][0]["arxiv_id"] == "2501.00001"
+    assert mock_client.get.call_count == 3
+    citation_call = mock_client.get.call_args_list[1]
+    assert citation_call.args[0].endswith("/citations")
+    assert citation_call.kwargs["params"]["limit"] == 50
+    assert "externalIds" not in citation_call.kwargs["params"]["fields"]
 
 
 @pytest.mark.asyncio
 async def test_citation_graph_http_error():
     """Citation graph should surface HTTP API errors."""
     mock_response = MagicMock()
+    mock_response.status_code = 500
     mock_response.raise_for_status.side_effect = Exception("boom")
 
-    with patch("httpx.AsyncClient") as mock_client_class:
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
+    mock_client = _mock_async_client([mock_response])
 
+    with patch("httpx.AsyncClient", return_value=mock_client):
         response = await handle_citation_graph({"paper_id": "2401.12345"})
 
     assert response[0].text.startswith("Error:")
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_retries_on_429_then_succeeds():
+    """A transient Semantic Scholar 429 should be retried and then succeed."""
+    responses = [_json_response({}, status_code=429), *_success_responses()]
+    mock_client = _mock_async_client(responses)
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(
+            citation_graph_module.asyncio, "sleep", new_callable=AsyncMock
+        ) as sleep,
+    ):
+        response = await handle_citation_graph({"paper_id": "1706.03762"})
+
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    assert payload["paper"]["arxiv_id"] == "1706.03762"
+    assert mock_client.get.call_count == 4
+    sleep.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_429_exhausted_has_useful_error():
+    """Persistent 429s should tell the caller how to raise the S2 quota."""
+    rate_limited = _json_response({}, status_code=429)
+    mock_client = _mock_async_client([rate_limited] * 4)
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module.asyncio, "sleep", new_callable=AsyncMock),
+    ):
+        response = await handle_citation_graph({"paper_id": "2608.18261"})
+
+    assert response[0].text == (
+        "Error: Semantic Scholar rate-limited; set SEMANTIC_SCHOLAR_API_KEY "
+        "or try again later"
+    )
+    assert mock_client.get.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_sends_api_key_and_honors_max_citations():
+    """Optional API key and max_citations should be forwarded to Semantic Scholar."""
+    mock_client = _mock_async_client(_success_responses())
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(
+            citation_graph_module.settings, "SEMANTIC_SCHOLAR_API_KEY", "s2-key"
+        ),
+    ):
+        response = await handle_citation_graph(
+            {"paper_id": "2401.12345", "max_citations": 10}
+        )
+
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    assert payload["max_citations"] == 10
+    for call in mock_client.get.call_args_list:
+        assert call.kwargs["headers"]["x-api-key"] == "s2-key"
+    assert mock_client.get.call_args_list[1].kwargs["params"]["limit"] == 10


### PR DESCRIPTION
## Summary
- `citation_graph` was one unauthenticated Graph API call for the full citation/reference graphs. Attention-scale papers 429 and the error was raw httpx.
- Retry 429s with backoff (honors `Retry-After`).
- Error text tells you to set `SEMANTIC_SCHOLAR_API_KEY` or try later.
- Optional key in Settings + README.
- Split citations/references requests with default `max_citations=50` (cap 200) and a smaller neighbor field set.

Closes #160

## Test plan
- [x] `uv run pytest tests/tools/test_citation_graph.py tests/test_config.py tests/test_tool_schemas.py` (17 passed)
- [ ] CI