### PR TITLE
fix: always include total_results from search_papers (#189)

### DIFF
--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -1,6 +1,5 @@
 """Search functionality for the arXiv MCP server."""
 
-import arxiv
 import json
 import logging
 import httpx
@@ -12,8 +11,8 @@ from datetime import datetime, timezone
 from dateutil import parser
 import mcp.types as types
 from mcp.types import ToolAnnotations
-from ..config import Settings, get_arxiv_client
-from ..arxiv_api import ARXIV_RATE_LIMITER, canonical_pdf_url
+from ..config import Settings
+from ..arxiv_api import ARXIV_RATE_LIMITER
 
 logger = logging.getLogger("arxiv-mcp-server")
 settings = Settings()
@@ -539,26 +538,13 @@ def _optimize_query(query: str) -> str:
     return query
 
 
-def _process_paper(paper: arxiv.Result) -> Dict[str, Any]:
-    """Process paper information with resource URI."""
-    return {
-        "id": paper.get_short_id(),
-        "title": paper.title,
-        "authors": [author.name for author in paper.authors],
-        "abstract": "[EXTERNAL CONTENT] " + paper.summary,
-        "categories": paper.categories,
-        "published": paper.published.isoformat(),
-        "url": canonical_pdf_url(paper),
-        "resource_uri": f"arxiv://{paper.get_short_id()}",
-    }
-
-
 async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
-    """Handle paper search requests with improved arXiv API integration.
+    """Handle paper search requests via the arXiv Atom API.
 
-    Uses raw HTTP requests when date filtering is requested to avoid URL encoding
-    issues with the arxiv Python package. Falls back to the arxiv package for
-    non-date queries for better compatibility.
+    Always uses raw HTTP so OpenSearch ``totalResults`` (corpus hit count)
+    is available for every query — including those without date filters
+    (see #189). Raw requests also avoid the arxiv package URL-encoding
+    bug that breaks ``submittedDate`` ranges.
     """
     try:
         max_results = min(int(arguments.get("max_results", 10)), settings.MAX_RESULTS)
@@ -586,134 +572,37 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 )
             ]
 
-        # Use raw HTTP API when date filtering is requested
-        # This bypasses the arxiv package's URL encoding which breaks date syntax
-        if date_from_arg or date_to_arg:
-            logger.debug(
-                f"Date filtering requested - using raw API: {date_from_arg} to {date_to_arg}"
+        try:
+            optimized_query = _optimize_query(base_query) if base_query.strip() else ""
+            results, total_results = await _raw_arxiv_search(
+                query=optimized_query,
+                max_results=max_results,
+                sort_by=sort_by_arg,
+                date_from=date_from_arg,
+                date_to=date_to_arg,
+                categories=categories,
+                start=start,
             )
 
-            try:
-                optimized_query = (
-                    _optimize_query(base_query) if base_query.strip() else ""
-                )
-                results, total_results = await _raw_arxiv_search(
-                    query=optimized_query,
-                    max_results=max_results,
-                    sort_by=sort_by_arg,
-                    date_from=date_from_arg,
-                    date_to=date_to_arg,
-                    categories=categories,
-                    start=start,
-                )
+            logger.info(f"Search completed: {len(results)} results returned")
+            response_data = _build_search_response(
+                results, total_results=total_results, start=start
+            )
 
-                logger.info(
-                    f"Raw API search completed: {len(results)} results returned"
-                )
-                response_data = _build_search_response(
-                    results, total_results=total_results, start=start
-                )
-
-                return [
-                    types.TextContent(
-                        type="text", text=json.dumps(response_data, indent=2)
-                    )
-                ]
-
-            except httpx.HTTPStatusError as e:
-                logger.error(f"arXiv API HTTP error: {e}")
-                return [
-                    types.TextContent(
-                        type="text", text=f"Error: arXiv API HTTP error - {str(e)}"
-                    )
-                ]
-            except ValueError as e:
-                return [types.TextContent(type="text", text=f"Error: {str(e)}")]
-
-        # For non-date queries, use the shared arxiv client (lazy, avoids eager import overhead)
-        client = get_arxiv_client()
-
-        # Build query components
-        query_parts = []
-
-        # Add base query with optimization
-        if base_query.strip():
-            optimized_query = _optimize_query(base_query)
-            query_parts.append(_scope_user_query(optimized_query))
-            if optimized_query != base_query:
-                logger.debug(f"Optimized query: '{base_query}' -> '{optimized_query}'")
-
-        # Add category filtering
-        if categories:
-            category_filter = " OR ".join(f"cat:{cat}" for cat in categories)
-            query_parts.append(f"({category_filter})")
-            logger.debug(f"Added category filter: {category_filter}")
-
-        # Combine query parts
-        if not query_parts:
             return [
-                types.TextContent(
-                    type="text", text="Error: No search criteria provided"
-                )
+                types.TextContent(type="text", text=json.dumps(response_data, indent=2))
             ]
 
-        # Combine query parts - arXiv uses space for AND by default
-        final_query = " ".join(query_parts)
-        logger.debug(f"Final arXiv query: {final_query}")
-
-        # Determine sort method
-        if sort_by_arg == "date":
-            sort_criterion = arxiv.SortCriterion.SubmittedDate
-            logger.debug("Using date sorting (newest first)")
-        else:
-            sort_criterion = arxiv.SortCriterion.Relevance
-            logger.debug("Using relevance sorting (most relevant first)")
-
-        # Request one extra hit so has_more is real, not a page-size guess.
-        # Client.results(offset=start) yields up to (max_results - offset)
-        # papers, so bump Search.max_results by start to keep the page size.
-        fetch_limit = max_results + 1
-        search = arxiv.Search(
-            query=final_query,
-            max_results=start + fetch_limit,
-            sort_by=sort_criterion,
-        )
-
-        def fetch_results() -> List[Dict[str, Any]]:
-            client.page_size = fetch_limit
-            results = []
-            for paper in client.results(search, offset=start):
-                results.append(_process_paper(paper))
-                if len(results) >= fetch_limit:
-                    break
-            return results
-
-        try:
-            fetched = await asyncio.to_thread(
-                ARXIV_RATE_LIMITER.run_sync, fetch_results
-            )
-        except arxiv.ArxivError as e:
-            if "429" in str(e) or "rate" in str(e).lower() or "503" in str(e):
-                logger.warning(f"arXiv rate limited — not retrying: {e}")
-                raise RuntimeError(
-                    "arXiv is rate limiting this IP. Please wait 60 seconds before retrying."
+        except httpx.HTTPStatusError as e:
+            logger.error(f"arXiv API HTTP error: {e}")
+            return [
+                types.TextContent(
+                    type="text", text=f"Error: arXiv API HTTP error - {str(e)}"
                 )
-            raise
+            ]
+        except ValueError as e:
+            return [types.TextContent(type="text", text=f"Error: {str(e)}")]
 
-        has_more = len(fetched) > max_results
-        results = fetched[:max_results]
-        logger.info(f"Search completed: {len(results)} results returned")
-        response_data = _build_search_response(results, has_more=has_more, start=start)
-
-        return [
-            types.TextContent(type="text", text=json.dumps(response_data, indent=2))
-        ]
-
-    except arxiv.ArxivError as e:
-        logger.error(f"ArXiv API error: {e}")
-        return [
-            types.TextContent(type="text", text=f"Error: ArXiv API error - {str(e)}")
-        ]
     except Exception as e:
         logger.error(f"Unexpected search error: {e}")
         return [types.TextContent(type="text", text=f"Error: {str(e)}")]

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -27,17 +27,34 @@ def disable_request_spacing_for_search_unit_tests(monkeypatch):
     monkeypatch.setattr(config, "_arxiv_client", None)
 
 
+def _mock_httpx_response(xml_text: str):
+    """Patch httpx.AsyncClient to return an Atom feed body."""
+    mock_response = MagicMock()
+    mock_response.text = xml_text
+    mock_response.raise_for_status = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_response, mock_client
+
+
 @pytest.mark.asyncio
-async def test_basic_search(mock_client):
-    """Test basic paper search functionality."""
-    with patch("arxiv.Client", return_value=mock_client):
+async def test_basic_search():
+    """Test basic paper search includes OpenSearch total_results (#189)."""
+    xml = _atom_feed_with_totals(entry_count=1, total_results=1)
+    # Use a fixed id matching historical fixture expectations where possible.
+    xml = xml.replace("2301.00001", "2103.12345").replace("Test Paper 1", "Test Paper")
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search({"query": "test query", "max_results": 1})
 
         assert len(result) == 1
         content = json.loads(result[0].text)
         assert content["returned"] == 1
         assert content["start"] == 0
-        assert "total_results" not in content
+        assert content["total_results"] == 1
         assert content["has_more"] is False
         assert content["next_start"] is None
         paper = content["papers"][0]
@@ -47,29 +64,53 @@ async def test_basic_search(mock_client):
 
 
 @pytest.mark.asyncio
-async def test_package_search_uses_process_wide_rate_limiter(mock_client, mocker):
-    """The arxiv package path must share the same gate as raw API requests."""
-    mocker.patch.object(search_module, "get_arxiv_client", return_value=mock_client)
-    run_sync = mocker.patch.object(
+async def test_search_uses_process_wide_rate_limiter(mocker):
+    """All search_papers requests share the process-wide arXiv gate."""
+    xml = _atom_feed_with_totals(entry_count=1, total_results=1)
+    _, mock_client = _mock_httpx_response(xml)
+
+    async def run_async(operation):
+        return await operation()
+
+    mocked = mocker.patch.object(
         search_module.ARXIV_RATE_LIMITER,
-        "run_sync",
-        side_effect=lambda operation: operation(),
+        "run_async",
+        side_effect=run_async,
     )
 
-    await handle_search({"query": "test query", "max_results": 1})
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await handle_search({"query": "test query", "max_results": 1})
 
-    run_sync.assert_called_once()
+    mocked.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_search_with_categories(mock_client):
-    """Test paper search with category filtering."""
-    with patch("arxiv.Client", return_value=mock_client):
+async def test_search_with_categories():
+    """Test paper search with category filtering via raw Atom API."""
+    xml = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:arxiv=\"http://arxiv.org/schemas/atom\" xmlns:opensearch=\"http://a9.com/-/spec/opensearch/1.1/\">
+        <opensearch:totalResults>1</opensearch:totalResults>
+        <entry>
+            <id>http://arxiv.org/abs/2103.12345v1</id>
+            <title>Test Paper</title>
+            <summary>Test abstract</summary>
+            <published>2023-01-01T00:00:00Z</published>
+            <author><name>John Doe</name></author>
+            <arxiv:primary_category term=\"cs.AI\"/>
+            <category term=\"cs.AI\"/>
+            <category term=\"cs.LG\"/>
+            <link title=\"pdf\" href=\"http://arxiv.org/pdf/2103.12345v1\"/>
+        </entry>
+    </feed>"""
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search(
             {"query": "test query", "categories": ["cs.AI", "cs.LG"], "max_results": 1}
         )
 
         content = json.loads(result[0].text)
+        assert content["total_results"] == 1
         assert content["papers"][0]["categories"] == ["cs.AI", "cs.LG"]
 
 
@@ -210,109 +251,138 @@ async def test_raw_arxiv_search_builds_correct_url():
 
 
 @pytest.mark.asyncio
-async def test_search_with_invalid_categories(mock_client):
+async def test_search_with_invalid_categories():
     """Test search with invalid categories."""
-    with patch("arxiv.Client", return_value=mock_client):
-        result = await handle_search(
-            {
-                "query": "test query",
-                "categories": ["invalid.category"],
-                "max_results": 1,
-            }
-        )
+    result = await handle_search(
+        {
+            "query": "test query",
+            "categories": ["invalid.category"],
+            "max_results": 1,
+        }
+    )
 
-        assert "Error: Invalid category" in result[0].text
+    assert "Error: Invalid category" in result[0].text
 
 
 @pytest.mark.asyncio
-async def test_search_empty_query(mock_client):
+async def test_search_empty_query():
     """Test search with empty query but categories."""
-    with patch("arxiv.Client", return_value=mock_client):
+    xml = _atom_feed_with_totals(entry_count=1, total_results=7)
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search(
             {"query": "", "categories": ["cs.AI"], "max_results": 1}
         )
 
-        # Should still work with just categories
         content = json.loads(result[0].text)
         assert "papers" in content
+        assert content["total_results"] == 7
 
 
 @pytest.mark.asyncio
-async def test_search_arxiv_error(mock_client):
-    """Test handling of arXiv API errors."""
-    import arxiv
+async def test_search_arxiv_http_error():
+    """Test handling of arXiv HTTP API errors."""
+    import httpx
 
-    # Create proper ArxivError with required parameters
-    error = arxiv.ArxivError("http://example.com", retry=3, message="API Error")
-    mock_client.results.side_effect = error
+    request = httpx.Request("GET", "https://export.arxiv.org/api/query")
+    response = httpx.Response(500, request=request)
+    error = httpx.HTTPStatusError("boom", request=request, response=response)
 
-    with patch(
-        "arxiv_mcp_server.tools.search.get_arxiv_client", return_value=mock_client
-    ):
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=error)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search({"query": "test", "max_results": 1})
 
-        assert "ArXiv API error" in result[0].text
+        assert "arXiv API HTTP error" in result[0].text
 
 
 @pytest.mark.asyncio
-async def test_search_max_results_limiting(mock_client):
+async def test_search_max_results_limiting():
     """Test that max_results is properly limited."""
-    with patch("arxiv.Client", return_value=mock_client):
-        # Test that very large max_results gets capped
+    xml = _atom_feed_with_totals(entry_count=1, total_results=50)
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client) as mock_cls:
         result = await handle_search({"query": "test", "max_results": 1000})
 
-        # Should not fail and should be limited by settings.MAX_RESULTS
         content = json.loads(result[0].text)
         assert "papers" in content
+        assert content["total_results"] == 50
+        from urllib.parse import parse_qs, urlparse
+
+        url = mock_client.get.call_args[0][0]
+        params = parse_qs(urlparse(url).query)
+        # Cap is settings.MAX_RESULTS (50)
+        assert int(params["max_results"][0]) <= 50
 
 
 @pytest.mark.asyncio
-async def test_search_reuses_client_and_updates_page_size_inside_gate(
-    mock_client, mock_paper, monkeypatch
-):
-    """Varying result limits must reuse one client without stale page sizes."""
-    from arxiv_mcp_server import config
+async def test_search_forwards_varying_max_results_to_arxiv_api():
+    """Varying max_results must be forwarded on the raw Atom query URL."""
+    xml = _atom_feed_with_totals(entry_count=1, total_results=100)
+    _, mock_client = _mock_httpx_response(xml)
+    observed = []
 
-    monkeypatch.setattr(config, "_arxiv_client", None)
-    observed_page_sizes = []
+    async def capture_get(url, **kwargs):
+        from urllib.parse import parse_qs, urlparse
 
-    def results(_search, offset=0):
-        observed_page_sizes.append(mock_client.page_size)
-        return [mock_paper]
+        observed.append(int(parse_qs(urlparse(url).query)["max_results"][0]))
+        resp = MagicMock()
+        resp.text = xml
+        resp.raise_for_status = MagicMock()
+        return resp
 
-    mock_client.page_size = 100
-    mock_client.results.side_effect = results
-    with patch("arxiv.Client", return_value=mock_client) as mock_client_class:
+    mock_client.get = AsyncMock(side_effect=capture_get)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         await handle_search({"query": "first", "max_results": 5})
         await handle_search({"query": "second", "max_results": 7})
 
-    mock_client_class.assert_called_once_with()
-    # Client path requests max_results+1 so has_more is not a page-size guess.
-    assert observed_page_sizes == [6, 8]
+    assert observed == [5, 7]
 
 
 @pytest.mark.asyncio
-async def test_search_sort_by_relevance(mock_client):
+async def test_search_sort_by_relevance():
     """Test search with relevance sorting (default)."""
-    with patch("arxiv.Client", return_value=mock_client):
+    xml = _atom_feed_with_totals(entry_count=1, total_results=3)
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search({"query": "test", "sort_by": "relevance"})
 
         content = json.loads(result[0].text)
         assert "papers" in content
+        assert content["total_results"] == 3
+        from urllib.parse import parse_qs, urlparse
+
+        url = mock_client.get.call_args[0][0]
+        assert parse_qs(urlparse(url).query)["sortBy"] == ["relevance"]
 
 
 @pytest.mark.asyncio
-async def test_search_sort_by_date(mock_client):
+async def test_search_sort_by_date():
     """Test search with date sorting."""
-    with patch("arxiv.Client", return_value=mock_client):
+    xml = _atom_feed_with_totals(entry_count=1, total_results=3)
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search({"query": "test", "sort_by": "date"})
 
         content = json.loads(result[0].text)
         assert "papers" in content
+        assert content["total_results"] == 3
+        from urllib.parse import parse_qs, urlparse
+
+        url = mock_client.get.call_args[0][0]
+        assert parse_qs(urlparse(url).query)["sortBy"] == ["submittedDate"]
 
 
 @pytest.mark.asyncio
-async def test_search_no_query_optimization(mock_client):
+async def test_search_no_query_optimization():
     """Test that queries are not automatically modified."""
     from arxiv_mcp_server.tools.search import _optimize_query
 
@@ -474,29 +544,21 @@ async def test_search_reports_feed_total_results_not_page_size():
 
 
 @pytest.mark.asyncio
-async def test_client_path_has_more_from_extra_fetched_paper(mock_paper):
-    """Without Atom totals, the client path uses max_results+1 to set has_more."""
-    extra = MagicMock()
-    extra.get_short_id.return_value = "2103.99999"
-    extra.title = "Extra Paper"
-    extra.authors = mock_paper.authors
-    extra.summary = "Extra abstract"
-    extra.categories = ["cs.LG"]
-    extra.published = mock_paper.published
-    extra.pdf_url = "https://arxiv.org/pdf/2103.99999"
+async def test_search_includes_total_results_without_date_filters():
+    """Issue #189: total_results present even when date_from/date_to are absent."""
+    xml = _atom_feed_with_totals(entry_count=1, total_results=4142)
+    xml = xml.replace("2301.00001", "2103.12345")
+    _, mock_client = _mock_httpx_response(xml)
 
-    client = MagicMock()
-    client.results.return_value = [mock_paper, extra]
-
-    with patch("arxiv_mcp_server.tools.search.get_arxiv_client", return_value=client):
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search({"query": "test query", "max_results": 1})
 
     content = json.loads(result[0].text)
     assert content["returned"] == 1
     assert content["start"] == 0
+    assert content["total_results"] == 4142
     assert content["has_more"] is True
     assert content["next_start"] == 1
-    assert "total_results" not in content
     assert len(content["papers"]) == 1
     assert content["papers"][0]["id"] == "2103.12345"
 
@@ -586,49 +648,41 @@ async def test_raw_search_end_of_results_clears_next_start():
 
 
 @pytest.mark.asyncio
-async def test_client_path_start_offset_page_two(mock_paper):
-    """Client path must pass offset=start and return next_start for page 2."""
-    papers = []
-    for i in range(3):
-        p = MagicMock()
-        p.get_short_id.return_value = f"2103.1000{i}"
-        p.title = f"Paper {i}"
-        p.authors = mock_paper.authors
-        p.summary = f"Abstract {i}"
-        p.categories = ["cs.LG"]
-        p.published = mock_paper.published
-        p.pdf_url = f"https://arxiv.org/pdf/2103.1000{i}"
-        papers.append(p)
+async def test_search_start_offset_page_two_without_dates():
+    """Without dates, start is forwarded and total_results drives next_start."""
+    xml = _atom_feed_with_totals(entry_count=2, total_results=100)
+    # Rewrite ids to stable values
+    xml = xml.replace("2301.00001", "2103.10000").replace("2301.00002", "2103.10001")
+    _, mock_client = _mock_httpx_response(xml)
 
-    client = MagicMock()
-    # max_results=2 requests fetch_limit=3; 3 papers => has_more
-    client.results.return_value = papers
-
-    with patch("arxiv_mcp_server.tools.search.get_arxiv_client", return_value=client):
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search(
             {"query": "test query", "max_results": 2, "start": 10}
         )
 
-    args, kwargs = client.results.call_args
-    assert kwargs.get("offset", args[1] if len(args) > 1 else None) == 10
-    search_arg = args[0]
-    assert search_arg.max_results == 13  # start + max_results + 1
+        from urllib.parse import parse_qs, urlparse
+
+        url = mock_client.get.call_args[0][0]
+        params = parse_qs(urlparse(url).query)
+        assert params["start"] == ["10"]
+        assert params["max_results"] == ["2"]
 
     content = json.loads(result[0].text)
     assert content["start"] == 10
     assert content["returned"] == 2
+    assert content["total_results"] == 100
     assert content["has_more"] is True
     assert content["next_start"] == 12
     assert content["papers"][0]["id"] == "2103.10000"
 
 
 @pytest.mark.asyncio
-async def test_client_path_end_of_results_no_next_start(mock_paper):
-    """Client path end page: fewer than max_results => next_start null."""
-    client = MagicMock()
-    client.results.return_value = [mock_paper]  # only one left
+async def test_search_end_of_results_no_next_start_without_dates():
+    """Last page without dates: has_more false and next_start null."""
+    xml = _atom_feed_with_totals(entry_count=1, total_results=21)
+    _, mock_client = _mock_httpx_response(xml)
 
-    with patch("arxiv_mcp_server.tools.search.get_arxiv_client", return_value=client):
+    with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search(
             {"query": "test query", "max_results": 5, "start": 20}
         )
@@ -636,6 +690,7 @@ async def test_client_path_end_of_results_no_next_start(mock_paper):
     content = json.loads(result[0].text)
     assert content["start"] == 20
     assert content["returned"] == 1
+    assert content["total_results"] == 21
     assert content["has_more"] is False
     assert content["next_start"] is None
 


### PR DESCRIPTION
## Summary

`search_papers` only populated `total_results` on the date-filtered raw Atom path. Queries without `date_from`/`date_to` used the `arxiv.Client` path, which cannot see OpenSearch `totalResults`, so agents got `has_more`/`next_start` but no corpus size (#189).

- Always search via `_raw_arxiv_search` (Atom + OpenSearch `totalResults`), with or without date filters.
- `_build_search_response` therefore always receives the corpus total whenever pagination fields are emitted.
- Drop the unused client-only `_process_paper` path from `handle_search`.

Closes #189.

## Test plan

- [x] `test_search_includes_total_results_without_date_filters` — no dates → `total_results` present
- [x] Date-filtered searches still report `total_results`
- [x] `uv`/`pytest` `tests/tools/test_search.py` — 28 passed
- [x] Black 26.1.0 on changed files
- [x] Contents API PUT of `search.py`; remote size matches local (21987 bytes, byte-identical)