### PR TITLE
chore: shrink MCP tool schemas to cut context tax (#131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,52 @@ The server currently exposes 16 tools.
 | `semantic_search` | Search downloaded papers by semantic similarity | Requires `[pro]` |
 | `reindex` | Rebuild the local semantic index | Requires `[pro]` |
 
+### search_papers query guide
+
+Tool schemas stay short on purpose. Use this section (not the always-loaded MCP description) for query tutorials, category catalogs, and workflow examples.
+
+**Query construction**
+
+- Use quoted phrases for exact matches: `"multi-agent systems"`, `"neural networks"`
+- Combine related concepts with OR: `"AI agents" OR "software agents"`
+- Field-specific searches: `ti:"exact title phrase"`, `au:"author name"`, `abs:"keyword"`, `cat:cs.LG`
+- Exclude with ANDNOT: `"machine learning" ANDNOT "survey"`
+- Prefer 2–4 core concepts over long keyword lists
+
+**Advanced patterns**
+
+- Field + phrase: `ti:"transformer architecture"`
+- Multiple fields: `au:"Smith" AND ti:"quantum"`
+- Exclusions: `"deep learning" ANDNOT ("survey" OR "review")`
+- Broad + narrow: `"artificial intelligence" AND (robotics OR "computer vision")`
+
+**Category filtering** (recommended for relevance)
+
+Computer Science: `cs.AI` (AI), `cs.LG` (ML), `cs.CL` (NLP), `cs.CV` (vision), `cs.MA` (multi-agent), `cs.RO` (robotics), `cs.NE` (neural/evolutionary), `cs.IR` (IR), `cs.HC` (HCI), `cs.CR` (security), `cs.DB` (databases)
+
+Statistics & Math: `stat.ML`, `stat.AP`, `math.OC`, `math.ST`
+
+Physics & other: `quant-ph`, `eess.SP`, `eess.AS`, `physics.data-an`
+
+**Effective examples**
+
+- `ti:"reinforcement learning"` with `categories: ["cs.LG", "cs.AI"]`
+- `au:"Hinton" AND "deep learning"` with `categories: ["cs.LG"]`
+- `"multi-agent" ANDNOT "survey"` with `categories: ["cs.MA"]`
+- `abs:"transformer" AND ti:"attention"` with `categories: ["cs.CL"]`
+
+**Dates and sorting**
+
+- Dates use `YYYY-MM-DD` (`date_from` / `date_to`)
+- Default `sort_by` is `relevance`; use `date` for newest-first monitoring
+- Foundational work: `date_to: "2010-12-31"` with title/abstract field searches
+
+**Pagination and rate limits**
+
+- Responses report `total_results` (corpus hits), `returned`, `has_more`, `start`, and `next_start`
+- Pass `start=next_start` for the next page
+- arXiv enforces ~3 seconds between requests (handled server-side); on rate-limit errors wait ~60s
+
 ### Search and inspect a paper
 
 Ask your MCP client to call `search_papers` with:

--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -394,103 +394,63 @@ def _parse_arxiv_atom_response(xml_text: str) -> List[Dict[str, Any]]:
 search_tool = types.Tool(
     name="search_papers",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
-    description="""Search for papers on arXiv with advanced filtering and query optimization.
-
-QUERY CONSTRUCTION GUIDELINES:
-- Use QUOTED PHRASES for exact matches: "multi-agent systems", "neural networks", "machine learning"
-- Combine related concepts with OR: "AI agents" OR "software agents" OR "intelligent agents"  
-- Use field-specific searches for precision:
-  - ti:"exact title phrase" - search in titles only
-  - au:"author name" - search by author
-  - abs:"keyword" - search in abstracts only
-- Use ANDNOT to exclude unwanted results: "machine learning" ANDNOT "survey"
-- For best results, use 2-4 core concepts rather than long keyword lists
-
-ADVANCED SEARCH PATTERNS:
-- Field + phrase: ti:"transformer architecture" for papers with exact title phrase
-- Multiple fields: au:"Smith" AND ti:"quantum" for author Smith's quantum papers  
-- Exclusions: "deep learning" ANDNOT ("survey" OR "review") to exclude survey papers
-- Broad + narrow: "artificial intelligence" AND (robotics OR "computer vision")
-
-CATEGORY FILTERING (highly recommended for relevance):
-Computer Science:
-- cs.AI: Artificial Intelligence
-- cs.LG: Machine Learning
-- cs.CL: Computation and Language (NLP)
-- cs.CV: Computer Vision
-- cs.MA: Multi-Agent Systems
-- cs.RO: Robotics
-- cs.NE: Neural and Evolutionary Computing
-- cs.IR: Information Retrieval
-- cs.HC: Human-Computer Interaction
-- cs.CR: Cryptography and Security
-- cs.DB: Databases
-Statistics & Math:
-- stat.ML: Machine Learning (Statistics)
-- stat.AP: Applications
-- math.OC: Optimization and Control
-- math.ST: Statistics Theory
-Physics & Other:
-- quant-ph: Quantum Physics
-- eess.SP: Signal Processing
-- eess.AS: Audio and Speech Processing
-- physics.data-an: Data Analysis and Statistics
-
-EXAMPLES OF EFFECTIVE QUERIES:
-- ti:"reinforcement learning" with categories: ["cs.LG", "cs.AI"] - for RL papers by title
-- au:"Hinton" AND "deep learning" with categories: ["cs.LG"] - for Hinton's deep learning work
-- "multi-agent" ANDNOT "survey" with categories: ["cs.MA"] - exclude survey papers
-- abs:"transformer" AND ti:"attention" with categories: ["cs.CL"] - attention papers with transformer abstracts
-
-DATE FILTERING: Use YYYY-MM-DD format for historical research:
-- date_to: "2015-12-31" - for foundational/classic work (pre-2016)
-- date_from: "2020-01-01" - for recent developments (post-2020)
-- Both together for specific time periods
-
-RESULT QUALITY: Default sort is RELEVANCE (most pertinent results first). Use sort_by: "date" to get newest papers first.
-Choose relevance for focused topic searches; choose date for monitoring recent developments.
-Each response reports total_results (arXiv corpus hit count, not page size), returned (papers in this page), has_more, start, and next_start (use start=next_start to fetch the next page).
-
-RATE LIMITING: arXiv enforces a 3-second minimum between requests. This server handles that automatically.
-If you see a rate limit error, wait 60 seconds before retrying — do not call the tool repeatedly in a loop.
-
-TIPS FOR FOUNDATIONAL RESEARCH:
-- Use date_to: "2010-12-31" to find classic papers on BDI, SOAR, ACT-R
-- Combine with field searches: ti:"BDI" AND abs:"belief desire intention"  
-- Try author searches: au:"Rao" AND "BDI" for Anand Rao's foundational BDI work""",
+    description=(
+        "Search arXiv by query with optional categories, date range, sort, and pagination.\n\n"
+        "Query: prefer quoted phrases; field prefixes ti:/au:/abs:/cat:; AND/OR/ANDNOT. "
+        "Unprefixed terms match title+abstract (not authors). "
+        "Use categories for relevance (e.g. cs.AI, cs.LG, cs.CL, cs.CV, cs.MA, cs.RO, "
+        "stat.ML, quant-ph). Full category catalog and worked examples: README "
+        "'search_papers query guide'.\n\n"
+        "Dates: YYYY-MM-DD via date_from/date_to. sort_by: relevance (default) or date "
+        "(newest first). max_results default 10 (cap 50). start default 0; responses "
+        "include total_results (corpus hits), returned, has_more, next_start.\n\n"
+        "arXiv enforces ~3s between requests (handled server-side). On rate-limit "
+        "errors wait ~60s before retrying."
+    ),
     inputSchema={
         "type": "object",
         "properties": {
             "query": {
                 "type": "string",
-                "description": 'Search query using quoted phrases for exact matches (e.g., \'"machine learning" OR "deep learning"\') or specific technical terms. Avoid overly broad or generic terms.',
+                "description": (
+                    "arXiv query string. Prefer quoted phrases and ti:/au:/abs:/cat: "
+                    "field prefixes; AND/OR/ANDNOT supported."
+                ),
             },
             "max_results": {
                 "type": "integer",
-                "description": "Maximum number of results to return (default: 10, max: 50). Use 15-20 for comprehensive searches.",
+                "description": "Maximum results to return (default: 10, max: 50).",
             },
             "start": {
                 "type": "integer",
                 "minimum": 0,
-                "description": "Zero-based offset into the arXiv result set (default: 0). Pass next_start from a previous response to fetch the next page.",
+                "description": (
+                    "Zero-based result offset (default: 0). Pass next_start from a "
+                    "previous response to fetch the next page."
+                ),
             },
             "date_from": {
                 "type": "string",
-                "description": "Start date for papers (YYYY-MM-DD format). Use to find recent work, e.g., '2023-01-01' for last 2 years.",
+                "description": "Inclusive start date (YYYY-MM-DD).",
             },
             "date_to": {
                 "type": "string",
-                "description": "End date for papers (YYYY-MM-DD format). Use with date_from to find historical work, e.g., '2020-12-31' for older research.",
+                "description": "Inclusive end date (YYYY-MM-DD).",
             },
             "categories": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Strongly recommended: arXiv categories to focus search (e.g., ['cs.AI', 'cs.MA'] for agent research, ['cs.LG'] for ML, ['cs.CL'] for NLP, ['cs.CV'] for vision). Greatly improves relevance.",
+                "description": (
+                    "arXiv category filters (e.g. ['cs.LG', 'cs.AI']). Strongly "
+                    "improves relevance."
+                ),
             },
             "sort_by": {
                 "type": "string",
                 "enum": ["relevance", "date"],
-                "description": "Sort results by 'relevance' (most relevant first, default) or 'date' (newest first). Use 'relevance' for focused searches, 'date' for recent developments.",
+                "description": (
+                    "Sort by 'relevance' (default) or 'date' (newest first)."
+                ),
             },
         },
         "required": ["query"],

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,6 +1,32 @@
-"""Tool schema compatibility tests."""
+"""Tool schema compatibility and size tests."""
+
+import json
 
 from arxiv_mcp_server.server import list_tools
+from arxiv_mcp_server.tools.search import search_tool
+
+# Baseline measured on main @94a1317 (search_papers Tool.description only).
+_SEARCH_PAPERS_DESC_BASELINE_CHARS = 3241
+_SEARCH_PAPERS_DESC_REDUCTION_TARGET = 0.40
+
+EXPECTED_TOOL_NAMES = {
+    "search_papers",
+    "download_paper",
+    "list_papers",
+    "read_paper",
+    "get_abstract",
+    "semantic_search",
+    "reindex",
+    "citation_graph",
+    "export_citations",
+    "watch_topic",
+    "check_alerts",
+    "list_watches",
+    "unwatch_topic",
+    "get_paper_latex",
+    "list_paper_latex_sections",
+    "get_paper_latex_section",
+}
 
 
 async def test_tool_input_schemas_are_closed():
@@ -13,3 +39,109 @@ async def test_tool_input_schemas_are_closed():
         assert (
             tool.inputSchema.get("additionalProperties") is False
         ), f"{tool.name} inputSchema must set additionalProperties=False"
+
+
+async def test_list_tools_metadata_is_valid_mcp():
+    """Every tool exposes a name, description, and typed argument schema."""
+    tools = await list_tools()
+    names = {tool.name for tool in tools}
+    assert names == EXPECTED_TOOL_NAMES
+
+    for tool in tools:
+        assert isinstance(tool.name, str) and tool.name
+        assert isinstance(tool.description, str) and tool.description.strip()
+        schema = tool.inputSchema
+        assert schema["type"] == "object"
+        assert schema.get("additionalProperties") is False
+        properties = schema.get("properties", {})
+        assert isinstance(properties, dict)
+        for prop_name, prop_schema in properties.items():
+            assert isinstance(prop_name, str) and prop_name
+            assert isinstance(prop_schema, dict)
+            assert "description" in prop_schema
+            assert (
+                "type" in prop_schema
+                or "anyOf" in prop_schema
+                or "oneOf" in prop_schema
+                or "$ref" in prop_schema
+            )
+        required = schema.get("required", [])
+        assert isinstance(required, list)
+        for req in required:
+            assert req in properties
+
+
+def test_search_papers_schema_semantics_preserved():
+    """Required params, enums, and invocation-critical guidance stay intact."""
+    schema = search_tool.inputSchema
+    props = schema["properties"]
+
+    assert schema["required"] == ["query"]
+    assert set(props) == {
+        "query",
+        "max_results",
+        "start",
+        "date_from",
+        "date_to",
+        "categories",
+        "sort_by",
+    }
+    assert props["query"]["type"] == "string"
+    assert props["max_results"]["type"] == "integer"
+    assert props["start"]["type"] == "integer"
+    assert props["start"]["minimum"] == 0
+    assert props["date_from"]["type"] == "string"
+    assert props["date_to"]["type"] == "string"
+    assert props["categories"]["type"] == "array"
+    assert props["categories"]["items"] == {"type": "string"}
+    assert props["sort_by"]["type"] == "string"
+    assert props["sort_by"]["enum"] == ["relevance", "date"]
+
+    desc = search_tool.description
+    assert "ti:" in desc and "au:" in desc and "abs:" in desc
+    assert "categor" in desc.lower()
+    assert "YYYY-MM-DD" in desc
+    assert "relevance" in desc and "date" in desc
+    assert "next_start" in desc
+
+
+def test_search_papers_description_reduced_vs_baseline():
+    """Description must shrink >=40% vs main @94a1317 baseline (3241 chars)."""
+    desc_len = len(search_tool.description)
+    reduction = 1.0 - (desc_len / _SEARCH_PAPERS_DESC_BASELINE_CHARS)
+    assert reduction >= _SEARCH_PAPERS_DESC_REDUCTION_TARGET, (
+        f"search_papers description is {desc_len} chars "
+        f"({reduction:.1%} reduction); need >= "
+        f"{_SEARCH_PAPERS_DESC_REDUCTION_TARGET:.0%} vs baseline "
+        f"{_SEARCH_PAPERS_DESC_BASELINE_CHARS}"
+    )
+
+
+async def test_tools_list_serialized_size_snapshot():
+    """Document tools/list payload size for PR before/after comparison."""
+    tools = await list_tools()
+    payload = [
+        (
+            t.model_dump(by_alias=True, exclude_none=True)
+            if hasattr(t, "model_dump")
+            else t.dict()
+        )
+        for t in tools
+    ]
+    total_chars = len(json.dumps(payload, separators=(",", ":")))
+    search = next(t for t in tools if t.name == "search_papers")
+    search_chars = len(
+        json.dumps(
+            (
+                search.model_dump(by_alias=True, exclude_none=True)
+                if hasattr(search, "model_dump")
+                else search.dict()
+            ),
+            separators=(",", ":"),
+        )
+    )
+    # Soft ceiling: after shrinking search_papers, total list should stay well
+    # under the pre-change ~16k measurement on main @94a1317.
+    assert search_chars < 3000
+    assert total_chars < 14000
+    assert len(search.description) < 1500


### PR DESCRIPTION
Closes #131

## Summary
Shrink always-loaded MCP tool schemas so clients pay less permanent context tax. The long `search_papers` query tutorials, category catalogs, and workflow examples move to a README section; the tool description keeps invocation-critical semantics only.

## Before / after (main `@94a1317` → this branch)

Measured by serializing `list_tools()` with `model_dump(by_alias=True, exclude_none=True)` and `json.dumps(..., separators=(',', ':'))` (≈4 chars/token).

| Metric | Before | After | Change |
|---|---:|---:|---:|
| `search_papers` **description** chars | 3,241 | 722 | **−77.7%** |
| `search_papers` serialized tool chars | 4,926 | 1,765 | −64.2% |
| Total `tools/list` chars (16 tools) | 16,132 | 12,971 | −19.6% |
| Total `tools/list` tokens (÷4) | ~4,033 | ~3,243 | −790 tokens |

Issue live snapshot on main cited ~15,162 / ~3,790 for `tools/list` and ~4,869 / ~1,217 for `search_papers` alone (description ≈ 3,241). Same direction; small absolute deltas come from annotation/serialization differences.

## Changes
- `src/arxiv_mcp_server/tools/search.py`: rewrite `search_papers` description to field prefixes, categories, dates, sort, pagination, and rate-limit notes only; tighten property descriptions; keep `required`, defaults, and `sort_by` enum.
- `README.md`: add **search_papers query guide** with tutorials, category catalog, and examples.
- `tests/test_tool_schemas.py`: validate tool names, descriptions, argument schemas, required fields, enums; assert ≥40% description reduction vs 3,241-char baseline; soft-cap serialized sizes.

## Test plan
- [x] `pytest tests/test_tool_schemas.py tests/tools/test_search.py --no-cov` (33 passed)
- [x] Black 26.1.0 on touched Python files
- [x] Contents API PUT remote size for `search.py` = 19,369 bytes (matches local)