### PR TITLE
feat: add start/next_start to search_papers (#186)

### DIFF
--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -182,6 +182,7 @@ def build_arxiv_search_url(
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
     categories: Optional[List[str]] = None,
+    start: int = 0,
 ) -> str:
     """Build a raw arXiv API URL with a percent-encoded search_query."""
     final_query = build_arxiv_search_query(
@@ -197,8 +198,10 @@ def build_arxiv_search_url(
         "date": "submittedDate",
     }
     encoded_query = quote(final_query, safe="")
+    start = max(0, int(start))
     base_params = (
-        f"max_results={max_results}"
+        f"start={start}"
+        f"&max_results={max_results}"
         f"&sortBy={sort_map.get(sort_by, 'relevance')}"
         f"&sortOrder=descending"
     )
@@ -212,6 +215,7 @@ async def _raw_arxiv_search(
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
     categories: Optional[List[str]] = None,
+    start: int = 0,
 ) -> tuple[List[Dict[str, Any]], Optional[int]]:
     """
     Perform arXiv search using raw HTTP requests.
@@ -230,6 +234,7 @@ async def _raw_arxiv_search(
         date_from=date_from,
         date_to=date_to,
         categories=categories,
+        start=start,
     )
     logger.debug(f"Raw API URL: {url}")
 
@@ -269,16 +274,31 @@ def _build_search_response(
     *,
     total_results: Optional[int] = None,
     has_more: Optional[bool] = None,
+    start: int = 0,
 ) -> Dict[str, Any]:
-    """Assemble search JSON. Never report page size as total_results."""
+    """Assemble search JSON. Never report page size as total_results.
+
+    Pagination mirrors read_paper / content helpers: ``start`` is the
+    zero-based offset for this page and ``next_start`` is set when more
+    results remain (otherwise None).
+    """
     returned = len(papers)
-    response: Dict[str, Any] = {"returned": returned, "papers": papers}
+    start = max(0, int(start))
+    response: Dict[str, Any] = {
+        "returned": returned,
+        "start": start,
+        "papers": papers,
+    }
     if total_results is not None:
         response["total_results"] = total_results
         if has_more is None:
-            has_more = total_results > returned
+            has_more = total_results > (start + returned)
     if has_more is not None:
         response["has_more"] = bool(has_more)
+    if response.get("has_more"):
+        response["next_start"] = start + returned
+    else:
+        response["next_start"] = None
     return response
 
 
@@ -429,7 +449,7 @@ DATE FILTERING: Use YYYY-MM-DD format for historical research:
 
 RESULT QUALITY: Default sort is RELEVANCE (most pertinent results first). Use sort_by: "date" to get newest papers first.
 Choose relevance for focused topic searches; choose date for monitoring recent developments.
-Each response reports total_results (arXiv corpus hit count, not page size), returned (papers in this page), and has_more.
+Each response reports total_results (arXiv corpus hit count, not page size), returned (papers in this page), has_more, start, and next_start (use start=next_start to fetch the next page).
 
 RATE LIMITING: arXiv enforces a 3-second minimum between requests. This server handles that automatically.
 If you see a rate limit error, wait 60 seconds before retrying — do not call the tool repeatedly in a loop.
@@ -448,6 +468,11 @@ TIPS FOR FOUNDATIONAL RESEARCH:
             "max_results": {
                 "type": "integer",
                 "description": "Maximum number of results to return (default: 10, max: 50). Use 15-20 for comprehensive searches.",
+            },
+            "start": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Zero-based offset into the arXiv result set (default: 0). Pass next_start from a previous response to fetch the next page.",
             },
             "date_from": {
                 "type": "string",
@@ -537,6 +562,11 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """
     try:
         max_results = min(int(arguments.get("max_results", 10)), settings.MAX_RESULTS)
+        start_arg = arguments.get("start", 0)
+        try:
+            start = max(0, int(start_arg))
+        except (TypeError, ValueError):
+            start = 0
         base_query = arguments["query"]
         date_from_arg = arguments.get("date_from")
         date_to_arg = arguments.get("date_to")
@@ -544,7 +574,7 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
         sort_by_arg = arguments.get("sort_by", "relevance")
 
         logger.debug(
-            f"Starting search with query: '{base_query}', max_results: {max_results}"
+            f"Starting search with query: '{base_query}', max_results: {max_results}, start: {start}"
         )
 
         # Validate categories if provided
@@ -574,13 +604,14 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                     date_from=date_from_arg,
                     date_to=date_to_arg,
                     categories=categories,
+                    start=start,
                 )
 
                 logger.info(
                     f"Raw API search completed: {len(results)} results returned"
                 )
                 response_data = _build_search_response(
-                    results, total_results=total_results
+                    results, total_results=total_results, start=start
                 )
 
                 return [
@@ -639,17 +670,19 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
             logger.debug("Using relevance sorting (most relevant first)")
 
         # Request one extra hit so has_more is real, not a page-size guess.
+        # Client.results(offset=start) yields up to (max_results - offset)
+        # papers, so bump Search.max_results by start to keep the page size.
         fetch_limit = max_results + 1
         search = arxiv.Search(
             query=final_query,
-            max_results=fetch_limit,
+            max_results=start + fetch_limit,
             sort_by=sort_criterion,
         )
 
         def fetch_results() -> List[Dict[str, Any]]:
             client.page_size = fetch_limit
             results = []
-            for paper in client.results(search):
+            for paper in client.results(search, offset=start):
                 results.append(_process_paper(paper))
                 if len(results) >= fetch_limit:
                     break
@@ -670,7 +703,7 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
         has_more = len(fetched) > max_results
         results = fetched[:max_results]
         logger.info(f"Search completed: {len(results)} results returned")
-        response_data = _build_search_response(results, has_more=has_more)
+        response_data = _build_search_response(results, has_more=has_more, start=start)
 
         return [
             types.TextContent(type="text", text=json.dumps(response_data, indent=2))

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -36,8 +36,10 @@ async def test_basic_search(mock_client):
         assert len(result) == 1
         content = json.loads(result[0].text)
         assert content["returned"] == 1
+        assert content["start"] == 0
         assert "total_results" not in content
         assert content["has_more"] is False
+        assert content["next_start"] is None
         paper = content["papers"][0]
         assert paper["id"] == "2103.12345"
         assert paper["title"] == "Test Paper"
@@ -111,7 +113,9 @@ async def test_search_with_dates():
         content = json.loads(result[0].text)
         assert content["total_results"] == 42
         assert content["returned"] == 1
+        assert content["start"] == 0
         assert content["has_more"] is True
+        assert content["next_start"] == 1
         assert len(content["papers"]) == 1
 
 
@@ -272,7 +276,7 @@ async def test_search_reuses_client_and_updates_page_size_inside_gate(
     monkeypatch.setattr(config, "_arxiv_client", None)
     observed_page_sizes = []
 
-    def results(_search):
+    def results(_search, offset=0):
         observed_page_sizes.append(mock_client.page_size)
         return [mock_paper]
 
@@ -422,7 +426,9 @@ def test_parse_opensearch_total_results_from_atom_feed():
     payload = _build_search_response(papers, total_results=1234)
     assert payload["total_results"] == 1234
     assert payload["returned"] == 5
+    assert payload["start"] == 0
     assert payload["has_more"] is True
+    assert payload["next_start"] == 5
     assert len(payload["papers"]) == 5
 
 
@@ -460,7 +466,9 @@ async def test_search_reports_feed_total_results_not_page_size():
     content = json.loads(result[0].text)
     assert content["total_results"] == 1234
     assert content["returned"] == 5
+    assert content["start"] == 0
     assert content["has_more"] is True
+    assert content["next_start"] == 5
     assert len(content["papers"]) == 5
     assert content["total_results"] != content["returned"]
 
@@ -485,7 +493,158 @@ async def test_client_path_has_more_from_extra_fetched_paper(mock_paper):
 
     content = json.loads(result[0].text)
     assert content["returned"] == 1
+    assert content["start"] == 0
     assert content["has_more"] is True
+    assert content["next_start"] == 1
     assert "total_results" not in content
     assert len(content["papers"]) == 1
     assert content["papers"][0]["id"] == "2103.12345"
+
+
+def test_build_search_response_next_start_accounts_for_offset():
+    """has_more/next_start must use start + returned, not just returned."""
+    papers = [{"id": str(i)} for i in range(5)]
+    payload = _build_search_response(papers, total_results=14, start=10)
+    assert payload["start"] == 10
+    assert payload["returned"] == 5
+    assert payload["total_results"] == 14
+    assert payload["has_more"] is False
+    assert payload["next_start"] is None
+
+    payload = _build_search_response(papers, total_results=100, start=10)
+    assert payload["has_more"] is True
+    assert payload["next_start"] == 15
+
+
+@pytest.mark.asyncio
+async def test_raw_search_passes_start_to_arxiv_api():
+    """Date-filter path must forward start to the arXiv API URL."""
+    mock_response = MagicMock()
+    mock_response.text = _atom_feed_with_totals(entry_count=2, total_results=14)
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        result = await handle_search(
+            {
+                "query": "transformers",
+                "date_from": "2020-01-01",
+                "max_results": 2,
+                "start": 5,
+            }
+        )
+
+        from urllib.parse import parse_qs, urlparse
+
+        url = mock_client.get.call_args[0][0]
+        params = parse_qs(urlparse(url).query)
+        assert params["start"] == ["5"]
+        assert params["max_results"] == ["2"]
+
+    content = json.loads(result[0].text)
+    assert content["start"] == 5
+    assert content["returned"] == 2
+    assert content["total_results"] == 14
+    assert content["has_more"] is True
+    assert content["next_start"] == 7
+
+
+@pytest.mark.asyncio
+async def test_raw_search_end_of_results_clears_next_start():
+    """Last page should set has_more=false and next_start=null."""
+    mock_response = MagicMock()
+    mock_response.text = _atom_feed_with_totals(entry_count=4, total_results=14)
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_class.return_value = mock_client
+
+        result = await handle_search(
+            {
+                "query": "transformers",
+                "date_from": "2020-01-01",
+                "max_results": 10,
+                "start": 10,
+            }
+        )
+
+    content = json.loads(result[0].text)
+    assert content["start"] == 10
+    assert content["returned"] == 4
+    assert content["total_results"] == 14
+    assert content["has_more"] is False
+    assert content["next_start"] is None
+
+
+@pytest.mark.asyncio
+async def test_client_path_start_offset_page_two(mock_paper):
+    """Client path must pass offset=start and return next_start for page 2."""
+    papers = []
+    for i in range(3):
+        p = MagicMock()
+        p.get_short_id.return_value = f"2103.1000{i}"
+        p.title = f"Paper {i}"
+        p.authors = mock_paper.authors
+        p.summary = f"Abstract {i}"
+        p.categories = ["cs.LG"]
+        p.published = mock_paper.published
+        p.pdf_url = f"https://arxiv.org/pdf/2103.1000{i}"
+        papers.append(p)
+
+    client = MagicMock()
+    # max_results=2 requests fetch_limit=3; 3 papers => has_more
+    client.results.return_value = papers
+
+    with patch("arxiv_mcp_server.tools.search.get_arxiv_client", return_value=client):
+        result = await handle_search(
+            {"query": "test query", "max_results": 2, "start": 10}
+        )
+
+    args, kwargs = client.results.call_args
+    assert kwargs.get("offset", args[1] if len(args) > 1 else None) == 10
+    search_arg = args[0]
+    assert search_arg.max_results == 13  # start + max_results + 1
+
+    content = json.loads(result[0].text)
+    assert content["start"] == 10
+    assert content["returned"] == 2
+    assert content["has_more"] is True
+    assert content["next_start"] == 12
+    assert content["papers"][0]["id"] == "2103.10000"
+
+
+@pytest.mark.asyncio
+async def test_client_path_end_of_results_no_next_start(mock_paper):
+    """Client path end page: fewer than max_results => next_start null."""
+    client = MagicMock()
+    client.results.return_value = [mock_paper]  # only one left
+
+    with patch("arxiv_mcp_server.tools.search.get_arxiv_client", return_value=client):
+        result = await handle_search(
+            {"query": "test query", "max_results": 5, "start": 20}
+        )
+
+    content = json.loads(result[0].text)
+    assert content["start"] == 20
+    assert content["returned"] == 1
+    assert content["has_more"] is False
+    assert content["next_start"] is None
+
+
+def test_search_tool_schema_includes_start():
+    """Tool schema exposes optional start (>=0) for pagination."""
+    from arxiv_mcp_server.tools.search import search_tool
+
+    props = search_tool.inputSchema["properties"]
+    assert "start" in props
+    assert props["start"]["type"] == "integer"
+    assert props["start"]["minimum"] == 0


### PR DESCRIPTION
## Summary
Fixes #186 — `search_papers` advertised `has_more`/`total_results` but had no pagination control.

## Changes
- Add optional `start` (int, default 0, `minimum: 0`) to the tool schema
- Pass `start` through to the arXiv API (`start` query param on the raw/date-filter path; `Client.results(..., offset=start)` on the package path)
- Return `start` + `next_start` (set when `has_more`, else `null`), matching `read_paper` / content pagination
- Fix `has_more` to use `total_results > (start + returned)` so page 2+ is correct
- Tests for page 2, end-of-results, schema, and URL forwarding

## Out of scope
Does **not** implement the full #128 compact/paginated search redesign — narrow control only.

## Test plan
- [x] `pytest tests/tools/test_search.py` — 28 passed
- [x] `black 26.1.0` on changed files
- [x] Verified remote `search.py` size matches local (26388 bytes) after Contents API PUT