### PR TITLE
fix: accept arxiv: IDs and reject invalid ones cleanly

### DIFF
--- a/src/arxiv_mcp_server/tools/arxiv_ids.py
+++ b/src/arxiv_mcp_server/tools/arxiv_ids.py
@@ -1,0 +1,58 @@
+"""Shared arXiv identifier normalization and validation.
+
+Used by tools that accept a paper_id so ``arxiv:`` prefixes and common
+abs/pdf URL wrappers are stripped before lookup, and invalid IDs never
+reach the arXiv API.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Matches both new-style (YYMM.NNNNN) and old-style (cat/YYMMNNN) arXiv IDs,
+# with optional version suffix (v1, v2, …).
+_ARXIV_ID_RE = re.compile(
+    r"^(\d{4}\.\d{4,5}(v\d+)?"  # new-style: 2404.18922 or 2404.18922v3
+    r"|[a-z\-]+(/[a-z\-]+)?/\d{7}(v\d+)?)$",  # old-style: hep-ph/9901234
+    re.IGNORECASE,
+)
+
+_PREFIX_RE = re.compile(r"^arxiv:", re.IGNORECASE)
+
+# Cheap wrappers: optional scheme, optional www, arxiv.org/(abs|pdf)/ID[.pdf]
+_URL_RE = re.compile(
+    r"^(?:https?://)?(?:www\.)?arxiv\.org/(?:abs|pdf)/([^?#]+?)(?:\.pdf)?/?$",
+    re.IGNORECASE,
+)
+
+
+def is_valid_arxiv_id(stem: str) -> bool:
+    """Return True if *stem* looks like a valid arXiv paper ID."""
+    return bool(_ARXIV_ID_RE.match(stem))
+
+
+def normalize_arxiv_id(raw: str) -> str:
+    """Strip whitespace, ``arxiv:`` prefixes, and common abs/pdf URL wrappers.
+
+    Version suffixes (e.g. ``v7``) are preserved. Invalid input is returned
+    in best-effort stripped form so callers can validate separately.
+    """
+    value = raw.strip()
+    url_match = _URL_RE.match(value)
+    if url_match:
+        value = url_match.group(1).strip()
+    # Query/fragment may remain if the caller passed a bare ID?query — drop them.
+    value = value.split("?", 1)[0].split("#", 1)[0].strip()
+    value = _PREFIX_RE.sub("", value).strip()
+    return value
+
+
+def parse_arxiv_id(raw: str) -> Optional[str]:
+    """Normalize *raw* and return it only if it is a valid arXiv ID."""
+    if not isinstance(raw, str):
+        return None
+    normalized = normalize_arxiv_id(raw)
+    if not normalized or not is_valid_arxiv_id(normalized):
+        return None
+    return normalized

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -13,6 +13,7 @@ import mcp.types as types
 from mcp.types import ToolAnnotations
 
 from ..config import Settings
+from .arxiv_ids import is_valid_arxiv_id, normalize_arxiv_id
 
 logger = logging.getLogger("arxiv-mcp-server")
 settings = Settings()
@@ -157,9 +158,13 @@ def _bound_max_citations(value: Any) -> int:
 async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Handle citation graph lookup for a single arXiv paper ID."""
     try:
-        paper_id = arguments["paper_id"].strip()
+        paper_id = normalize_arxiv_id(arguments["paper_id"])
         if not paper_id:
             return [types.TextContent(type="text", text="Error: paper_id is required")]
+        if not is_valid_arxiv_id(paper_id):
+            return [
+                types.TextContent(type="text", text="Error: invalid arXiv ID format")
+            ]
 
         limit = _bound_max_citations(arguments.get("max_citations"))
         s2_paper_identifier = quote(f"ARXIV:{paper_id}", safe=":")

--- a/src/arxiv_mcp_server/tools/export_citations.py
+++ b/src/arxiv_mcp_server/tools/export_citations.py
@@ -16,7 +16,7 @@ import httpx
 import mcp.types as types
 from mcp.types import ToolAnnotations
 
-from .list_papers import is_valid_arxiv_id
+from .arxiv_ids import is_valid_arxiv_id, normalize_arxiv_id
 from .search import ARXIV_API_URL, _parse_arxiv_atom_response, _rate_limited_get
 
 logger = logging.getLogger("arxiv-mcp-server")
@@ -195,17 +195,19 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
         if len(raw_ids) > MAX_IDS:
             return _error(f"too many IDs: {len(raw_ids)} (max {MAX_IDS})")
 
-        valid_ids = [
-            pid.strip()
-            for pid in raw_ids
-            if isinstance(pid, str) and is_valid_arxiv_id(pid.strip())
-        ]
+        valid_ids = []
+        for pid in raw_ids:
+            if not isinstance(pid, str):
+                continue
+            candidate = normalize_arxiv_id(pid)
+            if is_valid_arxiv_id(candidate):
+                valid_ids.append(candidate)
         metadata = await _fetch_metadata(valid_ids) if valid_ids else {}
 
         results: List[Dict[str, Any]] = []
         used_keys: set = set()
         for pid in raw_ids:
-            candidate = pid.strip() if isinstance(pid, str) else ""
+            candidate = normalize_arxiv_id(pid) if isinstance(pid, str) else ""
             if not candidate or not is_valid_arxiv_id(candidate):
                 results.append(
                     {

--- a/src/arxiv_mcp_server/tools/get_abstract.py
+++ b/src/arxiv_mcp_server/tools/get_abstract.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 import mcp.types as types
 from mcp.types import ToolAnnotations
 
+from .arxiv_ids import parse_arxiv_id
 from .search import _rate_limited_get, ARXIV_API_URL
 import httpx
 import xml.etree.ElementTree as ET
@@ -39,7 +40,8 @@ abstract_tool = types.Tool(
 async def handle_get_abstract(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Fetch paper metadata via arXiv API without downloading the full paper."""
     try:
-        paper_id = arguments["paper_id"].strip()
+        raw_id = arguments["paper_id"]
+        paper_id = raw_id.strip() if isinstance(raw_id, str) else ""
         if not paper_id:
             return [
                 types.TextContent(
@@ -49,6 +51,18 @@ async def handle_get_abstract(arguments: Dict[str, Any]) -> List[types.TextConte
                     ),
                 )
             ]
+
+        parsed = parse_arxiv_id(paper_id)
+        if parsed is None:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {"status": "error", "message": "invalid arXiv ID format"}
+                    ),
+                )
+            ]
+        paper_id = parsed
 
         url = f"{ARXIV_API_URL}?id_list={paper_id}&max_results=1"
 
@@ -128,6 +142,19 @@ async def handle_get_abstract(arguments: Dict[str, Any]) -> List[types.TextConte
         return [
             types.TextContent(
                 type="text", text=json.dumps({"status": "error", "message": str(e)})
+            )
+        ]
+    except httpx.HTTPStatusError:
+        # Never leak upstream status lines / URLs (issue #166).
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "status": "error",
+                        "message": f"Paper {paper_id} not found on arXiv",
+                    }
+                ),
             )
         ]
     except Exception as e:

--- a/src/arxiv_mcp_server/tools/list_papers.py
+++ b/src/arxiv_mcp_server/tools/list_papers.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -10,24 +9,12 @@ import mcp.types as types
 from mcp.types import ToolAnnotations
 
 from ..config import Settings
+from .arxiv_ids import is_valid_arxiv_id
 
 settings = Settings()
 logger = logging.getLogger("arxiv-mcp-server")
 
-# Matches both new-style (YYMM.NNNNN) and old-style (cat/YYMMNNN) arXiv IDs,
-# with optional version suffix (v1, v2, …).
-_ARXIV_ID_RE = re.compile(
-    r"^(\d{4}\.\d{4,5}(v\d+)?"  # new-style: 2404.18922 or 2404.18922v3
-    r"|[a-z\-]+(/[a-z\-]+)?/\d{7}(v\d+)?)$",  # old-style: hep-ph/9901234
-    re.IGNORECASE,
-)
-
 METADATA_SUFFIX = ".meta.json"
-
-
-def is_valid_arxiv_id(stem: str) -> bool:
-    """Return True if *stem* looks like a valid arXiv paper ID."""
-    return bool(_ARXIV_ID_RE.match(stem))
 
 
 list_tool = types.Tool(

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, List
 import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings
+from .arxiv_ids import normalize_arxiv_id
 from .content import add_content_payload
 
 settings = Settings()
@@ -58,7 +59,7 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
     """Handle requests to read a paper's content."""
     try:
         paper_ids = list_papers()
-        paper_id = arguments["paper_id"]
+        paper_id = normalize_arxiv_id(arguments["paper_id"])
         # Check if paper exists
         if paper_id not in paper_ids:
             return [

--- a/tests/tools/test_arxiv_ids.py
+++ b/tests/tools/test_arxiv_ids.py
@@ -1,0 +1,66 @@
+"""Unit tests for shared arXiv ID normalize + validate helpers."""
+
+import pytest
+
+from arxiv_mcp_server.tools.arxiv_ids import (
+    is_valid_arxiv_id,
+    normalize_arxiv_id,
+    parse_arxiv_id,
+)
+from arxiv_mcp_server.tools.list_papers import is_valid_arxiv_id as list_reexport
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("1706.03762", "1706.03762"),
+        ("1706.03762v7", "1706.03762v7"),
+        ("  1706.03762v7  ", "1706.03762v7"),
+        ("arxiv:1706.03762v7", "1706.03762v7"),
+        ("arXiv:1706.03762v7", "1706.03762v7"),
+        ("ARXIV:1706.03762", "1706.03762"),
+        ("https://arxiv.org/abs/1706.03762", "1706.03762"),
+        ("https://arxiv.org/abs/1706.03762v7", "1706.03762v7"),
+        ("http://arxiv.org/abs/1706.03762", "1706.03762"),
+        ("https://www.arxiv.org/abs/1706.03762", "1706.03762"),
+        ("https://arxiv.org/pdf/1706.03762.pdf", "1706.03762"),
+        ("https://arxiv.org/pdf/1706.03762v7.pdf", "1706.03762v7"),
+        ("arxiv.org/abs/1706.03762", "1706.03762"),
+        ("hep-th/9901001", "hep-th/9901001"),
+        ("https://arxiv.org/abs/hep-th/9901001", "hep-th/9901001"),
+        ("https://arxiv.org/pdf/hep-th/9901001.pdf", "hep-th/9901001"),
+        ("arxiv:hep-th/9901001v1", "hep-th/9901001v1"),
+    ],
+)
+def test_normalize_arxiv_id(raw, expected):
+    assert normalize_arxiv_id(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("arxiv:1706.03762v7", "1706.03762v7"),
+        ("https://arxiv.org/abs/1706.03762", "1706.03762"),
+        ("https://arxiv.org/pdf/1706.03762v7.pdf", "1706.03762v7"),
+        ("hep-th/9901001", "hep-th/9901001"),
+        ("2401.12345", "2401.12345"),
+    ],
+)
+def test_parse_arxiv_id_accepts_wrappers(raw, expected):
+    assert parse_arxiv_id(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "   ", "not-a-paper", "garbage!!!", "arxiv:not-a-paper", "1234", "abcd"],
+)
+def test_parse_arxiv_id_rejects_garbage(raw):
+    assert parse_arxiv_id(raw) is None
+
+
+def test_is_valid_arxiv_id_reexported_from_list_papers():
+    """Existing importers of list_papers.is_valid_arxiv_id keep working."""
+    assert list_reexport is is_valid_arxiv_id
+    assert is_valid_arxiv_id("1706.03762v7")
+    assert is_valid_arxiv_id("hep-th/9901001")
+    assert not is_valid_arxiv_id("not-a-paper")

--- a/tests/tools/test_paper_id_normalize.py
+++ b/tests/tools/test_paper_id_normalize.py
@@ -9,17 +9,17 @@ from arxiv_mcp_server.tools.get_abstract import handle_get_abstract
 from arxiv_mcp_server.tools import export_citations as ec
 
 FULL_ATOM_XML = """\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<feed xmlns=\"http://www.w3.org/2005/Atom\"
-      xmlns:arxiv=\"http://arxiv.org/schemas/atom\">
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:arxiv="http://arxiv.org/schemas/atom">
   <entry>
     <id>http://arxiv.org/abs/1706.03762v7</id>
     <title>Attention Is All You Need</title>
     <summary>We propose a novel model.</summary>
     <published>2017-06-12T00:00:00Z</published>
     <author><name>Ashish Vaswani</name></author>
-    <arxiv:primary_category term=\"cs.CL\"/>
-    <link title=\"pdf\" href=\"https://arxiv.org/pdf/1706.03762v7\"/>
+    <arxiv:primary_category term="cs.CL"/>
+    <link title="pdf" href="https://arxiv.org/pdf/1706.03762v7"/>
   </entry>
 </feed>
 """
@@ -36,17 +36,17 @@ def _mock_rate_limited_get(xml_text: str):
 
 
 def _paper(
-    pid, title, authors, published=\"2017-06-12T00:00:00Z\", categories=(\"cs.CL\",)
+    pid, title, authors, published="2017-06-12T00:00:00Z", categories=("cs.CL",)
 ):
     return {
-        \"id\": pid,
-        \"title\": title,
-        \"authors\": list(authors),
-        \"abstract\": \"[EXTERNAL CONTENT] x\",
-        \"categories\": list(categories),
-        \"published\": published,
-        \"url\": f\"https://arxiv.org/pdf/{pid}\",
-        \"resource_uri\": f\"arxiv://{pid}\",
+        "id": pid,
+        "title": title,
+        "authors": list(authors),
+        "abstract": "[EXTERNAL CONTENT] x",
+        "categories": list(categories),
+        "published": published,
+        "url": f"https://arxiv.org/pdf/{pid}",
+        "resource_uri": f"arxiv://{pid}",
     }
 
 
@@ -55,104 +55,104 @@ def _stub_metadata(monkeypatch, papers, recorder=None):
         if recorder is not None:
             recorder.extend(ids)
         bases = {ec._base_id(i) for i in ids}
-        return {p[\"id\"]: p for p in papers if p[\"id\"] in bases}
+        return {p["id"]: p for p in papers if p["id"] in bases}
 
-    monkeypatch.setattr(ec, \"_fetch_metadata\", _fake)
+    monkeypatch.setattr(ec, "_fetch_metadata", _fake)
 
 
 async def _run(arguments):
     result = await ec.handle_export_citations(arguments)
-    assert len(result) == 1 and result[0].type == \"text\"
+    assert len(result) == 1 and result[0].type == "text"
     return json.loads(result[0].text)
 
 
 @pytest.mark.asyncio
 async def test_arxiv_prefix_id_normalizes_and_succeeds(mocker):
-    \"\"\"arxiv:1706.03762v7 is stripped to 1706.03762v7 before the API call.\"\"\"
+    """arxiv:1706.03762v7 is stripped to 1706.03762v7 before the API call."""
     mock_get = _mock_rate_limited_get(FULL_ATOM_XML)
     mocker.patch(
-        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        "arxiv_mcp_server.tools.get_abstract._rate_limited_get",
         mock_get,
     )
-    result = await handle_get_abstract({\"paper_id\": \"arxiv:1706.03762v7\"})
+    result = await handle_get_abstract({"paper_id": "arxiv:1706.03762v7"})
     data = json.loads(result[0].text)
-    assert data[\"status\"] == \"success\"
-    assert data[\"paper_id\"] == \"1706.03762v7\"
+    assert data["status"] == "success"
+    assert data["paper_id"] == "1706.03762v7"
     mock_get.assert_awaited_once()
     called_url = mock_get.await_args.args[1]
-    assert \"id_list=1706.03762v7\" in called_url
-    assert \"arxiv:\" not in called_url
+    assert "id_list=1706.03762v7" in called_url
+    assert "arxiv:" not in called_url
 
 
 @pytest.mark.asyncio
 async def test_abs_url_normalizes_and_succeeds(mocker):
-    \"\"\"https://arxiv.org/abs/1706.03762 is extracted before the API call.\"\"\"
+    """https://arxiv.org/abs/1706.03762 is extracted before the API call."""
     mock_get = _mock_rate_limited_get(FULL_ATOM_XML)
     mocker.patch(
-        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        "arxiv_mcp_server.tools.get_abstract._rate_limited_get",
         mock_get,
     )
-    result = await handle_get_abstract({\"paper_id\": \"https://arxiv.org/abs/1706.03762\"})
+    result = await handle_get_abstract({"paper_id": "https://arxiv.org/abs/1706.03762"})
     data = json.loads(result[0].text)
-    assert data[\"status\"] == \"success\"
-    assert data[\"paper_id\"] == \"1706.03762\"
+    assert data["status"] == "success"
+    assert data["paper_id"] == "1706.03762"
     mock_get.assert_awaited_once()
     called_url = mock_get.await_args.args[1]
-    assert \"id_list=1706.03762\" in called_url
-    assert \"arxiv.org/abs\" not in called_url
+    assert "id_list=1706.03762" in called_url
+    assert "arxiv.org/abs" not in called_url
 
 
 @pytest.mark.asyncio
 async def test_pdf_url_normalizes_and_succeeds(mocker):
     mock_get = _mock_rate_limited_get(FULL_ATOM_XML)
     mocker.patch(
-        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        "arxiv_mcp_server.tools.get_abstract._rate_limited_get",
         mock_get,
     )
     result = await handle_get_abstract(
-        {\"paper_id\": \"https://arxiv.org/pdf/1706.03762v7.pdf\"}
+        {"paper_id": "https://arxiv.org/pdf/1706.03762v7.pdf"}
     )
     data = json.loads(result[0].text)
-    assert data[\"status\"] == \"success\"
-    assert data[\"paper_id\"] == \"1706.03762v7\"
+    assert data["status"] == "success"
+    assert data["paper_id"] == "1706.03762v7"
     called_url = mock_get.await_args.args[1]
-    assert \"id_list=1706.03762v7\" in called_url
+    assert "id_list=1706.03762v7" in called_url
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    \"paper_id\",
-    [\"not-a-paper\", \"garbage!!!\", \"arxiv:not-a-paper\", \"just some text\"],
+    "paper_id",
+    ["not-a-paper", "garbage!!!", "arxiv:not-a-paper", "just some text"],
 )
 async def test_invalid_paper_id_does_not_call_http(mocker, paper_id):
-    \"\"\"Garbage IDs return a clean format error and never hit the arXiv API.\"\"\"
+    """Garbage IDs return a clean format error and never hit the arXiv API."""
     mock_get = AsyncMock()
     mocker.patch(
-        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        "arxiv_mcp_server.tools.get_abstract._rate_limited_get",
         mock_get,
     )
-    result = await handle_get_abstract({\"paper_id\": paper_id})
+    result = await handle_get_abstract({"paper_id": paper_id})
     data = json.loads(result[0].text)
-    assert data[\"status\"] == \"error\"
-    assert data[\"message\"] == \"invalid arXiv ID format\"
-    assert \"400\" not in data[\"message\"]
-    assert \"export.arxiv.org\" not in data[\"message\"]
+    assert data["status"] == "error"
+    assert data["message"] == "invalid arXiv ID format"
+    assert "400" not in data["message"]
+    assert "export.arxiv.org" not in data["message"]
     mock_get.assert_not_called()
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(\"paper_id\", [\"\", \"   \"])
+@pytest.mark.parametrize("paper_id", ["", "   "])
 async def test_empty_paper_id_does_not_call_http(mocker, paper_id):
     mock_get = AsyncMock()
     mocker.patch(
-        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        "arxiv_mcp_server.tools.get_abstract._rate_limited_get",
         mock_get,
     )
-    result = await handle_get_abstract({\"paper_id\": paper_id})
+    result = await handle_get_abstract({"paper_id": paper_id})
     data = json.loads(result[0].text)
-    assert data[\"status\"] == \"error\"
-    assert \"400\" not in data[\"message\"]
-    assert \"export.arxiv.org\" not in result[0].text
+    assert data["status"] == "error"
+    assert "400" not in data["message"]
+    assert "export.arxiv.org" not in result[0].text
     mock_get.assert_not_called()
 
 
@@ -160,45 +160,45 @@ async def test_empty_paper_id_does_not_call_http(mocker, paper_id):
 async def test_http_status_error_does_not_leak_upstream_url(mocker):
     import httpx
 
-    request = httpx.Request(\"GET\", \"https://export.arxiv.org/api/query?id_list=x\")
+    request = httpx.Request("GET", "https://export.arxiv.org/api/query?id_list=x")
     response = httpx.Response(400, request=request)
     mocker.patch(
-        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        "arxiv_mcp_server.tools.get_abstract._rate_limited_get",
         AsyncMock(
             side_effect=httpx.HTTPStatusError(
-                \"400 Bad Request\", request=request, response=response
+                "400 Bad Request", request=request, response=response
             )
         ),
     )
-    result = await handle_get_abstract({\"paper_id\": \"1706.03762\"})
+    result = await handle_get_abstract({"paper_id": "1706.03762"})
     data = json.loads(result[0].text)
-    assert data[\"status\"] == \"error\"
-    assert \"400\" not in data[\"message\"]
-    assert \"export.arxiv.org\" not in data[\"message\"]
-    assert \"Bad Request\" not in data[\"message\"]
+    assert data["status"] == "error"
+    assert "400" not in data["message"]
+    assert "export.arxiv.org" not in data["message"]
+    assert "Bad Request" not in data["message"]
 
 
 @pytest.mark.asyncio
 async def test_export_citations_normalizes_wrappers(monkeypatch):
-    \"\"\"Wrappers such as arxiv: and abs URLs are stripped before fetch (#162).\"\"\"
+    """Wrappers such as arxiv: and abs URLs are stripped before fetch (#162)."""
     requested = []
     _stub_metadata(
         monkeypatch,
-        [_paper(\"1706.03762\", \"Attention\", [\"Ashish Vaswani\"])],
+        [_paper("1706.03762", "Attention", ["Ashish Vaswani"])],
         recorder=requested,
     )
     payload = await _run(
         {
-            \"paper_ids\": [
-                \"arxiv:1706.03762v7\",
-                \"https://arxiv.org/abs/1706.03762\",
-                \"not-a-paper\",
+            "paper_ids": [
+                "arxiv:1706.03762v7",
+                "https://arxiv.org/abs/1706.03762",
+                "not-a-paper",
             ]
         }
     )
-    assert requested == [\"1706.03762v7\", \"1706.03762\"]
-    assert payload[\"status\"] == \"partial\"
-    assert payload[\"results\"][0][\"status\"] == \"success\"
-    assert payload[\"results\"][0][\"paper_id\"] == \"1706.03762v7\"
-    assert \"eprint = {1706.03762v7}\" in payload[\"results\"][0][\"bibtex\"]
-    assert payload[\"results\"][2][\"error\"] == \"invalid arXiv ID format\"
+    assert requested == ["1706.03762v7", "1706.03762"]
+    assert payload["status"] == "partial"
+    assert payload["results"][0]["status"] == "success"
+    assert payload["results"][0]["paper_id"] == "1706.03762v7"
+    assert "eprint = {1706.03762v7}" in payload["results"][0]["bibtex"]
+    assert payload["results"][2]["error"] == "invalid arXiv ID format"

--- a/tests/tools/test_paper_id_normalize.py
+++ b/tests/tools/test_paper_id_normalize.py
@@ -1,0 +1,204 @@
+"""get_abstract / export_citations ID normalize + validate (issues #162, #166)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from arxiv_mcp_server.tools.get_abstract import handle_get_abstract
+from arxiv_mcp_server.tools import export_citations as ec
+
+FULL_ATOM_XML = """\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<feed xmlns=\"http://www.w3.org/2005/Atom\"
+      xmlns:arxiv=\"http://arxiv.org/schemas/atom\">
+  <entry>
+    <id>http://arxiv.org/abs/1706.03762v7</id>
+    <title>Attention Is All You Need</title>
+    <summary>We propose a novel model.</summary>
+    <published>2017-06-12T00:00:00Z</published>
+    <author><name>Ashish Vaswani</name></author>
+    <arxiv:primary_category term=\"cs.CL\"/>
+    <link title=\"pdf\" href=\"https://arxiv.org/pdf/1706.03762v7\"/>
+  </entry>
+</feed>
+"""
+
+
+def _make_mock_response(xml_text: str) -> MagicMock:
+    resp = MagicMock()
+    resp.text = xml_text
+    return resp
+
+
+def _mock_rate_limited_get(xml_text: str):
+    return AsyncMock(return_value=_make_mock_response(xml_text))
+
+
+def _paper(
+    pid, title, authors, published=\"2017-06-12T00:00:00Z\", categories=(\"cs.CL\",)
+):
+    return {
+        \"id\": pid,
+        \"title\": title,
+        \"authors\": list(authors),
+        \"abstract\": \"[EXTERNAL CONTENT] x\",
+        \"categories\": list(categories),
+        \"published\": published,
+        \"url\": f\"https://arxiv.org/pdf/{pid}\",
+        \"resource_uri\": f\"arxiv://{pid}\",
+    }
+
+
+def _stub_metadata(monkeypatch, papers, recorder=None):
+    async def _fake(ids):
+        if recorder is not None:
+            recorder.extend(ids)
+        bases = {ec._base_id(i) for i in ids}
+        return {p[\"id\"]: p for p in papers if p[\"id\"] in bases}
+
+    monkeypatch.setattr(ec, \"_fetch_metadata\", _fake)
+
+
+async def _run(arguments):
+    result = await ec.handle_export_citations(arguments)
+    assert len(result) == 1 and result[0].type == \"text\"
+    return json.loads(result[0].text)
+
+
+@pytest.mark.asyncio
+async def test_arxiv_prefix_id_normalizes_and_succeeds(mocker):
+    \"\"\"arxiv:1706.03762v7 is stripped to 1706.03762v7 before the API call.\"\"\"
+    mock_get = _mock_rate_limited_get(FULL_ATOM_XML)
+    mocker.patch(
+        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        mock_get,
+    )
+    result = await handle_get_abstract({\"paper_id\": \"arxiv:1706.03762v7\"})
+    data = json.loads(result[0].text)
+    assert data[\"status\"] == \"success\"
+    assert data[\"paper_id\"] == \"1706.03762v7\"
+    mock_get.assert_awaited_once()
+    called_url = mock_get.await_args.args[1]
+    assert \"id_list=1706.03762v7\" in called_url
+    assert \"arxiv:\" not in called_url
+
+
+@pytest.mark.asyncio
+async def test_abs_url_normalizes_and_succeeds(mocker):
+    \"\"\"https://arxiv.org/abs/1706.03762 is extracted before the API call.\"\"\"
+    mock_get = _mock_rate_limited_get(FULL_ATOM_XML)
+    mocker.patch(
+        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        mock_get,
+    )
+    result = await handle_get_abstract({\"paper_id\": \"https://arxiv.org/abs/1706.03762\"})
+    data = json.loads(result[0].text)
+    assert data[\"status\"] == \"success\"
+    assert data[\"paper_id\"] == \"1706.03762\"
+    mock_get.assert_awaited_once()
+    called_url = mock_get.await_args.args[1]
+    assert \"id_list=1706.03762\" in called_url
+    assert \"arxiv.org/abs\" not in called_url
+
+
+@pytest.mark.asyncio
+async def test_pdf_url_normalizes_and_succeeds(mocker):
+    mock_get = _mock_rate_limited_get(FULL_ATOM_XML)
+    mocker.patch(
+        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        mock_get,
+    )
+    result = await handle_get_abstract(
+        {\"paper_id\": \"https://arxiv.org/pdf/1706.03762v7.pdf\"}
+    )
+    data = json.loads(result[0].text)
+    assert data[\"status\"] == \"success\"
+    assert data[\"paper_id\"] == \"1706.03762v7\"
+    called_url = mock_get.await_args.args[1]
+    assert \"id_list=1706.03762v7\" in called_url
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    \"paper_id\",
+    [\"not-a-paper\", \"garbage!!!\", \"arxiv:not-a-paper\", \"just some text\"],
+)
+async def test_invalid_paper_id_does_not_call_http(mocker, paper_id):
+    \"\"\"Garbage IDs return a clean format error and never hit the arXiv API.\"\"\"
+    mock_get = AsyncMock()
+    mocker.patch(
+        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        mock_get,
+    )
+    result = await handle_get_abstract({\"paper_id\": paper_id})
+    data = json.loads(result[0].text)
+    assert data[\"status\"] == \"error\"
+    assert data[\"message\"] == \"invalid arXiv ID format\"
+    assert \"400\" not in data[\"message\"]
+    assert \"export.arxiv.org\" not in data[\"message\"]
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(\"paper_id\", [\"\", \"   \"])
+async def test_empty_paper_id_does_not_call_http(mocker, paper_id):
+    mock_get = AsyncMock()
+    mocker.patch(
+        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        mock_get,
+    )
+    result = await handle_get_abstract({\"paper_id\": paper_id})
+    data = json.loads(result[0].text)
+    assert data[\"status\"] == \"error\"
+    assert \"400\" not in data[\"message\"]
+    assert \"export.arxiv.org\" not in result[0].text
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_status_error_does_not_leak_upstream_url(mocker):
+    import httpx
+
+    request = httpx.Request(\"GET\", \"https://export.arxiv.org/api/query?id_list=x\")
+    response = httpx.Response(400, request=request)
+    mocker.patch(
+        \"arxiv_mcp_server.tools.get_abstract._rate_limited_get\",
+        AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                \"400 Bad Request\", request=request, response=response
+            )
+        ),
+    )
+    result = await handle_get_abstract({\"paper_id\": \"1706.03762\"})
+    data = json.loads(result[0].text)
+    assert data[\"status\"] == \"error\"
+    assert \"400\" not in data[\"message\"]
+    assert \"export.arxiv.org\" not in data[\"message\"]
+    assert \"Bad Request\" not in data[\"message\"]
+
+
+@pytest.mark.asyncio
+async def test_export_citations_normalizes_wrappers(monkeypatch):
+    \"\"\"Wrappers such as arxiv: and abs URLs are stripped before fetch (#162).\"\"\"
+    requested = []
+    _stub_metadata(
+        monkeypatch,
+        [_paper(\"1706.03762\", \"Attention\", [\"Ashish Vaswani\"])],
+        recorder=requested,
+    )
+    payload = await _run(
+        {
+            \"paper_ids\": [
+                \"arxiv:1706.03762v7\",
+                \"https://arxiv.org/abs/1706.03762\",
+                \"not-a-paper\",
+            ]
+        }
+    )
+    assert requested == [\"1706.03762v7\", \"1706.03762\"]
+    assert payload[\"status\"] == \"partial\"
+    assert payload[\"results\"][0][\"status\"] == \"success\"
+    assert payload[\"results\"][0][\"paper_id\"] == \"1706.03762v7\"
+    assert \"eprint = {1706.03762v7}\" in payload[\"results\"][0][\"bibtex\"]
+    assert payload[\"results\"][2][\"error\"] == \"invalid arXiv ID format\"


### PR DESCRIPTION
## Summary

Centralize arXiv ID normalize+validate so tools accept `arxiv:` / `arXiv:` prefixes and cheap `abs`/`pdf` URL wrappers, and so invalid IDs never hit the arXiv API.

- New shared helper `src/arxiv_mcp_server/tools/arxiv_ids.py` (`normalize_arxiv_id`, `parse_arxiv_id`, and the existing `is_valid_arxiv_id` regex moved here).
- `get_abstract` strips wrappers (keeps version suffixes like `v7`) and returns `invalid arXiv ID format` for garbage such as `not-a-paper` without calling the client. HTTP 400s no longer leak the upstream URL/status line.
- Same normalize+validate path is used by `export_citations`, `citation_graph`, and `read_paper`. `list_papers` re-exports `is_valid_arxiv_id` so existing importers keep working.

Closes #162
Closes #166

## Test plan

```bash
uv run pytest tests/tools/test_arxiv_ids.py tests/tools/test_paper_id_normalize.py tests/tools/test_get_abstract.py tests/tools/test_export_citations.py --no-cov
uv run pytest tests/tools/test_download.py tests/tools/test_read_paper.py tests/tools/test_citation_graph.py tests/tools/test_latex.py tests/tools/test_list_papers.py --no-cov
uv run black --check src/arxiv_mcp_server/tools/arxiv_ids.py src/arxiv_mcp_server/tools/list_papers.py src/arxiv_mcp_server/tools/get_abstract.py src/arxiv_mcp_server/tools/export_citations.py src/arxiv_mcp_server/tools/citation_graph.py src/arxiv_mcp_server/tools/read_paper.py tests/tools/test_arxiv_ids.py tests/tools/test_paper_id_normalize.py
```

Local results (2026-08-20 ET):
- 87 passed (`test_arxiv_ids` + `test_get_abstract` + `test_export_citations`, including the new normalize/validate cases)
- 41 passed for the new files on this branch (`test_arxiv_ids.py` + `test_paper_id_normalize.py`)
- 63 passed for related paper-id tools (download / read_paper / citation_graph / latex / list_papers)
- `black --check` clean on touched files

Covered cases:
- `arxiv:1706.03762v7` and `https://arxiv.org/abs/1706.03762` normalize and succeed (HTTP client mocked)
- `not-a-paper` / empty / garbage return a clean format/required error and do **not** call the HTTP client
- HTTP 400 from the client is mapped to a message without the upstream URL or status line