### PR TITLE
feat: bound download_paper/read_paper content by default (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ The server currently exposes 16 tools.
 |---|---|---|
 | `search_papers` | Search arXiv by query, category, date, and sort order | Remote arXiv API |
 | `get_abstract` | Fetch metadata and an abstract by arXiv ID | Does not download the paper |
-| `download_paper` | Download and convert a paper to local Markdown | HTML first; PDF fallback uses `[pdf]`; `force=true` re-fetches |
+| `download_paper` | Download and convert a paper to local Markdown | HTML first; PDF fallback uses `[pdf]`; `force=true` re-fetches; content bounded to 12,000 chars by default |
 | `list_papers` | List papers stored locally | Returns id, title, authors, published; `compact` for IDs only |
-| `read_paper` | Read locally stored paper content | Supports `start` and `max_chars` |
+| `read_paper` | Read locally stored paper content | Bounded to 12,000 chars by default; supports `start`/`max_chars`/`return_full_text` |
 | `get_paper_latex` | Retrieve bounded author-submitted LaTeX | Remote arXiv source archive |
 | `list_paper_latex_sections` | Return a paginated LaTeX outline | Supports `start` and `max_sections` |
 | `get_paper_latex_section` | Read one bounded LaTeX section | Select by outline ID or exact title |
@@ -274,24 +274,44 @@ Call `download_paper` with:
 
 ```json
 {
-  "paper_id": "2404.19756",
-  "max_chars": 12000
+  "paper_id": "2404.19756"
 }
 ```
 
-Cached papers are returned immediately. Pass `"force": true` to re-download and overwrite the local markdown and sidecar (also happens automatically when the HTML extractor version changes).
+Omitting `max_chars` returns a bounded first chunk (default **12,000** paper characters). Cached papers are returned immediately. Pass `"force": true` to re-download and overwrite the local markdown and sidecar (also happens automatically when the HTML extractor version changes).
 
 Then page through the cached content with `read_paper`:
 
 ```json
 {
   "paper_id": "2404.19756",
-  "start": 0,
-  "max_chars": 12000
+  "start": 0
 }
 ```
 
-Large-content responses include `content_length`, `returned_chars`, `next_start`, and `is_truncated`. Pass `next_start` into the next call to continue reading.
+Or continue from a prior chunk:
+
+```json
+{
+  "paper_id": "2404.19756",
+  "start": 12000
+}
+```
+
+Large-content responses include `content_length`, `returned_chars`, `next_start`, `is_truncated`, and (when truncated) `next_retrieval` with the next-call instruction. Pass `next_start` into the next call's `start` to continue reading. Pass an explicit `max_chars` to override the default chunk size, or `"return_full_text": true` to opt into the previous unbounded full-paper response.
+
+#### Migration notes (bounded content default)
+
+Previously, omitting `max_chars` on `download_paper` / `read_paper` returned the **entire** paper. That default is now a **12,000-character** chunk so a single MCP tool call cannot flood the client context window.
+
+| Need | Call |
+|---|---|
+| First bounded chunk (new default) | `{ "paper_id": "…" }` |
+| Continue reading | `{ "paper_id": "…", "start": <next_start> }` |
+| Custom chunk size | `{ "paper_id": "…", "max_chars": 5000 }` |
+| Old unbounded behavior | `{ "paper_id": "…", "return_full_text": true }` |
+
+Clients that already passed `max_chars` are unchanged. Only callers that relied on the omitted-`max_chars` = full-text behavior need to add `return_full_text: true` or page via `next_start`.
 
 ### Read original LaTeX by section
 

--- a/src/arxiv_mcp_server/tools/content.py
+++ b/src/arxiv_mcp_server/tools/content.py
@@ -2,6 +2,17 @@
 
 from typing import Any
 
+# Default chunk size for download_paper / read_paper when max_chars is omitted.
+# Keeps a single MCP tool response inside typical client context budgets
+# (~8k–12k paper characters; aligned with LaTeX tool defaults).
+DEFAULT_MAX_CHARS = 12_000
+
+_CONTINUATION_INSTRUCTION = (
+    "Content is truncated. Call again with start set to next_start "
+    "(and optionally max_chars) to retrieve the next chunk, "
+    "or pass return_full_text=true for the entire remaining paper."
+)
+
 
 def _coerce_nonnegative_int(value: Any, default: int) -> int:
     """Return ``value`` as a non-negative integer, or ``default`` if absent."""
@@ -25,6 +36,28 @@ def _coerce_positive_int(value: Any) -> int | None:
     return parsed if parsed > 0 else None
 
 
+def bound_arguments(
+    arguments: dict[str, Any], default_max_chars: int = DEFAULT_MAX_CHARS
+) -> dict[str, Any]:
+    """Return a copy of ``arguments`` with a bounded ``max_chars`` applied.
+
+    Omitting ``max_chars`` used to mean "return the whole paper," which made
+    efficient behavior depend on every caller remembering an optional argument.
+    Default responses are now capped at ``default_max_chars``. Explicit
+    caller-specified ``max_chars`` values are preserved unchanged. Pass
+    ``return_full_text: true`` to opt back into unbounded full-text retrieval.
+    """
+    bounded = dict(arguments)
+    if bounded.get("return_full_text") is True:
+        # Drop max_chars so paginate_content returns the remainder in full.
+        bounded.pop("max_chars", None)
+        return bounded
+    if "max_chars" not in bounded or bounded["max_chars"] is None:
+        bounded["max_chars"] = default_max_chars
+    # Caller-specified max_chars is left unchanged (no hard cap).
+    return bounded
+
+
 def paginate_content(content: str, arguments: dict[str, Any]) -> dict[str, Any]:
     """Slice paper content and report continuation metadata.
 
@@ -42,7 +75,7 @@ def paginate_content(content: str, arguments: dict[str, Any]) -> dict[str, Any]:
     chunk = content[start:end]
     is_truncated = end < content_length
 
-    return {
+    page: dict[str, Any] = {
         "content": chunk,
         "content_length": content_length,
         "start": start,
@@ -50,6 +83,9 @@ def paginate_content(content: str, arguments: dict[str, Any]) -> dict[str, Any]:
         "next_start": end if is_truncated else None,
         "is_truncated": is_truncated,
     }
+    if is_truncated:
+        page["next_retrieval"] = _CONTINUATION_INSTRUCTION
+    return page
 
 
 def add_content_payload(
@@ -58,8 +94,8 @@ def add_content_payload(
     arguments: dict[str, Any],
     content_warning: str,
 ) -> dict[str, Any]:
-    """Add paginated content fields to a JSON response payload."""
-    page = paginate_content(content, arguments)
+    """Add paginated (bounded-by-default) content fields to a JSON payload."""
+    page = paginate_content(content, bound_arguments(arguments))
     chunk = page.pop("content")
     payload.update(page)
     payload["content"] = content_warning + chunk

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -458,9 +458,12 @@ download_tool = types.Tool(
     description=(
         "Download a paper from arXiv and return its text content. "
         "Tries the HTML version first for clean extraction; falls back to "
-        "PDF conversion if HTML is unavailable. Stores the paper locally "
-        "and supports start/max_chars pagination for very large papers. "
-        "Set force=true to re-fetch and overwrite a cached paper."
+        "PDF conversion if HTML is unavailable. Stores the paper locally. "
+        "Returned text is bounded to roughly 12,000 characters by default so "
+        "one call cannot return an unbounded paper body. When is_truncated is "
+        "true, call again with start=next_start (see next_retrieval) to "
+        "continue, or pass return_full_text=true for the entire remaining "
+        "paper. Set force=true to re-fetch and overwrite a cached paper."
     ),
     inputSchema={
         "type": "object",
@@ -472,12 +475,25 @@ download_tool = types.Tool(
             "start": {
                 "type": "integer",
                 "minimum": 0,
-                "description": "Zero-based character offset for returning large papers in chunks",
+                "description": (
+                    "Zero-based character offset for returning large papers in chunks; "
+                    "pass next_start from a prior truncated response to continue"
+                ),
             },
             "max_chars": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Maximum raw paper characters to return from start; omit for full content",
+                "description": (
+                    "Maximum raw paper characters to return from start; "
+                    "omit for the bounded default (12,000 chars)"
+                ),
+            },
+            "return_full_text": {
+                "type": "boolean",
+                "description": (
+                    "Set true to opt out of the bounded default and return the "
+                    "entire remaining paper from start in one call"
+                ),
             },
             "force": {
                 "type": "boolean",

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -23,7 +23,10 @@ read_tool = types.Tool(
     annotations=ToolAnnotations(readOnlyHint=True),
     description=(
         "Read the text content of a paper that was previously downloaded via download_paper. "
-        "Returns the paper in markdown format and supports start/max_chars pagination for large papers. "
+        "Returns the paper in markdown format, bounded to roughly 12,000 characters by default "
+        "so one call cannot return an unbounded paper body. When is_truncated is true, call again "
+        "with start=next_start (see next_retrieval) to continue, or pass return_full_text=true "
+        "for the entire remaining paper. "
         "Will fail with a clear error if the paper has not been downloaded yet — call download_paper first. "
         "Workflow: search_papers -> download_paper -> read_paper."
     ),
@@ -37,12 +40,25 @@ read_tool = types.Tool(
             "start": {
                 "type": "integer",
                 "minimum": 0,
-                "description": "Zero-based character offset for reading large papers in chunks",
+                "description": (
+                    "Zero-based character offset for reading large papers in chunks; "
+                    "pass next_start from a prior truncated response to continue"
+                ),
             },
             "max_chars": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Maximum raw paper characters to return from start; omit for full content",
+                "description": (
+                    "Maximum raw paper characters to return from start; "
+                    "omit for the bounded default (12,000 chars)"
+                ),
+            },
+            "return_full_text": {
+                "type": "boolean",
+                "description": (
+                    "Set true to opt out of the bounded default and return the "
+                    "entire remaining paper from start in one call"
+                ),
             },
         },
         "required": ["paper_id"],

--- a/tests/test_mcp_bound_content_defaults.py
+++ b/tests/test_mcp_bound_content_defaults.py
@@ -1,0 +1,77 @@
+"""MCP-level assertion that default read_paper responses stay bounded (#127)."""
+
+import json
+from pathlib import Path
+
+import mcp.types as types
+import pytest
+
+from arxiv_mcp_server import server as server_module
+from arxiv_mcp_server.tools import read_paper as read_module
+from arxiv_mcp_server.tools.content import DEFAULT_MAX_CHARS
+from arxiv_mcp_server.tools.download import download_tool
+from arxiv_mcp_server.tools.read_paper import read_tool
+
+
+@pytest.mark.asyncio
+async def test_mcp_read_paper_default_response_is_size_bounded(
+    temp_storage_path, monkeypatch
+):
+    """A default CallToolRequest must not emit an unbounded paper body.
+
+    Exercises the real MCP request handler (stdio transport path) and asserts
+    both pagination metadata and raw JSON response size stay bounded.
+    """
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "1706.03762"
+    # Simulate a large cached paper (~50k chars) well above the default bound.
+    content = ("Attention is all you need. " * 2000)[:50_000]
+    assert len(content) > DEFAULT_MAX_CHARS
+    Path(temp_storage_path, f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    handler = server_module.server.request_handlers[types.CallToolRequest]
+    result = await handler(
+        types.CallToolRequest(
+            params=types.CallToolRequestParams(
+                name="read_paper", arguments={"paper_id": paper_id}
+            )
+        )
+    )
+
+    assert result.root.isError is False
+    raw = result.root.content[0].text
+    payload = json.loads(raw)
+
+    assert payload["status"] == "success"
+    assert payload["content_length"] == len(content)
+    assert payload["returned_chars"] == DEFAULT_MAX_CHARS
+    assert payload["is_truncated"] is True
+    assert payload["next_start"] == DEFAULT_MAX_CHARS
+    assert "next_retrieval" in payload
+
+    # Paper body (excluding the fixed untrusted-content warning) is bounded.
+    body = payload["content"].split("\n\n", 1)[1]
+    assert len(body) == DEFAULT_MAX_CHARS
+
+    # Whole MCP text payload must stay well under a naive full-paper dump.
+    # Full paper JSON would be >50k; default chunk should be roughly warning +
+    # 12k + small metadata overhead.
+    assert len(raw) < 30_000
+    assert len(raw) < len(content)
+
+
+def test_download_and_read_tool_schemas_document_bounded_default():
+    """Tool descriptions and schemas must advertise the default + opt-in."""
+    for tool in (download_tool, read_tool):
+        assert "12,000" in tool.description or "12000" in tool.description
+        assert "return_full_text" in tool.description
+        assert "next_start" in tool.description
+        props = tool.inputSchema["properties"]
+        assert "return_full_text" in props
+        assert props["return_full_text"]["type"] == "boolean"
+        assert "12,000" in props["max_chars"]["description"]
+        assert "full content" not in props["max_chars"]["description"].lower()

--- a/tests/tools/test_content.py
+++ b/tests/tools/test_content.py
@@ -1,0 +1,136 @@
+"""Tests for bounded-by-default paper content pagination (#127)."""
+
+import json
+
+import pytest
+
+from arxiv_mcp_server.tools.content import (
+    DEFAULT_MAX_CHARS,
+    add_content_payload,
+    bound_arguments,
+    paginate_content,
+)
+
+
+def test_default_max_chars_is_in_accepted_band():
+    """Issue #127 asks for roughly 8,000–12,000 characters by default."""
+    assert 8_000 <= DEFAULT_MAX_CHARS <= 12_000
+
+
+def test_bound_arguments_applies_default_when_max_chars_omitted():
+    assert bound_arguments({})["max_chars"] == DEFAULT_MAX_CHARS
+    assert bound_arguments({"start": 10})["max_chars"] == DEFAULT_MAX_CHARS
+    assert bound_arguments({"max_chars": None})["max_chars"] == DEFAULT_MAX_CHARS
+
+
+def test_bound_arguments_preserves_caller_specified_max_chars():
+    """Explicit max_chars must not be clamped or rewritten (#127)."""
+    assert bound_arguments({"max_chars": 50})["max_chars"] == 50
+    assert bound_arguments({"max_chars": 100_000})["max_chars"] == 100_000
+    assert bound_arguments({"max_chars": 1})["max_chars"] == 1
+
+
+def test_bound_arguments_return_full_text_opts_into_unbounded():
+    bounded = bound_arguments({"return_full_text": True, "max_chars": 50})
+    assert "max_chars" not in bounded
+    assert bounded["return_full_text"] is True
+
+    bounded = bound_arguments({"return_full_text": True})
+    assert "max_chars" not in bounded
+
+
+def test_paginate_short_paper_returns_entire_body_under_default():
+    content = "short paper body"
+    page = paginate_content(content, bound_arguments({}))
+    assert page["content"] == content
+    assert page["content_length"] == len(content)
+    assert page["start"] == 0
+    assert page["returned_chars"] == len(content)
+    assert page["next_start"] is None
+    assert page["is_truncated"] is False
+    assert "next_retrieval" not in page
+
+
+def test_paginate_long_paper_defaults_to_bounded_chunk():
+    content = "x" * (DEFAULT_MAX_CHARS + 5_000)
+    page = paginate_content(content, bound_arguments({}))
+    assert page["content_length"] == len(content)
+    assert page["start"] == 0
+    assert page["returned_chars"] == DEFAULT_MAX_CHARS
+    assert page["next_start"] == DEFAULT_MAX_CHARS
+    assert page["is_truncated"] is True
+    assert page["content"] == content[:DEFAULT_MAX_CHARS]
+    assert "next_start" in page["next_retrieval"]
+
+
+def test_paginate_explicit_limit_and_continuation():
+    content = "abcdefghijklmnopqrstuvwxyz"
+    first = paginate_content(content, bound_arguments({"max_chars": 10}))
+    assert first["returned_chars"] == 10
+    assert first["next_start"] == 10
+    assert first["is_truncated"] is True
+    assert first["content"] == "abcdefghij"
+
+    second = paginate_content(
+        content, bound_arguments({"start": first["next_start"], "max_chars": 10})
+    )
+    assert second["start"] == 10
+    assert second["content"] == "klmnopqrst"
+    assert second["next_start"] == 20
+    assert second["is_truncated"] is True
+
+    final = paginate_content(
+        content, bound_arguments({"start": second["next_start"], "max_chars": 10})
+    )
+    assert final["start"] == 20
+    assert final["content"] == "uvwxyz"
+    assert final["returned_chars"] == 6
+    assert final["next_start"] is None
+    assert final["is_truncated"] is False
+    assert "next_retrieval" not in final
+
+
+def test_paginate_end_of_content_and_invalid_offsets():
+    content = "abcdefghij"
+    past_end = paginate_content(
+        content, bound_arguments({"start": 100, "max_chars": 5})
+    )
+    assert past_end["start"] == len(content)
+    assert past_end["returned_chars"] == 0
+    assert past_end["next_start"] is None
+    assert past_end["is_truncated"] is False
+    assert past_end["content"] == ""
+
+    negative_coerced = paginate_content(
+        content, bound_arguments({"start": -5, "max_chars": 3})
+    )
+    assert negative_coerced["start"] == 0
+    assert negative_coerced["content"] == "abc"
+
+    invalid_max = paginate_content(content, {"start": 0, "max_chars": "nope"})
+    # Invalid max_chars is ignored by paginate_content itself (treated as full).
+    assert invalid_max["returned_chars"] == len(content)
+
+
+def test_paginate_full_text_opt_in_returns_entire_long_paper():
+    content = "y" * (DEFAULT_MAX_CHARS + 2_500)
+    page = paginate_content(content, bound_arguments({"return_full_text": True}))
+    assert page["returned_chars"] == len(content)
+    assert page["is_truncated"] is False
+    assert page["next_start"] is None
+    assert page["content"] == content
+
+
+def test_add_content_payload_applies_default_bound_and_preserves_metadata():
+    content = "z" * (DEFAULT_MAX_CHARS + 100)
+    warning = "[WARN]\n\n"
+    payload = add_content_payload({"status": "success"}, content, {}, warning)
+    assert payload["status"] == "success"
+    assert payload["content_length"] == len(content)
+    assert payload["start"] == 0
+    assert payload["returned_chars"] == DEFAULT_MAX_CHARS
+    assert payload["next_start"] == DEFAULT_MAX_CHARS
+    assert payload["is_truncated"] is True
+    assert payload["next_retrieval"]
+    assert payload["content"].startswith(warning)
+    assert payload["content"][len(warning) :] == content[:DEFAULT_MAX_CHARS]

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -335,3 +335,60 @@ async def test_download_rejects_invalid_id_forms(raw_id):
     result = json.loads(response[0].text)
     assert result["status"] == "error"
     assert "Invalid arXiv ID" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_download_paper_defaults_to_bounded_cached_content(
+    temp_storage_path, mocker
+):
+    """Omitting max_chars on download_paper returns a bounded chunk (#127)."""
+    from arxiv_mcp_server.tools import download as download_module
+    from arxiv_mcp_server.tools.content import DEFAULT_MAX_CHARS
+
+    paper_id = "2103.12345"
+    content = "C" * (DEFAULT_MAX_CHARS + 2_500)
+    _write_cached_paper(temp_storage_path, paper_id, content)
+    mocker.patch.object(
+        download_module,
+        "get_paper_path",
+        side_effect=lambda pid, suffix=".md": temp_storage_path / f"{pid}{suffix}",
+    )
+    mock_html = mocker.patch.object(download_module, "_fetch_html_content")
+    mock_pdf = mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    response = await handle_download({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["source"] == "cache"
+    assert result["content_length"] == len(content)
+    assert result["returned_chars"] == DEFAULT_MAX_CHARS
+    assert result["is_truncated"] is True
+    assert result["next_start"] == DEFAULT_MAX_CHARS
+    assert "next_retrieval" in result
+    body = result["content"].split("\n\n", 1)[1]
+    assert len(body) == DEFAULT_MAX_CHARS
+    mock_html.assert_not_called()
+    mock_pdf.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_download_paper_return_full_text_opt_in(temp_storage_path, mocker):
+    from arxiv_mcp_server.tools import download as download_module
+    from arxiv_mcp_server.tools.content import DEFAULT_MAX_CHARS
+
+    paper_id = "2103.12345"
+    content = "D" * (DEFAULT_MAX_CHARS + 1_200)
+    _write_cached_paper(temp_storage_path, paper_id, content)
+    mocker.patch.object(
+        download_module,
+        "get_paper_path",
+        side_effect=lambda pid, suffix=".md": temp_storage_path / f"{pid}{suffix}",
+    )
+
+    response = await handle_download({"paper_id": paper_id, "return_full_text": True})
+    result = json.loads(response[0].text)
+
+    assert result["is_truncated"] is False
+    assert result["returned_chars"] == len(content)
+    assert result["next_start"] is None

--- a/tests/tools/test_read_paper.py
+++ b/tests/tools/test_read_paper.py
@@ -60,3 +60,98 @@ async def test_read_paper_reports_end_of_content_for_final_chunk(
     assert result["next_start"] is None
     assert result["is_truncated"] is False
     assert result["content"].endswith("uvwxyz")
+
+
+@pytest.mark.asyncio
+async def test_read_paper_defaults_to_bounded_content(temp_storage_path, monkeypatch):
+    """Omitting max_chars must not return an unbounded long paper (#127)."""
+    from arxiv_mcp_server.tools.content import DEFAULT_MAX_CHARS
+
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "2505.13525"
+    content = "A" * (DEFAULT_MAX_CHARS + 4_000)
+    (temp_storage_path / f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    response = await handle_read_paper({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["content_length"] == len(content)
+    assert result["returned_chars"] == DEFAULT_MAX_CHARS
+    assert result["next_start"] == DEFAULT_MAX_CHARS
+    assert result["is_truncated"] is True
+    assert "next_start" in result["next_retrieval"]
+    body = result["content"].split("\n\n", 1)[1]
+    assert len(body) == DEFAULT_MAX_CHARS
+
+
+@pytest.mark.asyncio
+async def test_read_paper_short_paper_unchanged_under_default(
+    temp_storage_path, monkeypatch
+):
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "2505.13525"
+    content = "tiny"
+    (temp_storage_path / f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    response = await handle_read_paper({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+
+    assert result["is_truncated"] is False
+    assert result["returned_chars"] == len(content)
+    assert result["next_start"] is None
+    assert result["content"].endswith("tiny")
+
+
+@pytest.mark.asyncio
+async def test_read_paper_return_full_text_opt_in(temp_storage_path, monkeypatch):
+    from arxiv_mcp_server.tools.content import DEFAULT_MAX_CHARS
+
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "2505.13525"
+    content = "B" * (DEFAULT_MAX_CHARS + 3_000)
+    (temp_storage_path / f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    response = await handle_read_paper({"paper_id": paper_id, "return_full_text": True})
+    result = json.loads(response[0].text)
+
+    assert result["is_truncated"] is False
+    assert result["returned_chars"] == len(content)
+    assert result["next_start"] is None
+    body = result["content"].split("\n\n", 1)[1]
+    assert body == content
+
+
+@pytest.mark.asyncio
+async def test_read_paper_invalid_offset_clamps_to_end(temp_storage_path, monkeypatch):
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "2505.13525"
+    content = "abcdefghij"
+    (temp_storage_path / f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    response = await handle_read_paper(
+        {"paper_id": paper_id, "start": 999, "max_chars": 50}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["start"] == len(content)
+    assert result["returned_chars"] == 0
+    assert result["is_truncated"] is False
+    assert result["next_start"] is None


### PR DESCRIPTION
## Summary

Closes #127.

`download_paper` and `read_paper` previously returned the entire paper when `max_chars` was omitted (measured ~111K chars / ~27.8K tokens for one real paper). Both tools now default to a **12,000-character** bounded chunk, matching the LaTeX tool default band (~8k–12k).

### Behavior

| Call | Result |
|---|---|
| Omit `max_chars` | First/next chunk of up to **12,000** paper characters |
| Explicit `max_chars` | Unchanged — caller value preserved (no hard cap) |
| `return_full_text: true` | Opt into previous unbounded full-text behavior |
| Truncated response | Includes `next_start`, `is_truncated`, and `next_retrieval` instruction |

Preserved pagination fields: `content_length`, `start`, `returned_chars`, `next_start`, `is_truncated`.

Implemented cleanly on current `main` (~f752211). Does **not** depend on external PR #148.

### Files

- `src/arxiv_mcp_server/tools/content.py` — `DEFAULT_MAX_CHARS`, `bound_arguments()`, `next_retrieval` signal
- `src/arxiv_mcp_server/tools/download.py` / `read_paper.py` — schemas + descriptions
- `README.md` — migration notes
- Tests for short/long papers, explicit limits, continuation, end-of-content, invalid offsets, full-text opt-in, and an MCP `CallToolRequest` size assertion

### Test plan

- [x] `pytest` for content/read/download/MCP bound defaults + tool schemas (25 passed locally)
- [ ] CI green on this PR