### PR TITLE
fix: unpack _raw_arxiv_search in check_alerts (#193)

### DIFF
--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -253,7 +253,7 @@ async def handle_check_alerts(arguments: Dict[str, Any]) -> List[types.TextConte
                 continue
 
             last_checked = topic.get("last_checked")
-            search_results = await _raw_arxiv_search(
+            search_results, _total = await _raw_arxiv_search(
                 query=topic_query,
                 max_results=min(
                     int(topic.get("max_results", 10)), settings.MAX_RESULTS

--- a/tests/tools/test_alerts.py
+++ b/tests/tools/test_alerts.py
@@ -38,18 +38,22 @@ async def test_check_alerts_returns_new_papers(monkeypatch, alerts_test_env):
     """check_alerts should return new papers and update last_checked."""
 
     async def _mock_raw_search(**kwargs):
-        return [
-            {
-                "id": "2501.00001",
-                "title": "New Paper",
-                "authors": ["A"],
-                "abstract": "x",
-                "categories": ["cs.AI"],
-                "published": "2025-01-01T00:00:00Z",
-                "url": "https://arxiv.org/pdf/2501.00001",
-                "resource_uri": "arxiv://2501.00001",
-            }
-        ]
+        # Mirrors post-#189 _raw_arxiv_search: (papers, total_results)
+        return (
+            [
+                {
+                    "id": "2501.00001",
+                    "title": "New Paper",
+                    "authors": ["A"],
+                    "abstract": "x",
+                    "categories": ["cs.AI"],
+                    "published": "2025-01-01T00:00:00Z",
+                    "url": "https://arxiv.org/pdf/2501.00001",
+                    "resource_uri": "arxiv://2501.00001",
+                }
+            ],
+            1,
+        )
 
     monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_raw_search)
 
@@ -67,19 +71,52 @@ async def test_check_alerts_returns_new_papers(monkeypatch, alerts_test_env):
 
 
 @pytest.mark.asyncio
+async def test_check_alerts_unpacks_raw_search_tuple(monkeypatch, alerts_test_env):
+    """Regression #193: _raw_arxiv_search returns (papers, total); must unpack."""
+
+    async def _mock_tuple(**kwargs):
+        return (
+            [
+                {
+                    "id": "2501.00099",
+                    "title": "Tuple Paper",
+                    "authors": ["B"],
+                    "abstract": "y",
+                    "categories": ["cs.LG"],
+                    "published": "2025-02-01T00:00:00Z",
+                    "url": "https://arxiv.org/pdf/2501.00099",
+                    "resource_uri": "arxiv://2501.00099",
+                }
+            ],
+            42,
+        )
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_tuple)
+    await alerts_module.handle_watch_topic({"topic": "moe"})
+    response = await alerts_module.handle_check_alerts({})
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    assert payload["alerts"][0]["new_paper_count"] == 1
+    assert payload["alerts"][0]["new_papers"][0]["id"] == "2501.00099"
+
+
+@pytest.mark.asyncio
 async def test_check_alerts_handles_partial_paper_fields(monkeypatch, alerts_test_env):
     """check_alerts must not raise KeyError when a paper entry is missing optional fields."""
 
     async def _mock_partial(**kwargs):
-        return [
-            {
-                "id": "2501.00002",
-                "title": "Sparse Paper",
-                # "authors", "abstract", "url", "resource_uri" intentionally absent
-                "categories": ["cs.AI"],
-                "published": "2025-01-01T00:00:00Z",
-            }
-        ]
+        return (
+            [
+                {
+                    "id": "2501.00002",
+                    "title": "Sparse Paper",
+                    # "authors", "abstract", "url", "resource_uri" intentionally absent
+                    "categories": ["cs.AI"],
+                    "published": "2025-01-01T00:00:00Z",
+                }
+            ],
+            1,
+        )
 
     monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_partial)
 


### PR DESCRIPTION
## Summary
P0 regression from #189/#191: `_raw_arxiv_search` now returns `(papers, total_results)`, but `check_alerts` still treated the return as a list of papers. Iterating the tuple yielded the papers list, then `paper.get(...)` crashed with `'list' object has no attribute 'get'`.

## Fix
- Unpack `search_results, _total = await _raw_arxiv_search(...)` in `alerts.py`
- Update test mocks to return `(papers, total)` and add a regression test

Closes #193
