### PR TITLE
fix: point [pro] install error at uvx, not a git checkout

### DIFF
--- a/src/arxiv_mcp_server/tools/semantic_search.py
+++ b/src/arxiv_mcp_server/tools/semantic_search.py
@@ -53,7 +53,8 @@ semantic_search_tool = types.Tool(
         "IMPORTANT: only searches your local downloaded collection — will return empty results if no papers "
         "have been downloaded yet. Use search_papers to find papers on arXiv, then download_paper to add "
         "them to the local index before using this tool. "
-        'Requires pro dependencies: uv pip install -e ".[pro]"'
+        "Requires pro dependencies: uvx --from 'arxiv-mcp-server[pro]' arxiv-mcp-server "
+        "(or uv tool install 'arxiv-mcp-server[pro]')."
     ),
     inputSchema={
         "type": "object",
@@ -116,8 +117,10 @@ def _dependency_error() -> Optional[str]:
     """Return a friendly dependency error if pro packages are missing."""
     if not _load_dependencies():
         return (
-            "Pro feature dependency missing. Install with: "
-            '`uv pip install -e ".[pro]"`'
+            "Pro feature dependency missing. Install with "
+            "`uvx --from 'arxiv-mcp-server[pro]' arxiv-mcp-server` "
+            "(or `uv tool install 'arxiv-mcp-server[pro]'`). "
+            'For a local checkout: `uv pip install -e ".[pro]"`.'
         )
     return None
 

--- a/tests/tools/test_semantic_search.py
+++ b/tests/tools/test_semantic_search.py
@@ -7,13 +7,41 @@ import pytest
 
 from arxiv_mcp_server.tools import semantic_search as semantic_module
 
-np = pytest.importorskip("numpy")
+EDITABLE_PRO_INSTALL = 'uv pip install -e ".[pro]"'
+
+
+def _assert_pro_install_hint(message: str) -> None:
+    """uvx users should see a PyPI extra path; checkout install is secondary."""
+    assert message
+    assert "uvx" in message
+    assert "arxiv-mcp-server[pro]" in message
+    assert message.index("uvx") < message.index(EDITABLE_PRO_INSTALL)
+
+
+@pytest.mark.asyncio
+async def test_missing_pro_deps_error_mentions_uvx(monkeypatch):
+    """Missing [pro] extras should not point only at a git-checkout install."""
+    monkeypatch.setattr(semantic_module, "_load_dependencies", lambda: False)
+
+    hint = semantic_module._dependency_error()
+    _assert_pro_install_hint(hint)
+    assert hint.count("uvx") >= 1
+    assert "uv tool install" in hint
+
+    search = await semantic_module.handle_semantic_search({"query": "transformers"})
+    _assert_pro_install_hint(search[0].text)
+
+    reindex = await semantic_module.handle_reindex({})
+    payload = json.loads(reindex[0].text)
+    assert payload["status"] == "error"
+    _assert_pro_install_hint(payload["message"])
 
 
 class DummyModel:
     """Deterministic embedding model for tests."""
 
     def encode(self, text, convert_to_numpy=True, normalize_embeddings=True):
+        np = pytest.importorskip("numpy")
         vector = np.array(
             [
                 float("transformer" in text.lower()),
@@ -31,6 +59,7 @@ class DummyModel:
 @pytest.fixture
 def semantic_test_env(monkeypatch, temp_storage_path):
     """Configure semantic search module to use a temporary index and dummy model."""
+    np = pytest.importorskip("numpy")
     monkeypatch.setattr(
         semantic_module.settings,
         "_get_storage_path_from_args",


### PR DESCRIPTION
uvx users who hit `semantic_search` / `reindex` without the `[pro]` extra were told to run `uv pip install -e ".[pro]"`, which only works from a local checkout. The error now leads with the PyPI extra install they actually used, and keeps the editable command as a secondary hint.

Closes #163

## Test plan
- [x] `uv run pytest tests/tools/test_semantic_search.py` — 4 passed
- [x] `uv run black --check` on touched files
- [ ] Call `semantic_search` from a `uvx arxiv-mcp-server` install without `[pro]` and confirm the hint mentions `uvx --from 'arxiv-mcp-server[pro]' arxiv-mcp-server` and `uv tool install 'arxiv-mcp-server[pro]'`
- [ ] Confirm a local checkout still sees `uv pip install -e ".[pro]"` as the secondary path