### PR TITLE
fix: expand simple macros in LaTeX section titles (#195)

### DIFF
--- a/src/arxiv_mcp_server/tools/latex.py
+++ b/src/arxiv_mcp_server/tools/latex.py
@@ -45,9 +45,12 @@ from .latex_flatten import (
     MAX_SECTION_COUNT,
     MAX_SECTION_TITLE_CHARS,
     LatexSection,
+    _collect_macros,
     _extract_section,
+    _find_section,
     _flatten_source as _flatten_source_impl,
     _flatten_source_with_unmatched as _flatten_source_with_unmatched_impl,
+    _mask_tex_comments,
     _parse_sections,
     _resolve_include,
 )
@@ -308,7 +311,7 @@ list_paper_latex_sections_tool = types.Tool(
 get_paper_latex_section_tool = types.Tool(
     name="get_paper_latex_section",
     annotations=ToolAnnotations(readOnlyHint=False, openWorldHint=True),
-    description="Return one bounded LaTeX section by outline ID or exact title.",
+    description="Return one bounded LaTeX section by outline ID or title (whitespace/case normalized; macros expanded).",
     inputSchema={
         "type": "object",
         "properties": {
@@ -316,7 +319,7 @@ get_paper_latex_section_tool = types.Tool(
             "section_id": {
                 "type": "string",
                 "maxLength": 200,
-                "description": "Section ID from list_paper_latex_sections or exact title",
+                "description": "Section ID from list_paper_latex_sections or section title",
             },
             **_page_properties(),
         },
@@ -438,18 +441,14 @@ async def handle_get_paper_latex_section(
     try:
         source = await asyncio.to_thread(_load_source, paper_id)
         sections = _parse_sections(source.content)
-        content = _extract_section(source.content, sections, section_id)
-        if content is None:
+        macros = _collect_macros(source.content, _mask_tex_comments(source.content))
+        section = _find_section(sections, section_id, macros)
+        if section is None:
             return _error(
                 f"LaTeX section {section_id!r} not found; call list_paper_latex_sections first",
                 paper_id,
             )
-        section = next(
-            item
-            for item in sections
-            if item.section_id.casefold() == section_id.strip().casefold()
-            or item.title.casefold() == section_id.strip().casefold()
-        )
+        content = source.content[section.start : section.end].rstrip()
         payload: dict[str, Any] = {
             "status": "success",
             "paper_id": paper_id,

--- a/src/arxiv_mcp_server/tools/latex_flatten.py
+++ b/src/arxiv_mcp_server/tools/latex_flatten.py
@@ -33,6 +33,12 @@ _MACRO_DEF_RE = re.compile(
     r"\s*(?:{\\([A-Za-z@]+)}|\\([A-Za-z@]+))"
     r"(?:\[(\d+)\])?(?:\[[^{}]*\])?"
 )
+_DEF_MACRO_RE = re.compile(r"\\(?:g)?def\s*\\([A-Za-z@]+)")
+_TITLE_STYLE_RE = re.compile(
+    r"\\(?:textsc|textrm|textsf|texttt|textit|textbf|emph|underline|"
+    r"mathrm|mathbf|mathit|operatorname)\s*\{([^{}]*)\}"
+)
+_XSPACE_RE = re.compile(r"\\xspace(?![A-Za-z@])")
 
 _INCLUDE_OR_SECTION_RE = re.compile(
     r"\\(?:subimport|subinputfrom|subincludefrom|import|inputfrom|"
@@ -110,8 +116,43 @@ def _skip_ws(source: str, index: int) -> int:
     return index
 
 
-def _plain_section_title(raw: str) -> str:
-    """Prefer the text argument of \\texorpdfstring{pdf}{text} when present."""
+def _normalize_heading(value: str) -> str:
+    """Casefold and collapse whitespace for human title matching."""
+    return re.sub(r"\s+", " ", value.strip()).casefold()
+
+
+def _strip_title_markup(title: str) -> str:
+    """Unwrap common text-style commands left after simple macro expansion."""
+    title = _XSPACE_RE.sub("", title)
+    for _ in range(MAX_MACRO_ROUNDS):
+        updated = _TITLE_STYLE_RE.sub(r"\1", title)
+        if updated == title:
+            break
+        title = updated
+    # Drop empty groups often left after macros written as \\name{}
+    title = title.replace("{}", "")
+    return title
+
+
+def _expand_title_macros(title: str, macros: dict[str, tuple[int, str]]) -> str:
+    """Expand simple macros inside a section title (not only include wrappers)."""
+    if not macros:
+        return title
+    # Prefer 0-arg macros; fall back to all collected macros if needed.
+    simple = {name: spec for name, spec in macros.items() if spec[0] == 0}
+    expandable = simple or macros
+    for _ in range(MAX_MACRO_ROUNDS):
+        masked = _mask_tex_comments(title)
+        title, changed = _expand_macros_once(title, masked, expandable)
+        if not changed:
+            break
+    return title
+
+
+def _plain_section_title(
+    raw: str, macros: dict[str, tuple[int, str]] | None = None
+) -> str:
+    """Prefer texorpdfstring text; expand simple macros; strip style markup."""
     title = raw.strip()
     prefix = "\\texorpdfstring"
     if title.startswith(prefix):
@@ -121,6 +162,9 @@ def _plain_section_title(raw: str) -> str:
             second = _balanced_arg(title, _skip_ws(title, first[1]))
             if second is not None:
                 title = second[0].strip()
+    if macros:
+        title = _expand_title_macros(title, macros)
+    title = _strip_title_markup(title)
     title = re.sub(r"\s+", " ", title).strip()
     return title[:MAX_SECTION_TITLE_CHARS]
 
@@ -135,6 +179,16 @@ def _collect_macros(text: str, masked: str) -> dict[str, tuple[int, str]]:
         if extracted is None:
             continue
         macros[name] = (nargs, extracted[0])
+    for match in _DEF_MACRO_RE.finditer(masked):
+        name = match.group(1)
+        body_start = _skip_ws(masked, match.end())
+        # Skip parameterized \\def\\name#1{...}; only simple replacements.
+        if body_start < len(masked) and masked[body_start] == "#":
+            continue
+        extracted = _balanced_arg(text, body_start)
+        if extracted is None:
+            continue
+        macros.setdefault(name, (0, extracted[0]))
     return macros
 
 
@@ -320,7 +374,9 @@ def _parse_sections(source: str) -> list[LatexSection]:
     raw: list[tuple[int, str, str, int]] = []
     levels = {"section": 1, "subsection": 2, "subsubsection": 3}
     counters = [0, 0, 0]
-    masked = _mask_macro_definitions(_mask_tex_comments(source))
+    comment_masked = _mask_tex_comments(source)
+    macros = _collect_macros(source, comment_masked)
+    masked = _mask_macro_definitions(comment_masked)
     for match in _SECTION_CMD_RE.finditer(masked):
         if len(raw) >= MAX_SECTION_COUNT:
             raise SourceArchiveLimitError("LaTeX source contains too many sections")
@@ -329,10 +385,9 @@ def _parse_sections(source: str) -> list[LatexSection]:
             fallback = _SECTION_RE.match(masked[match.start() :])
             if fallback is None:
                 continue
-            title = re.sub(r"\s+", " ", fallback.group(2)).strip()
-            title = title[:MAX_SECTION_TITLE_CHARS]
+            title = _plain_section_title(fallback.group(2), macros)
         else:
-            title = _plain_section_title(extracted[0])
+            title = _plain_section_title(extracted[0], macros)
         if not title:
             continue
         level = levels[match.group(1)]
@@ -353,14 +408,36 @@ def _parse_sections(source: str) -> list[LatexSection]:
     return sections
 
 
+def _find_section(
+    sections: list[LatexSection],
+    section_id: str,
+    macros: dict[str, tuple[int, str]] | None = None,
+) -> LatexSection | None:
+    """Match by section id or normalized title (expanded and raw forms)."""
+    raw = section_id.strip()
+    if not raw:
+        return None
+    id_needle = raw.casefold()
+    title_needle = _normalize_heading(raw)
+    expanded_needle = (
+        _normalize_heading(_plain_section_title(raw, macros)) if macros else None
+    )
+    for section in sections:
+        if section.section_id.casefold() == id_needle:
+            return section
+        normalized_title = _normalize_heading(section.title)
+        if normalized_title == title_needle:
+            return section
+        if expanded_needle and normalized_title == expanded_needle:
+            return section
+    return None
+
+
 def _extract_section(
     source: str, sections: list[LatexSection], section_id: str
 ) -> str | None:
-    needle = section_id.strip().casefold()
-    for section in sections:
-        if (
-            section.section_id.casefold() == needle
-            or section.title.casefold() == needle
-        ):
-            return source[section.start : section.end].rstrip()
-    return None
+    macros = _collect_macros(source, _mask_tex_comments(source))
+    section = _find_section(sections, section_id, macros)
+    if section is None:
+        return None
+    return source[section.start : section.end].rstrip()

--- a/tests/tools/test_latex.py
+++ b/tests/tools/test_latex.py
@@ -328,6 +328,85 @@ def test_parse_sections_ignores_commented_headings():
     assert [(item.section_id, item.title) for item in sections] == [("1", "Real")]
 
 
+def test_parse_sections_expands_simple_title_macros():
+    source = r"""
+\newcommand{\cinnamon}{Llama 2}
+\newcommand{\modelname}{\textsc{Llama 2-Chat}\xspace}
+\def\anise{Llama 1}
+\section{Introduction}
+Intro.
+\subsection{\cinnamon Pretrained Model Evaluation}
+Details.
+\section{\modelname Alignment}
+Chat.
+\subsection{\anise Baseline}
+Prior.
+"""
+
+    sections = latex._parse_sections(source)
+
+    assert [(item.section_id, item.title) for item in sections] == [
+        ("1", "Introduction"),
+        ("1.1", "Llama 2 Pretrained Model Evaluation"),
+        ("2", "Llama 2-Chat Alignment"),
+        ("2.1", "Llama 1 Baseline"),
+    ]
+    body = latex._extract_section(
+        source, sections, "Llama 2 Pretrained Model Evaluation"
+    )
+    assert body is not None
+    assert body.startswith("\\subsection{\\cinnamon Pretrained Model Evaluation}")
+    assert "\\section{\\modelname Alignment}" not in body
+    # Raw macro title and messy whitespace/case still resolve.
+    assert latex._extract_section(
+        source, sections, "\\cinnamon Pretrained Model Evaluation"
+    )
+    assert latex._extract_section(
+        source, sections, "  llama 2   pretrained model evaluation "
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_latex_section_by_expanded_human_title(monkeypatch):
+    source = (
+        "\\newcommand{\\cinnamon}{Llama 2}\n"
+        "\\section{Intro}\nA\n"
+        "\\subsection{\\cinnamon Pretrained Model Evaluation}\nBody text\n"
+        "\\section{Next}\nNope\n"
+    )
+    monkeypatch.setattr(
+        latex,
+        "_load_source",
+        lambda _paper_id: latex.LatexSource(source, "main.tex", 1),
+    )
+
+    listed = _payload(
+        await latex.handle_list_paper_latex_sections({"paper_id": "2401.00001"})
+    )
+    assert listed["sections"][1]["title"] == "Llama 2 Pretrained Model Evaluation"
+
+    by_title = _payload(
+        await latex.handle_get_paper_latex_section(
+            {
+                "paper_id": "2401.00001",
+                "section_id": "Llama 2 Pretrained Model Evaluation",
+            }
+        )
+    )
+    by_id = _payload(
+        await latex.handle_get_paper_latex_section(
+            {"paper_id": "2401.00001", "section_id": "1.1"}
+        )
+    )
+
+    assert by_title["status"] == "success"
+    assert by_title["section"]["id"] == "1.1"
+    assert by_title["section"]["title"] == "Llama 2 Pretrained Model Evaluation"
+    assert "Body text" in by_title["content"]
+    assert "Nope" not in by_title["content"]
+    assert by_id["section"]["title"] == by_title["section"]["title"]
+
+
 def test_download_archive_aborts_when_stream_exceeds_limit(monkeypatch):
     monkeypatch.setattr(latex, "MAX_ARCHIVE_BYTES", 5)
     response = MagicMock()


### PR DESCRIPTION
## Summary
- Expand simple `\newcommand` / `\def` macros when building LaTeX outline titles (reuse `#182` expansion helpers), then strip common text-style wrappers (`\textsc`, `\xspace`, etc.) so headings are human-readable.
- Improve `get_paper_latex_section` title matching: normalize whitespace/case and match expanded vs raw macro titles.
- Add fixture tests covering `\newcommand{\cinnamon}{Llama 2}` / `\textsc` / `\def` titles and get-by-human-title.

Closes #195

## Test plan
- [x] `pytest tests/tools/test_latex.py` (35 passed)
- [x] Live parse of `2307.09288`: outline §2.3 → `Llama 2 Pretrained Model Evaluation`; get-by-human-title succeeds
- [ ] CI green