### PR TITLE
fix: resolve bare paper IDs to stored versions (#202)

### DIFF
--- a/src/arxiv_mcp_server/tools/arxiv_ids.py
+++ b/src/arxiv_mcp_server/tools/arxiv_ids.py
@@ -26,6 +26,9 @@ _URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Trailing version suffix on an otherwise-valid arXiv ID (v1, v7, …).
+_VERSION_SUFFIX_RE = re.compile(r"(v\d+)$", re.IGNORECASE)
+
 
 def is_valid_arxiv_id(stem: str) -> bool:
     """Return True if *stem* looks like a valid arXiv paper ID."""
@@ -56,3 +59,24 @@ def parse_arxiv_id(raw: str) -> Optional[str]:
     if not normalized or not is_valid_arxiv_id(normalized):
         return None
     return normalized
+
+
+def arxiv_version_suffix(paper_id: str) -> Optional[str]:
+    """Return the trailing ``vN`` suffix (lowercased), or None if absent."""
+    match = _VERSION_SUFFIX_RE.search(paper_id)
+    if not match:
+        return None
+    return match.group(1).lower()
+
+
+def bare_arxiv_id(paper_id: str) -> str:
+    """Strip a trailing version suffix, keeping the bare arXiv identifier."""
+    return _VERSION_SUFFIX_RE.sub("", paper_id)
+
+
+def arxiv_version_number(paper_id: str) -> int:
+    """Numeric version for ordering; bare IDs sort as ``-1`` (below v1)."""
+    suffix = arxiv_version_suffix(paper_id)
+    if suffix is None:
+        return -1
+    return int(suffix[1:])

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -13,7 +13,12 @@ from mcp.types import ToolAnnotations
 from ..config import Settings, get_arxiv_client
 from ..arxiv_api import ARXIV_RATE_LIMITER, stream_pdf_to_path
 from .content import add_content_payload
-from .arxiv_ids import parse_arxiv_id
+from .arxiv_ids import (
+    arxiv_version_suffix,
+    bare_arxiv_id,
+    parse_arxiv_id,
+)
+from .list_papers import resolve_stored_stem
 from .list_papers import save_paper_metadata
 from .search import ARXIV_API_URL, ARXIV_NS, _rate_limited_get
 import logging
@@ -370,6 +375,74 @@ def _is_fresh_cache(paper_id: str) -> bool:
     return stored is not None and stored >= EXTRACTOR_VERSION
 
 
+def _read_arxiv_version(paper_id: str) -> str | None:
+    """Return the sidecar arXiv version (e.g. ``v7``), or None."""
+    path = get_paper_path(paper_id, ".meta.json")
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    version = data.get("arxiv_version")
+    if isinstance(version, str) and version.strip():
+        normalized = version.strip().lower()
+        if not normalized.startswith("v"):
+            normalized = f"v{normalized}"
+        return normalized if normalized[1:].isdigit() else None
+    return arxiv_version_suffix(paper_id)
+
+
+def _version_from_arxiv_result(paper) -> str | None:
+    """Best-effort ``vN`` from an arXiv result short id."""
+    short = getattr(paper, "get_short_id", None)
+    if callable(short):
+        try:
+            return arxiv_version_suffix(str(short()))
+        except Exception:
+            return None
+    return None
+
+
+def _cleanup_versioned_aliases(storage_id: str) -> None:
+    """Remove legacy versioned ``.md`` / sidecar files for the same bare ID."""
+    storage = get_paper_path(storage_id, ".md").parent
+    if not storage.exists():
+        return
+    for path in storage.iterdir():
+        if not path.is_file():
+            continue
+        stem = path.name
+        # Handle both ``id.md`` and ``id.meta.json``
+        if stem.endswith(".meta.json"):
+            paper_stem = stem[: -len(".meta.json")]
+        elif path.suffix == ".md":
+            paper_stem = path.stem
+        else:
+            continue
+        if paper_stem == storage_id:
+            continue
+        if bare_arxiv_id(paper_stem) != storage_id:
+            continue
+        try:
+            path.unlink()
+        except OSError:
+            logger.warning("Could not remove legacy alias %s", path)
+
+
+def _cache_satisfies_request(storage_stem: str, requested_id: str) -> bool:
+    """True when a fresh cache entry can answer *requested_id*."""
+    if not _is_fresh_cache(storage_stem):
+        return False
+    req_ver = arxiv_version_suffix(requested_id)
+    if req_ver is None:
+        return True
+    stored_ver = _read_arxiv_version(storage_stem) or arxiv_version_suffix(storage_stem)
+    return stored_ver is not None and stored_ver == req_ver
+
+
 def _wants_force_refresh(arguments: Dict[str, Any]) -> bool:
     """Return True when the caller asked to overwrite a cached paper."""
     return bool(arguments.get("force") or arguments.get("refresh"))
@@ -548,6 +621,7 @@ def _metadata_from_arxiv_result(paper_id: str, paper) -> dict[str, Any]:
         "title": title,
         "authors": authors,
         "published": published_text,
+        "arxiv_version": _version_from_arxiv_result(paper),
     }
 
 
@@ -568,6 +642,7 @@ def _persist_paper_metadata(
     paper_id: str,
     arxiv_result=None,
     title_hint: str | None = None,
+    arxiv_version: str | None = None,
 ) -> None:
     """Write a sidecar from arXiv API metadata. Never fail the download."""
     try:
@@ -583,12 +658,18 @@ def _persist_paper_metadata(
                 "authors": [],
                 "published": None,
             }
+        version = (
+            arxiv_version
+            or (metadata.get("arxiv_version") if metadata else None)
+            or arxiv_version_suffix(paper_id)
+        )
         save_paper_metadata(
             paper_id,
             title=metadata.get("title") or None,
             authors=metadata.get("authors") or [],
             published=metadata.get("published"),
             extractor_version=EXTRACTOR_VERSION,
+            arxiv_version=version,
             path=get_paper_path(paper_id, ".meta.json"),
         )
     except Exception:
@@ -618,49 +699,68 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
                     ),
                 )
             ]
-        md_path = get_paper_path(paper_id, ".md")
+        # Fetch may use a versioned ID; storage always uses the bare key so
+        # read_paper("1706.03762") finds download_paper("1706.03762v7") (#202).
+        storage_id = bare_arxiv_id(paper_id)
+        requested_version = arxiv_version_suffix(paper_id)
+        md_path = get_paper_path(storage_id, ".md")
         force = _wants_force_refresh(arguments)
 
-        # --- Cache hit: return immediately unless force/stale extractor ---
-        if md_path.exists() and not force and _is_fresh_cache(paper_id):
-            content = md_path.read_text(encoding="utf-8")
-            payload = add_content_payload(
-                {
-                    "status": "success",
-                    "message": "Paper already available (returned from cache)",
-                    "paper_id": paper_id,
-                    "source": "cache",
-                },
-                content,
-                arguments,
-                _CONTENT_WARNING,
-            )
-            return [
-                types.TextContent(
-                    type="text",
-                    text=json.dumps(payload),
+        # --- Cache hit: bare key (via get_paper_path) or legacy alias ---
+        if not force:
+            resolved = None
+            if md_path.exists() and _cache_satisfies_request(storage_id, paper_id):
+                resolved = storage_id
+            else:
+                # Legacy versioned filenames still live under STORAGE_PATH.
+                legacy = resolve_stored_stem(paper_id, Path(settings.STORAGE_PATH))
+                if (
+                    legacy
+                    and legacy != storage_id
+                    and _cache_satisfies_request(legacy, paper_id)
+                ):
+                    resolved = legacy
+            if resolved:
+                content = get_paper_path(resolved, ".md").read_text(encoding="utf-8")
+                payload = add_content_payload(
+                    {
+                        "status": "success",
+                        "message": "Paper already available (returned from cache)",
+                        "paper_id": storage_id,
+                        "source": "cache",
+                    },
+                    content,
+                    arguments,
+                    _CONTENT_WARNING,
                 )
-            ]
+                return [
+                    types.TextContent(
+                        type="text",
+                        text=json.dumps(payload),
+                    )
+                ]
 
         # --- Try HTML endpoint first ---
         html_text = await asyncio.to_thread(_fetch_html_content, paper_id)
 
         if html_text is not None:
-            # Save to cache
+            # Save to cache under the bare ID
             md_path.write_text(html_text, encoding="utf-8")
             await asyncio.to_thread(
                 _persist_paper_metadata,
-                paper_id,
+                storage_id,
                 None,
                 None,
+                requested_version,
             )
+            _cleanup_versioned_aliases(storage_id)
             # Best-effort index; the tracked task is drained at shutdown.
-            _track_index_task(_run_index_by_id(paper_id))
+            _track_index_task(_run_index_by_id(storage_id))
             payload = add_content_payload(
                 {
                     "status": "success",
                     "message": "Paper fetched from arXiv HTML endpoint",
-                    "paper_id": paper_id,
+                    "paper_id": storage_id,
                     "source": "html",
                 },
                 html_text,
@@ -701,14 +801,16 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
         logger.info(f"Falling back to PDF download for {paper_id}")
         markdown, arxiv_result = await asyncio.to_thread(_fetch_pdf_content, paper_id)
 
-        # Save to cache
+        # Save to cache under the bare ID
         md_path.write_text(markdown, encoding="utf-8")
         await asyncio.to_thread(
             _persist_paper_metadata,
-            paper_id,
+            storage_id,
             arxiv_result,
             None,
+            requested_version,
         )
+        _cleanup_versioned_aliases(storage_id)
 
         # Best-effort index; the tracked task is drained at shutdown.
         _track_index_task(_run_index_from_result(arxiv_result))
@@ -717,7 +819,7 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
             {
                 "status": "success",
                 "message": "Paper fetched via PDF conversion",
-                "paper_id": paper_id,
+                "paper_id": storage_id,
                 "source": "pdf",
             },
             markdown,

--- a/src/arxiv_mcp_server/tools/export_citations.py
+++ b/src/arxiv_mcp_server/tools/export_citations.py
@@ -16,7 +16,7 @@ import httpx
 import mcp.types as types
 from mcp.types import ToolAnnotations
 
-from .arxiv_ids import is_valid_arxiv_id, normalize_arxiv_id
+from .arxiv_ids import bare_arxiv_id, is_valid_arxiv_id, normalize_arxiv_id
 from .search import ARXIV_API_URL, _parse_arxiv_atom_response, _rate_limited_get
 
 logger = logging.getLogger("arxiv-mcp-server")
@@ -61,7 +61,7 @@ def _ascii_token(value: str) -> str:
 
 def _base_id(paper_id: str) -> str:
     """Strip a trailing version suffix, keeping the bare arXiv identifier."""
-    return _VERSION_SUFFIX.sub("", paper_id)
+    return bare_arxiv_id(paper_id)
 
 
 def _year_of(published: str) -> str:

--- a/src/arxiv_mcp_server/tools/list_papers.py
+++ b/src/arxiv_mcp_server/tools/list_papers.py
@@ -9,7 +9,13 @@ import mcp.types as types
 from mcp.types import ToolAnnotations
 
 from ..config import Settings
-from .arxiv_ids import is_valid_arxiv_id
+from .arxiv_ids import (
+    arxiv_version_number,
+    arxiv_version_suffix,
+    bare_arxiv_id,
+    is_valid_arxiv_id,
+    normalize_arxiv_id,
+)
 
 settings = Settings()
 logger = logging.getLogger("arxiv-mcp-server")
@@ -44,14 +50,9 @@ list_tool = types.Tool(
 )
 
 
-def list_papers() -> list[str]:
-    """List all stored paper IDs.
-
-    Returns an empty list if the storage directory does not exist yet or
-    contains no .md files.  Only plain files with the .md suffix are
-    considered; sub-directories and other file types are silently ignored.
-    """
-    storage = Path(settings.STORAGE_PATH)
+def _raw_stored_stems(storage_path: Optional[Path] = None) -> list[str]:
+    """Return every on-disk ``.md`` stem that looks like an arXiv ID."""
+    storage = Path(storage_path or settings.STORAGE_PATH)
     if not storage.exists():
         return []
     return [
@@ -59,6 +60,113 @@ def list_papers() -> list[str]:
         for p in storage.iterdir()
         if p.is_file() and p.suffix == ".md" and is_valid_arxiv_id(p.stem)
     ]
+
+
+def _stems_for_bare_id(
+    bare_id: str,
+    stems: Optional[List[str]] = None,
+    storage_path: Optional[Path] = None,
+) -> list[str]:
+    """Return stored stems that share *bare_id* (including the bare stem)."""
+    pool = stems if stems is not None else _raw_stored_stems(storage_path)
+    return [stem for stem in pool if bare_arxiv_id(stem) == bare_id]
+
+
+def preferred_stored_stem(candidates: List[str]) -> Optional[str]:
+    """Pick the canonical on-disk stem for one paper.
+
+    Prefer the bare-ID file (new storage model). Otherwise keep the highest
+    versioned legacy key.
+    """
+    if not candidates:
+        return None
+    bare = bare_arxiv_id(candidates[0])
+    if bare in candidates:
+        return bare
+    return max(candidates, key=arxiv_version_number)
+
+
+def _sidecar_arxiv_version(
+    stem: str, storage_path: Optional[Path] = None
+) -> Optional[str]:
+    """Read ``arxiv_version`` from a stem's sidecar, if present."""
+    path = (
+        Path(storage_path) / f"{stem}{METADATA_SUFFIX}"
+        if storage_path is not None
+        else paper_metadata_path(stem)
+    )
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    version = data.get("arxiv_version")
+    if isinstance(version, str) and version.strip():
+        normalized = version.strip().lower()
+        if not normalized.startswith("v"):
+            normalized = f"v{normalized}"
+        return normalized if normalized[1:].isdigit() else None
+    return arxiv_version_suffix(stem)
+
+
+def resolve_stored_stem(
+    paper_id: str, storage_path: Optional[Path] = None
+) -> Optional[str]:
+    """Map a requested paper ID to an on-disk markdown stem.
+
+    Bare IDs resolve to the bare storage key when present, otherwise to the
+    highest stored versioned legacy key. Versioned IDs match an exact legacy
+    stem, or a bare file whose sidecar records the same version (or has no
+    version metadata — treated as readable content for that paper).
+
+    Pass *storage_path* when the caller uses a different Settings instance
+    than this module (tests often patch per-module settings).
+    """
+    requested = normalize_arxiv_id(paper_id) if paper_id else ""
+    if not requested or not is_valid_arxiv_id(requested):
+        return None
+
+    stems = _raw_stored_stems(storage_path)
+    if requested in stems:
+        return requested
+
+    bare = bare_arxiv_id(requested)
+    group = _stems_for_bare_id(bare, stems, storage_path)
+    if not group:
+        return None
+
+    req_ver = arxiv_version_suffix(requested)
+    if req_ver is None:
+        return preferred_stored_stem(group)
+
+    if requested in group:
+        return requested
+
+    if bare in group:
+        stored_ver = _sidecar_arxiv_version(bare, storage_path)
+        if stored_ver is None or stored_ver == req_ver:
+            return bare
+
+    for stem in group:
+        if arxiv_version_suffix(stem) == req_ver:
+            return stem
+    return None
+
+
+def list_papers() -> list[str]:
+    """List stored paper IDs, deduped to one bare ID per paper.
+
+    Returns an empty list if the storage directory does not exist yet or
+    contains no .md files. Only plain files with the .md suffix are
+    considered; sub-directories and other file types are silently ignored.
+    Legacy versioned filenames are folded into their bare ID so the same
+    paper is never listed twice.
+    """
+    stems = _raw_stored_stems()
+    return sorted({bare_arxiv_id(stem) for stem in stems})
 
 
 def paper_metadata_path(paper_id: str) -> Path:
@@ -73,6 +181,7 @@ def save_paper_metadata(
     authors: Optional[List[str]] = None,
     published: Optional[str] = None,
     extractor_version: Optional[int] = None,
+    arxiv_version: Optional[str] = None,
     path: Optional[Path] = None,
 ) -> None:
     """Persist lightweight paper metadata next to the downloaded markdown."""
@@ -85,6 +194,12 @@ def save_paper_metadata(
     }
     if extractor_version is not None:
         payload["extractor_version"] = extractor_version
+    if arxiv_version:
+        normalized = arxiv_version.strip().lower()
+        if normalized and not normalized.startswith("v"):
+            normalized = f"v{normalized}"
+        if normalized and normalized[1:].isdigit():
+            payload["arxiv_version"] = normalized
     destination.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
@@ -103,7 +218,9 @@ def _title_from_markdown(paper_id: str) -> Optional[str]:
 
 def load_paper_metadata(paper_id: str) -> Dict[str, Any]:
     """Load local metadata for a stored paper without hitting the network."""
-    path = paper_metadata_path(paper_id)
+    bare = bare_arxiv_id(paper_id)
+    stem = resolve_stored_stem(paper_id) or paper_id
+    path = paper_metadata_path(stem)
     if path.exists():
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -115,14 +232,14 @@ def load_paper_metadata(paper_id: str) -> Dict[str, Any]:
                 if not isinstance(authors, list):
                     authors = []
                 return {
-                    "id": paper_id,
+                    "id": bare,
                     "title": data.get("title") or None,
                     "authors": [str(author) for author in authors],
                     "published": data.get("published") or None,
                 }
     return {
-        "id": paper_id,
-        "title": _title_from_markdown(paper_id),
+        "id": bare,
+        "title": _title_from_markdown(stem),
         "authors": [],
         "published": None,
     }

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -6,8 +6,9 @@ from typing import Dict, Any, List
 import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings
-from .arxiv_ids import normalize_arxiv_id
+from .arxiv_ids import bare_arxiv_id, normalize_arxiv_id, parse_arxiv_id
 from .content import add_content_payload
+from .list_papers import resolve_stored_stem
 
 settings = Settings()
 
@@ -50,39 +51,49 @@ read_tool = types.Tool(
 )
 
 
-def list_papers() -> list[str]:
-    """List all stored paper IDs."""
-    return [p.stem for p in Path(settings.STORAGE_PATH).glob("*.md")]
-
-
 async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Handle requests to read a paper's content."""
     try:
-        paper_ids = list_papers()
-        paper_id = normalize_arxiv_id(arguments["paper_id"])
-        # Check if paper exists
-        if paper_id not in paper_ids:
+        raw_id = arguments["paper_id"]
+        paper_id = parse_arxiv_id(raw_id) if isinstance(raw_id, str) else None
+        if paper_id is None and isinstance(raw_id, str):
+            # Preserve prior normalize-only behavior for slightly odd inputs
+            # that still match an on-disk stem via resolve.
+            paper_id = normalize_arxiv_id(raw_id)
+
+        resolved = (
+            resolve_stored_stem(paper_id, Path(settings.STORAGE_PATH))
+            if paper_id
+            else None
+        )
+        if resolved is None:
+            display = paper_id or (
+                raw_id.strip() if isinstance(raw_id, str) else raw_id
+            )
             return [
                 types.TextContent(
                     type="text",
                     text=json.dumps(
                         {
                             "status": "error",
-                            "message": f"Paper {paper_id} not found in storage. You may need to download it first using download_paper.",
+                            "message": (
+                                f"Paper {display} not found in storage. "
+                                "You may need to download it first using download_paper."
+                            ),
                         }
                     ),
                 )
             ]
 
         # Get paper content
-        content = Path(settings.STORAGE_PATH, f"{paper_id}.md").read_text(
+        content = Path(settings.STORAGE_PATH, f"{resolved}.md").read_text(
             encoding="utf-8"
         )
 
         payload = add_content_payload(
             {
                 "status": "success",
-                "paper_id": paper_id,
+                "paper_id": bare_arxiv_id(resolved),
             },
             content,
             arguments,

--- a/tests/tools/test_arxiv_ids.py
+++ b/tests/tools/test_arxiv_ids.py
@@ -3,6 +3,9 @@
 import pytest
 
 from arxiv_mcp_server.tools.arxiv_ids import (
+    arxiv_version_number,
+    arxiv_version_suffix,
+    bare_arxiv_id,
     is_valid_arxiv_id,
     normalize_arxiv_id,
     parse_arxiv_id,
@@ -64,3 +67,34 @@ def test_is_valid_arxiv_id_reexported_from_list_papers():
     assert is_valid_arxiv_id("1706.03762v7")
     assert is_valid_arxiv_id("hep-th/9901001")
     assert not is_valid_arxiv_id("not-a-paper")
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("1706.03762", "1706.03762"),
+        ("1706.03762v7", "1706.03762"),
+        ("hep-th/9901001v1", "hep-th/9901001"),
+        ("2401.12345v12", "2401.12345"),
+    ],
+)
+def test_bare_arxiv_id(raw, expected):
+    assert bare_arxiv_id(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("1706.03762", None),
+        ("1706.03762v7", "v7"),
+        ("1706.03762V7", "v7"),
+        ("hep-th/9901001v1", "v1"),
+    ],
+)
+def test_arxiv_version_suffix(raw, expected):
+    assert arxiv_version_suffix(raw) == expected
+
+
+def test_arxiv_version_number_orders_versions():
+    assert arxiv_version_number("1706.03762") == -1
+    assert arxiv_version_number("1706.03762v3") < arxiv_version_number("1706.03762v7")

--- a/tests/tools/test_versioned_storage_keys.py
+++ b/tests/tools/test_versioned_storage_keys.py
@@ -1,0 +1,194 @@
+"""Versioned download keys resolve via bare ID (#202)."""
+
+import json
+
+import pytest
+
+from arxiv_mcp_server.tools import download as download_module
+from arxiv_mcp_server.tools import list_papers as list_papers_module
+from arxiv_mcp_server.tools import read_paper as read_module
+from arxiv_mcp_server.tools.download import EXTRACTOR_VERSION, handle_download
+from arxiv_mcp_server.tools.list_papers import handle_list_papers, save_paper_metadata
+from arxiv_mcp_server.tools.read_paper import handle_read_paper
+
+
+def _patch_download_path(mocker, storage):
+    mocker.patch.object(
+        download_module,
+        "get_paper_path",
+        side_effect=lambda pid, suffix=".md": storage / f"{pid}{suffix}",
+    )
+
+
+def _patch_list_storage(mocker, storage):
+    mocker.patch.object(
+        list_papers_module.settings,
+        "_get_storage_path_from_args",
+        return_value=storage,
+    )
+
+
+def _patch_read_storage(monkeypatch, storage):
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: storage,
+    )
+
+
+@pytest.mark.asyncio
+async def test_versioned_download_stores_under_bare_id(temp_storage_path, mocker):
+    """download_paper('…v7') writes bare-ID markdown + sidecar version."""
+    _patch_download_path(mocker, temp_storage_path)
+    mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value="# Attention\nBody from v7",
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_arxiv_metadata",
+        return_value={
+            "title": "Attention Is All You Need",
+            "authors": ["Ashish Vaswani"],
+            "published": "2017-06-12T00:00:00Z",
+            "arxiv_version": "v7",
+        },
+    )
+    mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    response = await handle_download({"paper_id": "1706.03762v7"})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["paper_id"] == "1706.03762"
+    assert (temp_storage_path / "1706.03762.md").exists()
+    assert not (temp_storage_path / "1706.03762v7.md").exists()
+
+    sidecar = json.loads(
+        (temp_storage_path / "1706.03762.meta.json").read_text(encoding="utf-8")
+    )
+    assert sidecar["id"] == "1706.03762"
+    assert sidecar["arxiv_version"] == "v7"
+    assert sidecar["extractor_version"] == EXTRACTOR_VERSION
+
+
+@pytest.mark.asyncio
+async def test_bare_read_finds_versioned_download(
+    temp_storage_path, mocker, monkeypatch
+):
+    """After a versioned download, read_paper(bare) succeeds."""
+    _patch_download_path(mocker, temp_storage_path)
+    _patch_list_storage(mocker, temp_storage_path)
+    _patch_read_storage(monkeypatch, temp_storage_path)
+    mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value="# Attention\nTransformer body",
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_arxiv_metadata",
+        return_value={
+            "title": "Attention Is All You Need",
+            "authors": ["Ashish Vaswani"],
+            "published": "2017-06-12T00:00:00Z",
+            "arxiv_version": "v7",
+        },
+    )
+    mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    download = await handle_download({"paper_id": "1706.03762v7"})
+    assert json.loads(download[0].text)["status"] == "success"
+
+    read = await handle_read_paper({"paper_id": "1706.03762"})
+    payload = json.loads(read[0].text)
+    assert payload["status"] == "success"
+    assert payload["paper_id"] == "1706.03762"
+    assert "Transformer body" in payload["content"]
+
+
+@pytest.mark.asyncio
+async def test_list_papers_dedupes_bare_and_versioned_keys(temp_storage_path, mocker):
+    """Legacy dual keys for one paper collapse to a single bare ID."""
+    _patch_list_storage(mocker, temp_storage_path)
+    (temp_storage_path / "1706.03762v7.md").write_text("legacy v7", encoding="utf-8")
+    (temp_storage_path / "1706.03762.md").write_text("bare copy", encoding="utf-8")
+    save_paper_metadata(
+        "1706.03762",
+        title="Attention Is All You Need",
+        authors=["Ashish Vaswani"],
+        published="2017-06-12T00:00:00Z",
+        arxiv_version="v7",
+    )
+
+    response = await handle_list_papers({"compact": True})
+    payload = json.loads(response[0].text)
+
+    assert payload["total_papers"] == 1
+    assert payload["papers"] == ["1706.03762"]
+
+
+@pytest.mark.asyncio
+async def test_list_papers_prefers_latest_legacy_version_only(
+    temp_storage_path, mocker
+):
+    """When only versioned legacy files exist, list still shows one bare ID."""
+    _patch_list_storage(mocker, temp_storage_path)
+    (temp_storage_path / "1706.03762v3.md").write_text("v3", encoding="utf-8")
+    (temp_storage_path / "1706.03762v7.md").write_text("v7", encoding="utf-8")
+
+    response = await handle_list_papers({})
+    payload = json.loads(response[0].text)
+
+    assert payload["total_papers"] == 1
+    assert payload["papers"][0]["id"] == "1706.03762"
+    assert payload["papers"][0]["title"] == "v7"
+
+
+@pytest.mark.asyncio
+async def test_bare_read_resolves_legacy_versioned_only_storage(
+    temp_storage_path, mocker, monkeypatch
+):
+    """Bare read works against a pre-fix versioned filename."""
+    _patch_list_storage(mocker, temp_storage_path)
+    _patch_read_storage(monkeypatch, temp_storage_path)
+    (temp_storage_path / "1706.03762v7.md").write_text(
+        "legacy only content", encoding="utf-8"
+    )
+
+    read = await handle_read_paper({"paper_id": "1706.03762"})
+    payload = json.loads(read[0].text)
+    assert payload["status"] == "success"
+    assert payload["paper_id"] == "1706.03762"
+    assert "legacy only content" in payload["content"]
+
+
+@pytest.mark.asyncio
+async def test_versioned_download_cleans_legacy_alias(temp_storage_path, mocker):
+    """Writing the bare key removes a leftover versioned alias."""
+    _patch_download_path(mocker, temp_storage_path)
+    (temp_storage_path / "1706.03762v7.md").write_text("old", encoding="utf-8")
+    (temp_storage_path / "1706.03762v7.meta.json").write_text("{}", encoding="utf-8")
+    mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value="# Fresh\nBody",
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_arxiv_metadata",
+        return_value={
+            "title": "Attention Is All You Need",
+            "authors": ["Ashish Vaswani"],
+            "published": "2017-06-12T00:00:00Z",
+            "arxiv_version": "v7",
+        },
+    )
+    mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    await handle_download({"paper_id": "1706.03762v7"})
+
+    assert (temp_storage_path / "1706.03762.md").exists()
+    assert not (temp_storage_path / "1706.03762v7.md").exists()
+    assert not (temp_storage_path / "1706.03762v7.meta.json").exists()


### PR DESCRIPTION
## Summary
- Store `download_paper` results under the **bare** arXiv ID and record `arxiv_version` in the `.meta.json` sidecar (versioned fetch requests still hit the requested version on arXiv).
- `read_paper` resolves bare IDs to the stored bare key (or the highest legacy versioned filename).
- `list_papers` dedupes by bare ID so the same paper is never double-counted; writing a bare key removes leftover versioned aliases.

Closes #202

## Test plan
- [x] `pytest` for versioned storage, arxiv_ids, list/read/download/sidecar/force/export_citations (99 passed)
- [ ] Live: `download_paper("1706.03762v7")` then `read_paper("1706.03762")` succeeds
- [ ] Live: `list_papers(compact=true)` shows a single bare ID after versioned + bare downloads