### PR TITLE
fix: report arXiv totalResults instead of page size

### DIFF
--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -62,6 +62,7 @@ ARXIV_API_URL = "https://export.arxiv.org/api/query"
 ARXIV_NS = {
     "atom": "http://www.w3.org/2005/Atom",
     "arxiv": "http://arxiv.org/schemas/atom",
+    "opensearch": "http://a9.com/-/spec/opensearch/1.1/",
 }
 
 # Valid arXiv category prefixes for validation
@@ -211,13 +212,16 @@ async def _raw_arxiv_search(
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
     categories: Optional[List[str]] = None,
-) -> List[Dict[str, Any]]:
+) -> tuple[List[Dict[str, Any]], Optional[int]]:
     """
     Perform arXiv search using raw HTTP requests.
 
     This bypasses the arxiv Python package to avoid URL encoding issues
     with date filters. The arxiv package encodes '+' as '%2B' which breaks
     the submittedDate:[YYYYMMDD TO YYYYMMDD] syntax.
+
+    Returns (papers, total_results) where total_results is the OpenSearch
+    corpus hit count from the Atom feed, not the page size.
     """
     url = build_arxiv_search_url(
         query,
@@ -233,8 +237,49 @@ async def _raw_arxiv_search(
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await _rate_limited_get(client, url)
 
-    # Parse the Atom XML response
-    return _parse_arxiv_atom_response(response.text)
+    papers = _parse_arxiv_atom_response(response.text)
+    return papers, _parse_opensearch_total_results(response.text)
+
+
+def _parse_opensearch_total_results(xml_text: str) -> Optional[int]:
+    """Return arXiv OpenSearch totalResults, or None if the feed omits it."""
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return None
+
+    elem = root.find("opensearch:totalResults", ARXIV_NS)
+    if elem is None:
+        # Some feeds use a different prefix or the 1.0 namespace.
+        for child in list(root):
+            tag = child.tag.rsplit("}", 1)[-1]
+            if tag == "totalResults":
+                elem = child
+                break
+    if elem is None or elem.text is None:
+        return None
+    try:
+        return int(elem.text.strip())
+    except ValueError:
+        return None
+
+
+def _build_search_response(
+    papers: List[Dict[str, Any]],
+    *,
+    total_results: Optional[int] = None,
+    has_more: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Assemble search JSON. Never report page size as total_results."""
+    returned = len(papers)
+    response: Dict[str, Any] = {"returned": returned, "papers": papers}
+    if total_results is not None:
+        response["total_results"] = total_results
+        if has_more is None:
+            has_more = total_results > returned
+    if has_more is not None:
+        response["has_more"] = bool(has_more)
+    return response
 
 
 def _parse_arxiv_atom_response(xml_text: str) -> List[Dict[str, Any]]:
@@ -384,6 +429,7 @@ DATE FILTERING: Use YYYY-MM-DD format for historical research:
 
 RESULT QUALITY: Default sort is RELEVANCE (most pertinent results first). Use sort_by: "date" to get newest papers first.
 Choose relevance for focused topic searches; choose date for monitoring recent developments.
+Each response reports total_results (arXiv corpus hit count, not page size), returned (papers in this page), and has_more.
 
 RATE LIMITING: arXiv enforces a 3-second minimum between requests. This server handles that automatically.
 If you see a rate limit error, wait 60 seconds before retrying — do not call the tool repeatedly in a loop.
@@ -397,7 +443,7 @@ TIPS FOR FOUNDATIONAL RESEARCH:
         "properties": {
             "query": {
                 "type": "string",
-                "description": 'Search query using quoted phrases for exact matches (e.g., \'"machine learning" OR "deep learning"\') or specific technical terms. Avoid overly broad or generic terms.',
+                "description": "Search query using quoted phrases for exact matches (e.g., '\"machine learning\" OR \"deep learning\"') or specific technical terms. Avoid overly broad or generic terms.",
             },
             "max_results": {
                 "type": "integer",
@@ -521,7 +567,7 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 optimized_query = (
                     _optimize_query(base_query) if base_query.strip() else ""
                 )
-                results = await _raw_arxiv_search(
+                results, total_results = await _raw_arxiv_search(
                     query=optimized_query,
                     max_results=max_results,
                     sort_by=sort_by_arg,
@@ -533,7 +579,9 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 logger.info(
                     f"Raw API search completed: {len(results)} results returned"
                 )
-                response_data = {"total_results": len(results), "papers": results}
+                response_data = _build_search_response(
+                    results, total_results=total_results
+                )
 
                 return [
                     types.TextContent(
@@ -590,23 +638,25 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
             sort_criterion = arxiv.SortCriterion.Relevance
             logger.debug("Using relevance sorting (most relevant first)")
 
+        # Request one extra hit so has_more is real, not a page-size guess.
+        fetch_limit = max_results + 1
         search = arxiv.Search(
             query=final_query,
-            max_results=max_results,
+            max_results=fetch_limit,
             sort_by=sort_criterion,
         )
 
         def fetch_results() -> List[Dict[str, Any]]:
-            client.page_size = max_results
+            client.page_size = fetch_limit
             results = []
             for paper in client.results(search):
-                if len(results) >= max_results:
-                    break
                 results.append(_process_paper(paper))
+                if len(results) >= fetch_limit:
+                    break
             return results
 
         try:
-            results = await asyncio.to_thread(
+            fetched = await asyncio.to_thread(
                 ARXIV_RATE_LIMITER.run_sync, fetch_results
             )
         except arxiv.ArxivError as e:
@@ -617,8 +667,10 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 )
             raise
 
+        has_more = len(fetched) > max_results
+        results = fetched[:max_results]
         logger.info(f"Search completed: {len(results)} results returned")
-        response_data = {"total_results": len(results), "papers": results}
+        response_data = _build_search_response(results, has_more=has_more)
 
         return [
             types.TextContent(type="text", text=json.dumps(response_data, indent=2))

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -9,6 +9,8 @@ from arxiv_mcp_server.tools.search import (
     _validate_categories,
     _raw_arxiv_search,
     _parse_arxiv_atom_response,
+    _parse_opensearch_total_results,
+    _build_search_response,
     _scope_user_query,
     build_arxiv_search_query,
     build_arxiv_search_url,
@@ -33,7 +35,9 @@ async def test_basic_search(mock_client):
 
         assert len(result) == 1
         content = json.loads(result[0].text)
-        assert content["total_results"] == 1
+        assert content["returned"] == 1
+        assert "total_results" not in content
+        assert content["has_more"] is False
         paper = content["papers"][0]
         assert paper["id"] == "2103.12345"
         assert paper["title"] == "Test Paper"
@@ -70,16 +74,17 @@ async def test_search_with_categories(mock_client):
 @pytest.mark.asyncio
 async def test_search_with_dates():
     """Test paper search with date filtering uses raw API."""
-    mock_xml_response = """<?xml version="1.0" encoding="UTF-8"?>
-    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+    mock_xml_response = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:arxiv=\"http://arxiv.org/schemas/atom\" xmlns:opensearch=\"http://a9.com/-/spec/opensearch/1.1/\">
+        <opensearch:totalResults>42</opensearch:totalResults>
         <entry>
             <id>http://arxiv.org/abs/2301.00001v1</id>
             <title>Test Paper</title>
             <summary>Test abstract</summary>
             <published>2023-06-15T00:00:00Z</published>
             <author><name>Test Author</name></author>
-            <arxiv:primary_category term="cs.AI"/>
-            <link title="pdf" href="http://arxiv.org/pdf/2301.00001v1"/>
+            <arxiv:primary_category term=\"cs.AI\"/>
+            <link title=\"pdf\" href=\"http://arxiv.org/pdf/2301.00001v1\"/>
         </entry>
     </feed>"""
 
@@ -104,7 +109,9 @@ async def test_search_with_dates():
         )
 
         content = json.loads(result[0].text)
-        assert content["total_results"] == 1
+        assert content["total_results"] == 42
+        assert content["returned"] == 1
+        assert content["has_more"] is True
         assert len(content["papers"]) == 1
 
 
@@ -131,8 +138,8 @@ def test_validate_categories():
 
 def test_parse_arxiv_atom_response():
     """Test parsing of arXiv Atom XML response."""
-    sample_xml = """<?xml version="1.0" encoding="UTF-8"?>
-    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+    sample_xml = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:arxiv=\"http://arxiv.org/schemas/atom\">
         <entry>
             <id>http://arxiv.org/abs/2301.00001v1</id>
             <title>Test Paper Title</title>
@@ -140,10 +147,10 @@ def test_parse_arxiv_atom_response():
             <published>2023-01-01T00:00:00Z</published>
             <author><name>John Doe</name></author>
             <author><name>Jane Smith</name></author>
-            <arxiv:primary_category term="cs.AI"/>
-            <category term="cs.AI"/>
-            <category term="cs.LG"/>
-            <link title="pdf" href="http://arxiv.org/pdf/2301.00001v1"/>
+            <arxiv:primary_category term=\"cs.AI\"/>
+            <category term=\"cs.AI\"/>
+            <category term=\"cs.LG\"/>
+            <link title=\"pdf\" href=\"http://arxiv.org/pdf/2301.00001v1\"/>
         </entry>
     </feed>"""
 
@@ -165,8 +172,8 @@ async def test_raw_arxiv_search_builds_correct_url():
 
     # Mock the httpx client
     mock_response = MagicMock()
-    mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
-    <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+    mock_response.text = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:arxiv=\"http://arxiv.org/schemas/atom\">
     </feed>"""
     mock_response.raise_for_status = MagicMock()
 
@@ -276,7 +283,8 @@ async def test_search_reuses_client_and_updates_page_size_inside_gate(
         await handle_search({"query": "second", "max_results": 7})
 
     mock_client_class.assert_called_once_with()
-    assert observed_page_sizes == [5, 7]
+    # Client path requests max_results+1 so has_more is not a page-size guess.
+    assert observed_page_sizes == [6, 8]
 
 
 @pytest.mark.asyncio
@@ -378,3 +386,106 @@ def test_raw_search_url_groups_or_phrase_with_categories_and_date():
     assert "sortBy=submittedDate" in url
     decoded = unquote(url)
     assert '"mixture of experts" OR MoE' in decoded
+
+
+def _atom_feed_with_totals(entry_count: int, total_results: int) -> str:
+    """Build a minimal arXiv Atom feed with OpenSearch totalResults."""
+    entries = []
+    for i in range(entry_count):
+        n = i + 1
+        entries.append(f"""
+        <entry>
+            <id>http://arxiv.org/abs/2301.0000{n}v1</id>
+            <title>Test Paper {n}</title>
+            <summary>Test abstract {n}</summary>
+            <published>2023-01-0{n}T00:00:00Z</published>
+            <author><name>Test Author</name></author>
+            <arxiv:primary_category term=\"cs.AI\"/>
+            <link title=\"pdf\" href=\"http://arxiv.org/pdf/2301.0000{n}v1\"/>
+        </entry>""")
+    return f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <feed xmlns=\"http://www.w3.org/2005/Atom\"
+          xmlns:arxiv=\"http://arxiv.org/schemas/atom\"
+          xmlns:opensearch=\"http://a9.com/-/spec/opensearch/1.1/\">
+        <opensearch:totalResults>{total_results}</opensearch:totalResults>
+        {''.join(entries)}
+    </feed>"""
+
+
+def test_parse_opensearch_total_results_from_atom_feed():
+    """Atom totalResults is the corpus count, not the number of entries."""
+    xml = _atom_feed_with_totals(entry_count=5, total_results=1234)
+    papers = _parse_arxiv_atom_response(xml)
+    assert len(papers) == 5
+    assert _parse_opensearch_total_results(xml) == 1234
+
+    payload = _build_search_response(papers, total_results=1234)
+    assert payload["total_results"] == 1234
+    assert payload["returned"] == 5
+    assert payload["has_more"] is True
+    assert len(payload["papers"]) == 5
+
+
+def test_build_search_response_never_aliases_page_size_as_total():
+    """A 5-paper page must not report total_results=5 when the feed says otherwise."""
+    papers = [{"id": str(i)} for i in range(5)]
+    payload = _build_search_response(papers, total_results=1234)
+    assert payload["total_results"] == 1234
+    assert payload["returned"] == 5
+    assert payload["total_results"] != payload["returned"]
+
+
+@pytest.mark.asyncio
+async def test_search_reports_feed_total_results_not_page_size():
+    """max_results=5 must not force total_results=5 when the feed says 1234."""
+    mock_response = MagicMock()
+    mock_response.text = _atom_feed_with_totals(entry_count=5, total_results=1234)
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        result = await handle_search(
+            {
+                "query": "transformers",
+                "date_from": "2020-01-01",
+                "max_results": 5,
+            }
+        )
+
+    content = json.loads(result[0].text)
+    assert content["total_results"] == 1234
+    assert content["returned"] == 5
+    assert content["has_more"] is True
+    assert len(content["papers"]) == 5
+    assert content["total_results"] != content["returned"]
+
+
+@pytest.mark.asyncio
+async def test_client_path_has_more_from_extra_fetched_paper(mock_paper):
+    """Without Atom totals, the client path uses max_results+1 to set has_more."""
+    extra = MagicMock()
+    extra.get_short_id.return_value = "2103.99999"
+    extra.title = "Extra Paper"
+    extra.authors = mock_paper.authors
+    extra.summary = "Extra abstract"
+    extra.categories = ["cs.LG"]
+    extra.published = mock_paper.published
+    extra.pdf_url = "https://arxiv.org/pdf/2103.99999"
+
+    client = MagicMock()
+    client.results.return_value = [mock_paper, extra]
+
+    with patch("arxiv_mcp_server.tools.search.get_arxiv_client", return_value=client):
+        result = await handle_search({"query": "test query", "max_results": 1})
+
+    content = json.loads(result[0].text)
+    assert content["returned"] == 1
+    assert content["has_more"] is True
+    assert "total_results" not in content
+    assert len(content["papers"]) == 1
+    assert content["papers"][0]["id"] == "2103.12345"


### PR DESCRIPTION
## Summary

`search_papers` was reporting `total_results` as `len(papers)` — the page size — so every `max_results: 5` call returned `total_results: 5`. Agents could not tell a short page from a 5,000-hit corpus.

- Raw HTTP path now parses Atom `opensearch:totalResults` and returns that as `total_results`, plus `returned` (this page) and `has_more`.
- The `arxiv.Client` path cannot see OpenSearch totals, so it requests `max_results+1`, trims the extra hit, and sets `has_more` without naming page size `total_results`.
- Date-filter / scoped-query behavior from #159 is unchanged.

**Not in this PR:** compact/paginated search modes remain open as #128.

Closes #165.

## Test plan

- [x] Mocked Atom feed with `totalResults=1234` and 5 entries → `total_results=1234`, `returned=5`
- [x] `max_results=5` does not force `total_results=5` when the feed says otherwise
- [x] Existing search query-construction tests still pass (#159 OR + date + categories)
- [x] `uv run pytest tests/tools/test_search.py tests/test_tool_schemas.py` — 23 passed
- [x] `uv run black --check` on the changed files