### PR TITLE
fix: strip ICML style warnings from HTML download extract (#190)

### DIFF
--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -126,7 +126,7 @@ settings = Settings()
 
 # Bump when HTML extraction changes so cached markdown is treated as stale
 # and re-downloaded without requiring the caller to pass force=true.
-EXTRACTOR_VERSION = 3
+EXTRACTOR_VERSION = 4
 
 
 # ---------------------------------------------------------------------------
@@ -143,7 +143,9 @@ class _ArticleTextExtractor(HTMLParser):
       - Skip script/style/nav/header/footer plus arXiv UI widgets.
       - Skip author-note chrome (Thanks/ORCID/affiliation/email blocks).
       - Skip footnotemark markers (class, role, or the literal token).
-      - Skip license/permission one-liners that appear before the title.
+      - Skip license/permission one-liners and ICML/LaTeX page-layout
+        style warnings (marginparsep and similar) that appear before the
+        title.
       - Keep math once: prefer ``alttext``, otherwise MathML without TeX
         ``<annotation>`` duplicates.
     """
@@ -188,6 +190,17 @@ class _ArticleTextExtractor(HTMLParser):
         "permission to reproduce",
         "hereby grants permission",
         "tables and figures in this paper solely for use",
+    )
+    # ICML/LaTeX page-layout warnings that latexml dumps before the title.
+    STYLE_WARNING_MARKERS = (
+        "marginparsep has been altered",
+        "topmargin has been altered",
+        "marginparpush has been altered",
+        "page layout violates the icml style",
+        "please do not change the page layout",
+        "packages like geometry",
+        "reliably undo arbitrary changes to the style",
+        "layout-changing commands",
     )
     SKIP_IDS = {
         "modal-form",
@@ -235,16 +248,19 @@ class _ArticleTextExtractor(HTMLParser):
         elem_id = attr_map.get("id") or ""
         return elem_id in self.SKIP_IDS
 
-    def _is_permission_boilerplate(self, text: str) -> bool:
+    def _is_pre_title_chrome(self, text: str) -> bool:
+        """True for permission/license lines or ICML style warnings."""
         lowered = text.lower()
-        return any(marker in lowered for marker in self.PERMISSION_MARKERS)
+        if any(marker in lowered for marker in self.PERMISSION_MARKERS):
+            return True
+        return any(marker in lowered for marker in self.STYLE_WARNING_MARKERS)
 
     def _emit(self, text: str) -> None:
         if self._skip_depth or not text:
             return
         if self.FOOTNOTEMARK_TOKEN in text.lower():
             return
-        if not self._seen_title and self._is_permission_boilerplate(text):
+        if not self._seen_title and self._is_pre_title_chrome(text):
             return
         if self._article_depth > 0:
             self._article_chunks.append(text)

--- a/tests/tools/test_download_footnotemark.py
+++ b/tests/tools/test_download_footnotemark.py
@@ -23,7 +23,7 @@ FOOTNOTEMARK_HTML = """
 
 def test_extractor_version_bumped_for_footnotemark_fix():
     """#175 auto-invalidates old Attention caches after this extractor change."""
-    assert EXTRACTOR_VERSION >= 3
+    assert EXTRACTOR_VERSION >= 4
 
 
 def test_html_to_text_drops_footnotemark_and_permission_line():

--- a/tests/tools/test_download_icml_style.py
+++ b/tests/tools/test_download_icml_style.py
@@ -1,0 +1,88 @@
+"""HTML extract must drop ICML/LaTeX page-layout style warnings (#190)."""
+
+from arxiv_mcp_server.tools.download import EXTRACTOR_VERSION, _html_to_text
+
+ICML_STYLE_WARNING_HTML = """
+<html>
+  <body>
+    <article class="ltx_document">
+      <div id="p1" class="ltx_para">
+        <p id="p1.1" class="ltx_p">marginparsep has been altered.
+        <br class="ltx_break"/>topmargin has been altered.
+        <br class="ltx_break"/>marginparpush has been altered.
+        <br class="ltx_break"/></p>
+      </div>
+      <div id="p2" class="ltx_para ltx_noindent">
+        <p id="p2.1" class="ltx_p">
+          <span class="ltx_text ltx_font_bold ltx_font_italic">
+            The page layout violates the ICML style.
+          </span>
+        </p>
+      </div>
+      <div id="p3" class="ltx_para ltx_noindent">
+        <p id="p3.1" class="ltx_p">Please do not change the page layout, or include packages like geometry,
+        savetrees, or fullpage, which change it for you.</p>
+      </div>
+      <div id="p4" class="ltx_para ltx_noindent">
+        <p id="p4.1" class="ltx_p">We're not able to reliably undo arbitrary changes to the style. Please remove
+        the offending package(s), or layout-changing commands and try again.</p>
+      </div>
+      <div id="p5" class="ltx_para ltx_noindent ltx_align_center">
+        <p id="p5.1" class="ltx_p">
+          <span class="ltx_text ltx_font_bold">
+            Why Has Predicting Downstream Capabilities of Frontier AI Models with Scale Remained Elusive?
+          </span>
+        </p>
+      </div>
+      <div id="abstract1" class="ltx_abstract">
+        <h6 class="ltx_title ltx_title_abstract">Abstract</h6>
+        <p>Predicting changes from scaling advanced AI systems is a desirable property.</p>
+      </div>
+    </article>
+  </body>
+</html>
+"""
+
+
+def test_extractor_version_bumped_for_icml_style_fix():
+    """#175 auto-invalidates old HTML caches after this extractor change."""
+    assert EXTRACTOR_VERSION >= 4
+
+
+def test_html_to_text_strips_icml_style_warnings_before_title():
+    text = _html_to_text(ICML_STYLE_WARNING_HTML)
+    assert text.lstrip().startswith(
+        "Why Has Predicting Downstream Capabilities of Frontier AI Models"
+    )
+    assert "Predicting changes from scaling" in text
+    leaked = [
+        "marginparsep",
+        "topmargin has been altered",
+        "marginparpush",
+        "page layout violates the ICML style",
+        "Please do not change the page layout",
+        "packages like geometry",
+        "layout-changing commands",
+        "reliably undo arbitrary changes",
+    ]
+    for snippet in leaked:
+        assert snippet.lower() not in text.lower(), snippet
+
+
+def test_html_to_text_keeps_177_permission_and_footnotemark_strips():
+    """#177 permission/footnotemark chrome must stay gone alongside #190."""
+    html = """
+    <html><body>
+      <article class="ltx_document">
+        <p>Provided proper attribution is provided, Google hereby grants permission to reproduce the tables and figures in this paper solely for use in journalistic or scholarly works.</p>
+        <h1 class="ltx_title">Attention Is All You Need</h1>
+        <span class="ltx_personname">Noam Shazeer<span class="ltx_note ltx_role_footnotemark"><sup class="ltx_note_mark">1</sup><span class="ltx_note_type">footnotemark: </span></span></span>
+        <p>The dominant sequence transduction models are based on attention.</p>
+      </article>
+    </body></html>
+    """
+    text = _html_to_text(html)
+    assert text.lstrip().startswith("Attention Is All You Need")
+    assert "The dominant sequence transduction models" in text
+    assert "permission to reproduce" not in text.lower()
+    assert "footnotemark" not in text.lower()


### PR DESCRIPTION
## Summary
- Extends HTML pre-title chrome stripping to drop ICML/LaTeX page-layout style warnings (`marginparsep`, `topmargin`, ICML style violation copy, geometry/layout admonitions) so `download_paper` HTML extracts begin at the paper title/abstract.
- Bumps `EXTRACTOR_VERSION` to 4 so stale HTML caches are invalidated.
- Adds fixture-backed tests for the ICML warning preamble; keeps #177 permission/footnotemark coverage.

Closes #190

## Test plan
- [x] Unit: `test_download_icml_style.py` + `test_download_footnotemark.py` (6 passed)
- [x] Live: extract of `2406.04391` HTML no longer starts with `marginparsep` / ICML style warning; starts at title
- [ ] CI on PR