### PR TITLE
fix: use shared parse_arxiv_id in download and latex tools (#200)

### DIFF
--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -13,7 +13,8 @@ from mcp.types import ToolAnnotations
 from ..config import Settings, get_arxiv_client
 from ..arxiv_api import ARXIV_RATE_LIMITER, stream_pdf_to_path
 from .content import add_content_payload
-from .list_papers import is_valid_arxiv_id, save_paper_metadata
+from .arxiv_ids import parse_arxiv_id
+from .list_papers import save_paper_metadata
 from .search import ARXIV_API_URL, ARXIV_NS, _rate_limited_get
 import logging
 import threading
@@ -602,15 +603,17 @@ def _persist_paper_metadata(
 async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Handle paper download requests synchronously (HTML first, then PDF)."""
     try:
-        paper_id = arguments["paper_id"].strip()
-        if not is_valid_arxiv_id(paper_id):
+        raw_id = arguments["paper_id"]
+        paper_id = parse_arxiv_id(raw_id) if isinstance(raw_id, str) else None
+        if paper_id is None:
+            display = raw_id.strip() if isinstance(raw_id, str) else raw_id
             return [
                 types.TextContent(
                     type="text",
                     text=json.dumps(
                         {
                             "status": "error",
-                            "message": f"Invalid arXiv ID: {paper_id}",
+                            "message": f"Invalid arXiv ID: {display}",
                         }
                     ),
                 )

--- a/src/arxiv_mcp_server/tools/latex.py
+++ b/src/arxiv_mcp_server/tools/latex.py
@@ -54,7 +54,7 @@ from .latex_flatten import (
     _parse_sections,
     _resolve_include,
 )
-from .list_papers import is_valid_arxiv_id
+from .arxiv_ids import parse_arxiv_id
 
 logger = logging.getLogger("arxiv-mcp-server")
 settings = Settings()
@@ -142,10 +142,10 @@ def _normalized_paper_id(arguments: dict[str, Any]) -> str | None:
     value = arguments.get("paper_id")
     if not isinstance(value, str):
         return None
-    paper_id = value.strip()
-    if len(paper_id) > MAX_PAPER_ID_CHARS:
+    paper_id = parse_arxiv_id(value)
+    if paper_id is None or len(paper_id) > MAX_PAPER_ID_CHARS:
         return None
-    return paper_id if is_valid_arxiv_id(paper_id) else None
+    return paper_id
 
 
 def _bounded_arguments(arguments: dict[str, Any]) -> dict[str, Any]:

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -284,3 +284,54 @@ def test_html_to_text_extracts_article_text():
     # because nav/footer ARE in SKIP_TAGS — verify they're gone
     assert "Nav stuff" not in text
     assert "Footer" not in text
+
+
+# ---------------------------------------------------------------------------
+# Shared ID normalization (issue #200)
+# ---------------------------------------------------------------------------
+
+_ID_FORM_CASES = [
+    ("1810.04805", "1810.04805"),
+    ("arxiv:1810.04805", "1810.04805"),
+    ("https://arxiv.org/abs/1810.04805", "1810.04805"),
+    ("https://arxiv.org/pdf/1810.04805.pdf", "1810.04805"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_id, expected", _ID_FORM_CASES)
+async def test_download_paper_id_normalize_matrix(
+    temp_storage_path, mocker, raw_id, expected
+):
+    """download_paper accepts bare / arxiv: / abs / pdf forms via parse_arxiv_id."""
+    from arxiv_mcp_server.tools import download as download_module
+
+    _write_cached_paper(temp_storage_path, expected, "# Cached\nNormalized ID path.")
+    mocker.patch.object(
+        download_module,
+        "get_paper_path",
+        side_effect=lambda pid, suffix=".md": temp_storage_path / f"{pid}{suffix}",
+    )
+    mock_html = mocker.patch.object(download_module, "_fetch_html_content")
+    mock_pdf = mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    response = await handle_download({"paper_id": raw_id})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["paper_id"] == expected
+    assert result["source"] == "cache"
+    mock_html.assert_not_called()
+    mock_pdf.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_id",
+    ["not-a-paper", "arxiv:not-a-paper", "https://example.com/abs/1810.04805"],
+)
+async def test_download_rejects_invalid_id_forms(raw_id):
+    response = await handle_download({"paper_id": raw_id})
+    result = json.loads(response[0].text)
+    assert result["status"] == "error"
+    assert "Invalid arXiv ID" in result["message"]

--- a/tests/tools/test_latex.py
+++ b/tests/tools/test_latex.py
@@ -667,3 +667,74 @@ async def test_server_registers_and_routes_latex_tools(monkeypatch):
     monkeypatch.setattr(server, "handle_get_paper_latex", fake_handler)
     result = await server.call_tool("get_paper_latex", {"paper_id": "2401.00001"})
     assert json.loads(result[0].text)["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Shared ID normalization (issue #200)
+# ---------------------------------------------------------------------------
+
+_LATEX_ID_FORM_CASES = [
+    ("1706.03762", "1706.03762"),
+    ("arxiv:1706.03762", "1706.03762"),
+    ("https://arxiv.org/abs/1706.03762", "1706.03762"),
+    ("https://arxiv.org/pdf/1706.03762.pdf", "1706.03762"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_id, expected", _LATEX_ID_FORM_CASES)
+async def test_latex_list_paper_id_normalize_matrix(monkeypatch, raw_id, expected):
+    """list_paper_latex_sections accepts bare / arxiv: / abs / pdf forms."""
+    recorded = []
+
+    def _fake_load(paper_id):
+        recorded.append(paper_id)
+        return latex.LatexSource("\\section{Intro}\nHello", "main.tex", 1)
+
+    monkeypatch.setattr(latex, "_load_source", _fake_load)
+    payload = _payload(
+        await latex.handle_list_paper_latex_sections({"paper_id": raw_id})
+    )
+    assert payload["status"] == "success"
+    assert payload["paper_id"] == expected
+    assert recorded == [expected]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_id, expected", _LATEX_ID_FORM_CASES)
+async def test_latex_get_paper_id_normalize_matrix(monkeypatch, raw_id, expected):
+    """get_paper_latex accepts bare / arxiv: / abs / pdf forms."""
+    recorded = []
+
+    def _fake_load(paper_id):
+        recorded.append(paper_id)
+        return latex.LatexSource("body text", "main.tex", 1)
+
+    monkeypatch.setattr(latex, "_load_source", _fake_load)
+    payload = _payload(await latex.handle_get_paper_latex({"paper_id": raw_id}))
+    assert payload["status"] == "success"
+    assert payload["paper_id"] == expected
+    assert recorded == [expected]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw_id, expected", _LATEX_ID_FORM_CASES)
+async def test_latex_get_section_paper_id_normalize_matrix(
+    monkeypatch, raw_id, expected
+):
+    """get_paper_latex_section accepts bare / arxiv: / abs / pdf forms."""
+    recorded = []
+
+    def _fake_load(paper_id):
+        recorded.append(paper_id)
+        return latex.LatexSource("\\section{Intro}\nHello", "main.tex", 1)
+
+    monkeypatch.setattr(latex, "_load_source", _fake_load)
+    payload = _payload(
+        await latex.handle_get_paper_latex_section(
+            {"paper_id": raw_id, "section_id": "1"}
+        )
+    )
+    assert payload["status"] == "success"
+    assert payload["paper_id"] == expected
+    assert recorded == [expected]


### PR DESCRIPTION
## Summary
- Wire `download_paper` and latex `_normalized_paper_id` through shared `parse_arxiv_id` (same helper #174 used for get_abstract/export/citation_graph/read_paper)
- Accept bare IDs, `arxiv:` prefixes, and abs/pdf URLs consistently
- Add matrix tests across `download_paper` and latex list/get/section handlers

Closes #200

## Test plan
- [x] `pytest tests/tools/test_download.py tests/tools/test_latex.py tests/tools/test_arxiv_ids.py` (94 passed)
- [x] Black 26.1.0
- [x] Verified `download.py` size ~25KB (25884 bytes)