### PR TITLE
fix: return local titles and authors from list_papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The server currently exposes 14 tools.
 | `search_papers` | Search arXiv by query, category, date, and sort order | Remote arXiv API |
 | `get_abstract` | Fetch metadata and an abstract by arXiv ID | Does not download the paper |
 | `download_paper` | Download and convert a paper to local Markdown | HTML first; PDF fallback uses `[pdf]` |
-| `list_papers` | List papers stored locally | Returns arXiv IDs |
+| `list_papers` | List papers stored locally | Returns id, title, authors, published; `compact` for IDs only |
 | `read_paper` | Read locally stored paper content | Supports `start` and `max_chars` |
 | `get_paper_latex` | Retrieve bounded author-submitted LaTeX | Remote arXiv source archive |
 | `list_paper_latex_sections` | Return a paginated LaTeX outline | Supports `start` and `max_sections` |

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -13,7 +13,7 @@ from mcp.types import ToolAnnotations
 from ..config import Settings, get_arxiv_client
 from ..arxiv_api import ARXIV_RATE_LIMITER, stream_pdf_to_path
 from .content import add_content_payload
-from .list_papers import is_valid_arxiv_id
+from .list_papers import is_valid_arxiv_id, save_paper_metadata
 import logging
 import threading
 
@@ -425,6 +425,80 @@ def _fetch_pdf_content(paper_id: str) -> tuple[str, arxiv.Result]:
         return _fetch_pdf_content_unlocked(paper_id)
 
 
+def _metadata_from_arxiv_result(paper_id: str, paper) -> dict[str, Any]:
+    """Build local list_papers metadata from an arXiv result."""
+    published = getattr(paper, "published", None)
+    published_text = None
+    if published is not None:
+        iso = getattr(published, "isoformat", None)
+        published_text = iso() if callable(iso) else str(published)
+    authors = []
+    for author in getattr(paper, "authors", None) or []:
+        name = getattr(author, "name", None)
+        if name:
+            authors.append(name)
+        elif author:
+            authors.append(str(author))
+    return {
+        "title": getattr(paper, "title", None) or None,
+        "authors": authors,
+        "published": published_text,
+    }
+
+
+def _title_hint_from_text(text: str | None) -> str | None:
+    """Use the first non-empty markdown line as a title fallback."""
+    if not text:
+        return None
+    for line in text.splitlines():
+        hint = line.strip().lstrip("#").strip()
+        if hint:
+            return hint
+    return None
+
+
+def _fetch_arxiv_metadata(paper_id: str) -> dict[str, Any] | None:
+    """Best-effort arXiv metadata lookup used after an HTML download."""
+    try:
+        client = get_arxiv_client()
+        paper = ARXIV_RATE_LIMITER.run_sync(
+            lambda: next(client.results(arxiv.Search(id_list=[paper_id])))
+        )
+        return _metadata_from_arxiv_result(paper_id, paper)
+    except Exception as exc:
+        logger.info("Could not fetch metadata for %s: %s", paper_id, exc)
+        return None
+
+
+def _persist_paper_metadata(
+    paper_id: str,
+    arxiv_result=None,
+    title_hint: str | None = None,
+) -> None:
+    """Write a sidecar next to the downloaded markdown. Never fail the download."""
+    try:
+        metadata = None
+        if arxiv_result is not None:
+            metadata = _metadata_from_arxiv_result(paper_id, arxiv_result)
+        if metadata is None:
+            metadata = _fetch_arxiv_metadata(paper_id)
+        if metadata is None:
+            metadata = {
+                "title": title_hint,
+                "authors": [],
+                "published": None,
+            }
+        save_paper_metadata(
+            paper_id,
+            title=metadata.get("title") or title_hint,
+            authors=metadata.get("authors") or [],
+            published=metadata.get("published"),
+            path=get_paper_path(paper_id, ".meta.json"),
+        )
+    except Exception:
+        logger.warning("Failed to persist metadata for %s", paper_id, exc_info=True)
+
+
 # ---------------------------------------------------------------------------
 # Main handler
 # ---------------------------------------------------------------------------
@@ -475,6 +549,12 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
         if html_text is not None:
             # Save to cache
             md_path.write_text(html_text, encoding="utf-8")
+            await asyncio.to_thread(
+                _persist_paper_metadata,
+                paper_id,
+                None,
+                _title_hint_from_text(html_text),
+            )
             # Best-effort index; the tracked task is drained at shutdown.
             _track_index_task(_run_index_by_id(paper_id))
             payload = add_content_payload(
@@ -518,6 +598,12 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
 
         # Save to cache
         md_path.write_text(markdown, encoding="utf-8")
+        await asyncio.to_thread(
+            _persist_paper_metadata,
+            paper_id,
+            arxiv_result,
+            _title_hint_from_text(markdown),
+        )
 
         # Best-effort index; the tracked task is drained at shutdown.
         _track_index_task(_run_index_from_result(arxiv_result))

--- a/src/arxiv_mcp_server/tools/list_papers.py
+++ b/src/arxiv_mcp_server/tools/list_papers.py
@@ -1,14 +1,18 @@
 """List functionality for the arXiv MCP server."""
 
 import json
+import logging
 import re
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
+
 import mcp.types as types
 from mcp.types import ToolAnnotations
+
 from ..config import Settings
 
 settings = Settings()
+logger = logging.getLogger("arxiv-mcp-server")
 
 # Matches both new-style (YYMM.NNNNN) and old-style (cat/YYMMNNN) arXiv IDs,
 # with optional version suffix (v1, v2, …).
@@ -17,6 +21,8 @@ _ARXIV_ID_RE = re.compile(
     r"|[a-z\-]+(/[a-z\-]+)?/\d{7}(v\d+)?)$",  # old-style: hep-ph/9901234
     re.IGNORECASE,
 )
+
+METADATA_SUFFIX = ".meta.json"
 
 
 def is_valid_arxiv_id(stem: str) -> bool:
@@ -29,13 +35,22 @@ list_tool = types.Tool(
     annotations=ToolAnnotations(readOnlyHint=True),
     description=(
         "List all papers that have been downloaded and stored locally via download_paper. "
-        "Returns arXiv IDs only — use read_paper to access content. "
+        "Returns id, title, authors, and published from local metadata — no live re-fetch. "
+        "Set compact=true to return arXiv IDs only. "
         "Returns an empty list if no papers have been downloaded yet. "
         "Workflow: search_papers -> download_paper -> list_papers -> read_paper."
     ),
     inputSchema={
         "type": "object",
-        "properties": {},
+        "properties": {
+            "compact": {
+                "type": "boolean",
+                "description": (
+                    "If true, return arXiv IDs only. Default is full local metadata "
+                    "(id, title, authors, published)."
+                ),
+            }
+        },
         "required": [],
         "additionalProperties": False,
     },
@@ -59,15 +74,79 @@ def list_papers() -> list[str]:
     ]
 
 
+def paper_metadata_path(paper_id: str) -> Path:
+    """Return the sidecar path for locally stored paper metadata."""
+    return Path(settings.STORAGE_PATH) / f"{paper_id}{METADATA_SUFFIX}"
+
+
+def save_paper_metadata(
+    paper_id: str,
+    *,
+    title: Optional[str] = None,
+    authors: Optional[List[str]] = None,
+    published: Optional[str] = None,
+    path: Optional[Path] = None,
+) -> None:
+    """Persist lightweight paper metadata next to the downloaded markdown."""
+    destination = path or paper_metadata_path(paper_id)
+    payload = {
+        "id": paper_id,
+        "title": title or None,
+        "authors": list(authors or []),
+        "published": published or None,
+    }
+    destination.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _title_from_markdown(paper_id: str) -> Optional[str]:
+    """Best-effort title from the first non-empty markdown line (local only)."""
+    md_path = Path(settings.STORAGE_PATH) / f"{paper_id}.md"
+    try:
+        for line in md_path.read_text(encoding="utf-8").splitlines():
+            text = line.strip().lstrip("#").strip()
+            if text:
+                return text
+    except OSError:
+        return None
+    return None
+
+
+def load_paper_metadata(paper_id: str) -> Dict[str, Any]:
+    """Load local metadata for a stored paper without hitting the network."""
+    path = paper_metadata_path(paper_id)
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Ignoring unreadable metadata for %s: %s", paper_id, exc)
+        else:
+            if isinstance(data, dict):
+                authors = data.get("authors") or []
+                if not isinstance(authors, list):
+                    authors = []
+                return {
+                    "id": paper_id,
+                    "title": data.get("title") or None,
+                    "authors": [str(author) for author in authors],
+                    "published": data.get("published") or None,
+                }
+    return {
+        "id": paper_id,
+        "title": _title_from_markdown(paper_id),
+        "authors": [],
+        "published": None,
+    }
+
+
 async def handle_list_papers(
     arguments: Optional[Dict[str, Any]] = None,
 ) -> List[types.TextContent]:
     """Handle requests to list all stored papers."""
     try:
-        papers = list_papers()
+        paper_ids = list_papers()
+        compact = bool((arguments or {}).get("compact"))
 
-        # Short-circuit: nothing stored yet — avoid an empty arXiv API call
-        if not papers:
+        if not paper_ids:
             return [
                 types.TextContent(
                     type="text",
@@ -75,8 +154,13 @@ async def handle_list_papers(
                 )
             ]
 
+        papers: List[Any] = (
+            paper_ids
+            if compact
+            else [load_paper_metadata(paper_id) for paper_id in paper_ids]
+        )
         response_data = {
-            "total_papers": len(papers),
+            "total_papers": len(paper_ids),
             "papers": papers,
         }
 

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -468,6 +468,10 @@ async def test_html_endpoint_success(temp_storage_path, mocker):
         "arxiv_mcp_server.tools.download._fetch_html_content",
         return_value=html_text,
     )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_arxiv_metadata",
+        return_value=None,
+    )
     # PDF path should NOT be called
     mock_pdf = mocker.patch("arxiv_mcp_server.tools.download._fetch_pdf_content")
 
@@ -570,6 +574,10 @@ async def test_no_check_status_parameter(temp_storage_path, mocker):
         "arxiv_mcp_server.tools.download._fetch_html_content",
         return_value=html_text,
     )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_arxiv_metadata",
+        return_value=None,
+    )
 
     # Should not raise even if client passes check_status=True (it's ignored)
     response = await handle_download({"paper_id": paper_id})
@@ -615,3 +623,78 @@ async def test_unexpected_error_returns_error_status(temp_storage_path, mocker):
 
     assert result["status"] == "error"
     assert "Error:" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_html_download_persists_local_metadata(temp_storage_path, mocker):
+    """HTML downloads should write a sidecar so list_papers needs no re-fetch."""
+    paper_id = "2103.55555"
+
+    def fake_path(pid, suffix=".md"):
+        return temp_storage_path / f"{pid}{suffix}"
+
+    mocker.patch(
+        "arxiv_mcp_server.tools.download.get_paper_path", side_effect=fake_path
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_html_content",
+        return_value="Attention Is All You Need\nAbstract body.",
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_arxiv_metadata",
+        return_value={
+            "title": "Attention Is All You Need",
+            "authors": ["Ashish Vaswani"],
+            "published": "2017-06-12T00:00:00+00:00",
+        },
+    )
+    mocker.patch("arxiv_mcp_server.tools.download._fetch_pdf_content")
+
+    response = await handle_download({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+    assert result["status"] == "success"
+
+    sidecar = json.loads(
+        (temp_storage_path / f"{paper_id}.meta.json").read_text(encoding="utf-8")
+    )
+    assert sidecar["id"] == paper_id
+    assert sidecar["title"] == "Attention Is All You Need"
+    assert sidecar["authors"] == ["Ashish Vaswani"]
+    assert sidecar["published"] == "2017-06-12T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_pdf_download_persists_metadata_from_arxiv_result(
+    temp_storage_path, mocker, mock_paper
+):
+    """PDF fallback already has an arXiv result — persist it locally."""
+    paper_id = "2103.66666"
+
+    def fake_path(pid, suffix=".md"):
+        return temp_storage_path / f"{pid}{suffix}"
+
+    mocker.patch(
+        "arxiv_mcp_server.tools.download.get_paper_path", side_effect=fake_path
+    )
+    mocker.patch("arxiv_mcp_server.tools.download._pdf_available", True)
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_html_content",
+        return_value=None,
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_pdf_content",
+        return_value=("# Test Paper\nConverted from PDF.", mock_paper),
+    )
+    fetch_meta = mocker.patch("arxiv_mcp_server.tools.download._fetch_arxiv_metadata")
+
+    response = await handle_download({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+    assert result["status"] == "success"
+    fetch_meta.assert_not_called()
+
+    sidecar = json.loads(
+        (temp_storage_path / f"{paper_id}.meta.json").read_text(encoding="utf-8")
+    )
+    assert sidecar["title"] == "Test Paper"
+    assert sidecar["authors"] == ["John Doe", "Jane Smith"]
+    assert sidecar["published"].startswith("2023-01-01")

--- a/tests/tools/test_list_papers.py
+++ b/tests/tools/test_list_papers.py
@@ -1,0 +1,127 @@
+"""Tests for list_papers local metadata."""
+
+import json
+import pytest
+
+from arxiv_mcp_server.tools import list_papers as list_papers_module
+from arxiv_mcp_server.tools.list_papers import handle_list_papers, save_paper_metadata
+
+
+@pytest.fixture
+def storage(temp_storage_path, mocker):
+    """Point list_papers at an isolated storage directory."""
+    mocker.patch.object(
+        list_papers_module.settings,
+        "_get_storage_path_from_args",
+        return_value=temp_storage_path,
+    )
+    return temp_storage_path
+
+
+def _write_paper(storage, paper_id, markdown="Paper body", metadata=None):
+    (storage / f"{paper_id}.md").write_text(markdown, encoding="utf-8")
+    if metadata is not None:
+        save_paper_metadata(paper_id, **metadata)
+
+
+@pytest.mark.asyncio
+async def test_list_papers_empty(storage):
+    """No downloads yet — empty catalog, no error."""
+    response = await handle_list_papers({})
+    payload = json.loads(response[0].text)
+    assert payload == {"total_papers": 0, "papers": []}
+
+
+@pytest.mark.asyncio
+async def test_list_papers_returns_local_metadata(storage):
+    """Default list includes id, title, authors, and published from disk."""
+    _write_paper(
+        storage,
+        "1706.03762",
+        markdown="# Attention Is All You Need\nBody",
+        metadata={
+            "title": "Attention Is All You Need",
+            "authors": ["Ashish Vaswani", "Noam Shazeer"],
+            "published": "2017-06-12T17:57:34Z",
+        },
+    )
+    _write_paper(
+        storage,
+        "2608.18261",
+        markdown="# Another Paper\nBody",
+        metadata={
+            "title": "Another Paper",
+            "authors": ["Ada Lovelace"],
+            "published": "2026-08-20T00:00:00Z",
+        },
+    )
+
+    response = await handle_list_papers({})
+    payload = json.loads(response[0].text)
+
+    assert payload["total_papers"] == 2
+    by_id = {paper["id"]: paper for paper in payload["papers"]}
+    assert by_id["1706.03762"] == {
+        "id": "1706.03762",
+        "title": "Attention Is All You Need",
+        "authors": ["Ashish Vaswani", "Noam Shazeer"],
+        "published": "2017-06-12T17:57:34Z",
+    }
+    assert by_id["2608.18261"]["authors"] == ["Ada Lovelace"]
+
+
+@pytest.mark.asyncio
+async def test_list_papers_compact_returns_ids_only(storage):
+    """compact=true keeps the previous IDs-only response shape."""
+    _write_paper(
+        storage,
+        "1706.03762",
+        metadata={
+            "title": "Attention Is All You Need",
+            "authors": ["A"],
+            "published": "2017",
+        },
+    )
+
+    response = await handle_list_papers({"compact": True})
+    payload = json.loads(response[0].text)
+
+    assert payload["total_papers"] == 1
+    assert payload["papers"] == ["1706.03762"]
+
+
+@pytest.mark.asyncio
+async def test_list_papers_uses_markdown_title_without_network(storage, mocker):
+    """Already-downloaded papers without a sidecar still stay local."""
+    _write_paper(storage, "2401.12345", markdown="# Cached Title\nMore text")
+    httpx_get = mocker.patch("httpx.AsyncClient")
+    arxiv_search = mocker.patch(
+        "arxiv.Search", side_effect=AssertionError("live fetch")
+    )
+
+    response = await handle_list_papers({})
+    payload = json.loads(response[0].text)
+
+    assert payload["papers"] == [
+        {
+            "id": "2401.12345",
+            "title": "Cached Title",
+            "authors": [],
+            "published": None,
+        }
+    ]
+    httpx_get.assert_not_called()
+    arxiv_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_papers_ignores_unreadable_sidecar(storage):
+    """Corrupt sidecar must not fail the listing."""
+    _write_paper(storage, "2401.00001", markdown="Fallback Title\nBody")
+    (storage / "2401.00001.meta.json").write_text("{not-json", encoding="utf-8")
+
+    response = await handle_list_papers({})
+    payload = json.loads(response[0].text)
+
+    assert payload["papers"][0]["id"] == "2401.00001"
+    assert payload["papers"][0]["title"] == "Fallback Title"


### PR DESCRIPTION
## Summary
- `list_papers` only returned markdown stems. Download stored no title/authors/published sidecar.
- Default list is now `{id, title, authors, published}` from a `.meta.json` sidecar (no live re-fetch).
- `compact=true` keeps the old IDs-only shape.
- `download_paper` writes the sidecar. Older papers without one fall back to the first markdown line as title.

Closes #161

## Test plan
- [x] `uv run pytest tests/tools/test_list_papers.py tests/tools/test_download.py tests/test_tool_schemas.py` (28 passed)
- [ ] CI