### PR TITLE
fix: report not-found instead of pdf-extra for missing papers (#196)

### DIFF
--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -14,8 +14,10 @@ from ..config import Settings, get_arxiv_client
 from ..arxiv_api import ARXIV_RATE_LIMITER, stream_pdf_to_path
 from .content import add_content_payload
 from .list_papers import is_valid_arxiv_id, save_paper_metadata
+from .search import ARXIV_API_URL, ARXIV_NS, _rate_limited_get
 import logging
 import threading
+import xml.etree.ElementTree as ET
 
 pymupdf4llm: Any = None
 fitz: Any = None
@@ -448,6 +450,19 @@ class PaperNotFoundError(Exception):
     """Raised when an arXiv paper ID cannot be found."""
 
 
+async def _paper_exists_on_arxiv(paper_id: str) -> bool:
+    """Return True if arXiv has this paper/version.
+
+    Uses the same Atom ``id_list`` lookup as ``get_abstract``, so a missing
+    paper and a missing version both report as absent (empty feed).
+    """
+    url = f"{ARXIV_API_URL}?id_list={paper_id}&max_results=1"
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await _rate_limited_get(client, url)
+    root = ET.fromstring(response.text)
+    return bool(root.findall("atom:entry", ARXIV_NS))
+
+
 def _download_arxiv_pdf_to_path(paper: arxiv.Result, pdf_path: Path) -> None:
     """Persist an arXiv PDF using the version-independent streaming helper."""
     stream_pdf_to_path(
@@ -657,6 +672,12 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
             ]
 
         # --- HTML not available: fall back to PDF ---
+        # Distinguish a missing paper/version from a missing [pdf] extra so
+        # callers are not told to pip-install when the ID simply does not exist
+        # (issue #196). Same Atom id_list check as get_abstract.
+        if not await _paper_exists_on_arxiv(paper_id):
+            raise PaperNotFoundError(f"Paper {paper_id} not found on arXiv")
+
         if not _load_pdf_dependencies():
             return [
                 types.TextContent(

--- a/src/arxiv_mcp_server/tools/export_citations.py
+++ b/src/arxiv_mcp_server/tools/export_citations.py
@@ -218,6 +218,13 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
                 )
                 continue
             paper = metadata.get(_base_id(candidate))
+            # Versioned requests must match the Atom entry version (get_abstract
+            # rejects unknown versions; do not succeed with a bare abs URL for
+            # e.g. 2307.09288v999 when only another version exists).
+            if paper and _VERSION_SUFFIX.search(candidate):
+                resolved = paper.get("versioned_id") or ""
+                if resolved and resolved != candidate:
+                    paper = None
             if not paper:
                 results.append(
                     {

--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -373,6 +373,7 @@ def _parse_arxiv_atom_response(xml_text: str) -> List[Dict[str, Any]]:
             results.append(
                 {
                     "id": short_id,
+                    "versioned_id": paper_id,
                     "title": title,
                     "authors": authors,
                     "abstract": abstract,

--- a/tests/tools/test_download_html.py
+++ b/tests/tools/test_download_html.py
@@ -222,6 +222,10 @@ async def test_html_404_falls_back_to_pdf(temp_storage_path, mocker):
     mocker.patch(
         "arxiv_mcp_server.tools.download._fetch_html_content", return_value=None
     )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._paper_exists_on_arxiv",
+        return_value=True,
+    )
     mock_arxiv_result = MagicMock(spec=arxiv.Result)
     pdf_markdown = "# PDF Paper\nConverted from PDF."
     mocker.patch(
@@ -241,12 +245,16 @@ async def test_html_404_falls_back_to_pdf(temp_storage_path, mocker):
 
 @pytest.mark.asyncio
 async def test_paper_not_found_on_arxiv(temp_storage_path, mocker):
-    """StopIteration from PDF fallback -> error message returned."""
+    """Missing paper detected before PDF fallback -> error message returned."""
     paper_id = "9999.99999"
     _patch_path(mocker, temp_storage_path)
     mocker.patch("arxiv_mcp_server.tools.download._pdf_available", True)
     mocker.patch(
         "arxiv_mcp_server.tools.download._fetch_html_content", return_value=None
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._paper_exists_on_arxiv",
+        return_value=False,
     )
     mocker.patch(
         "arxiv_mcp_server.tools.download._fetch_pdf_content",
@@ -305,6 +313,10 @@ async def test_pdf_download_persists_metadata_from_arxiv_result(
         "arxiv_mcp_server.tools.download._fetch_html_content", return_value=None
     )
     mocker.patch(
+        "arxiv_mcp_server.tools.download._paper_exists_on_arxiv",
+        return_value=True,
+    )
+    mocker.patch(
         "arxiv_mcp_server.tools.download._fetch_pdf_content",
         return_value=("# Test Paper\nConverted from PDF.", mock_paper),
     )
@@ -322,3 +334,86 @@ async def test_pdf_download_persists_metadata_from_arxiv_result(
     assert sidecar["authors"] == ["John Doe", "Jane Smith"]
     assert sidecar["published"].startswith("2023-01-01")
     assert sidecar["extractor_version"] == EXTRACTOR_VERSION
+
+
+@pytest.mark.asyncio
+async def test_missing_paper_reports_not_found_not_pdf_extra(temp_storage_path, mocker):
+    """Nonexistent paper must not be misreported as a missing [pdf] extra (#196)."""
+    paper_id = "9999.99999"
+    _patch_path(mocker, temp_storage_path)
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_html_content", return_value=None
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._paper_exists_on_arxiv",
+        return_value=False,
+    )
+    # PDF extra intentionally unavailable — previously this path returned the
+    # pip-install hint even though the paper does not exist.
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._load_pdf_dependencies", return_value=False
+    )
+    mock_pdf = mocker.patch("arxiv_mcp_server.tools.download._fetch_pdf_content")
+
+    response = await handle_download({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "error"
+    assert result["message"] == f"Paper {paper_id} not found on arXiv"
+    assert "pdf extra" not in result["message"]
+    assert "pip install" not in result["message"]
+    mock_pdf.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_version_reports_not_found_not_pdf_extra(
+    temp_storage_path, mocker
+):
+    """Nonexistent version must not be misreported as a missing [pdf] extra (#196)."""
+    paper_id = "2307.09288v999"
+    _patch_path(mocker, temp_storage_path)
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_html_content", return_value=None
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._paper_exists_on_arxiv",
+        return_value=False,
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._load_pdf_dependencies", return_value=False
+    )
+    mock_pdf = mocker.patch("arxiv_mcp_server.tools.download._fetch_pdf_content")
+
+    response = await handle_download({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "error"
+    assert result["message"] == f"Paper {paper_id} not found on arXiv"
+    assert "pdf extra" not in result["message"]
+    mock_pdf.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_paper_without_html_still_hints_pdf_extra(
+    temp_storage_path, mocker
+):
+    """When the paper exists but HTML is gone, keep the [pdf] extra install hint."""
+    paper_id = "2103.22222"
+    _patch_path(mocker, temp_storage_path)
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._fetch_html_content", return_value=None
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._paper_exists_on_arxiv",
+        return_value=True,
+    )
+    mocker.patch(
+        "arxiv_mcp_server.tools.download._load_pdf_dependencies", return_value=False
+    )
+
+    response = await handle_download({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "error"
+    assert "pdf extra" in result["message"]
+    assert "pip install arxiv-mcp-server[pdf]" in result["message"]

--- a/tests/tools/test_export_citations.py
+++ b/tests/tools/test_export_citations.py
@@ -302,3 +302,33 @@ async def test_tool_registered_in_server():
     tools = {tool.name: tool for tool in await list_tools()}
     assert "export_citations" in tools
     assert tools["export_citations"].inputSchema["additionalProperties"] is False
+
+
+@pytest.mark.asyncio
+async def test_nonexistent_version_not_found(monkeypatch):
+    """Unknown version must not succeed with an abs URL (#196)."""
+    _stub_metadata(monkeypatch, [])
+    payload = await _run({"paper_ids": ["2307.09288v999"]})
+    assert payload["status"] == "error"
+    assert payload["results"][0]["paper_id"] == "2307.09288v999"
+    assert payload["results"][0]["error"] == "not found on arXiv"
+    assert payload["bibtex"] == ""
+
+
+@pytest.mark.asyncio
+async def test_nonexistent_version_rejected_when_other_version_exists(monkeypatch):
+    """Base metadata for another version must not satisfy a bad version request."""
+
+    async def _fake(ids):
+        paper = _paper("2307.09288", "Llama 2", ["Meta AI"])
+        paper["versioned_id"] = "2307.09288v1"
+        return {"2307.09288": paper}
+
+    monkeypatch.setattr(ec, "_fetch_metadata", _fake)
+    payload = await _run({"paper_ids": ["2307.09288v1", "2307.09288v999"]})
+    assert payload["status"] == "partial"
+    by_id = {r["paper_id"]: r for r in payload["results"]}
+    assert by_id["2307.09288v1"]["status"] == "success"
+    assert "2307.09288v1" in by_id["2307.09288v1"]["bibtex"]
+    assert by_id["2307.09288v999"]["status"] == "error"
+    assert by_id["2307.09288v999"]["error"] == "not found on arXiv"


### PR DESCRIPTION
## Summary
P1: `download_paper` treated missing papers/versions like a missing `[pdf]` extra after the HTML endpoint 404'd, so callers saw `pip install arxiv-mcp-server[pdf]` instead of a clear not-found error.

## Fix
- Before the PDF / pdf-extra fallback, check paper existence with the same Atom `id_list` lookup `get_abstract` uses
- Raise `Paper {id} not found on arXiv` for nonexistent IDs and nonexistent versions
- Keep the pdf-extra install hint only when the paper exists but HTML is unavailable

## Also in this PR (export_citations consistency)
- Atom parse now retains `versioned_id`
- `export_citations` rejects a versioned request when the resolved Atom entry is a different version (so `2307.09288v999` cannot succeed via base-ID metadata)

## Tests
- `test_missing_paper_reports_not_found_not_pdf_extra`
- `test_missing_version_reports_not_found_not_pdf_extra`
- `test_existing_paper_without_html_still_hints_pdf_extra`
- `test_nonexistent_version_not_found`
- `test_nonexistent_version_rejected_when_other_version_exists`

Closes #196
