### PR TITLE
feat: compact and paginated search result modes (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The server currently exposes 16 tools.
 
 | Tool | Purpose | Notes |
 |---|---|---|
-| `search_papers` | Search arXiv by query, category, date, and sort order | Remote arXiv API |
+| `search_papers` | Search arXiv by query, category, date, and sort order | Default ≤5 compact results (`abstract_mode=snippet`); remote arXiv API |
 | `get_abstract` | Fetch metadata and an abstract by arXiv ID | Does not download the paper |
 | `download_paper` | Download and convert a paper to local Markdown | HTML first; PDF fallback uses `[pdf]`; `force=true` re-fetches; content bounded to 12,000 chars by default |
 | `list_papers` | List papers stored locally | Returns id, title, authors, published; `compact` for IDs only |
@@ -241,10 +241,12 @@ Physics & other: `quant-ph`, `eess.SP`, `eess.AS`, `physics.data-an`
 - Default `sort_by` is `relevance`; use `date` for newest-first monitoring
 - Foundational work: `date_to: "2010-12-31"` with title/abstract field searches
 
-**Pagination and rate limits**
+**Result size, abstracts, and pagination**
 
-- Responses report `total_results` (corpus hits), `returned`, `has_more`, `start`, and `next_start`
-- Pass `start=next_start` for the next page
+- Default `max_results` is **5** (cap 50). Pass an explicit value for larger pages.
+- `abstract_mode`: `snippet` (default, ~280 chars, marked `… [truncated]` when cut), `full` (complete abstract), or `none` (omit abstracts). Other metadata (title, authors, categories, dates, URLs) is always returned.
+- Responses report `total_results` (corpus hits), `returned`, `has_more`, `start`, `next_start`, and `abstract_mode`
+- Pass `start=next_start` with the same `abstract_mode` for the next page
 - arXiv enforces ~3 seconds between requests (handled server-side); on rate-limit errors wait ~60s
 
 ### Search and inspect a paper
@@ -255,18 +257,19 @@ Ask your MCP client to call `search_papers` with:
 {
   "query": "\"Kolmogorov-Arnold Networks\"",
   "categories": ["cs.LG", "cs.AI"],
-  "max_results": 5,
   "sort_by": "date"
 }
 ```
 
-Then call `get_abstract` with:
+Defaults return up to five compact results with abstract snippets. Use `"abstract_mode": "full"` when you need complete abstracts in the search response, or call `get_abstract` for a single paper after a compact search:
 
 ```json
 {
   "paper_id": "2404.19756"
 }
 ```
+
+Do not call `get_abstract` again for papers already returned with `abstract_mode=full`.
 
 ### Download and read full text
 

--- a/src/arxiv_mcp_server/tools/get_abstract.py
+++ b/src/arxiv_mcp_server/tools/get_abstract.py
@@ -18,10 +18,10 @@ abstract_tool = types.Tool(
     name="get_abstract",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     description=(
-        "Fetch the abstract and metadata of an arXiv paper by ID, WITHOUT downloading the full paper. "
-        "Use this before download_paper to assess relevance and save tokens. "
-        "Returns: title, authors, abstract, categories, published date, and PDF URL. "
-        "Workflow tip: search_papers -> get_abstract (check relevance) -> download_paper (if needed) -> read_paper."
+        "Fetch abstract and metadata by arXiv ID without downloading the paper. "
+        "Use before download_paper to assess relevance. Returns title, authors, "
+        "abstract, categories, published date, and PDF URL. After compact search, "
+        "use for one full abstract; skip if search used abstract_mode=full."
     ),
     inputSchema={
         "type": "object",

--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -17,6 +17,14 @@ from ..arxiv_api import ARXIV_RATE_LIMITER
 logger = logging.getLogger("arxiv-mcp-server")
 settings = Settings()
 
+# Tool defaults (#128): compact pages by default.
+DEFAULT_MAX_RESULTS = 5
+DEFAULT_ABSTRACT_MODE = "snippet"
+ABSTRACT_SNIPPET_CHARS = 280
+ABSTRACT_MODES = ("none", "snippet", "full")
+_ABSTRACT_TRUNCATION_MARK = "… [truncated]"
+_EXTERNAL_CONTENT_PREFIX = "[EXTERNAL CONTENT] "
+
 ARXIV_HEADERS = {
     "User-Agent": (
         f"{settings.APP_NAME}/{settings.APP_VERSION} "
@@ -176,7 +184,7 @@ def build_arxiv_search_query(
 
 def build_arxiv_search_url(
     query: str,
-    max_results: int = 10,
+    max_results: int = DEFAULT_MAX_RESULTS,
     sort_by: str = "relevance",
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
@@ -209,7 +217,7 @@ def build_arxiv_search_url(
 
 async def _raw_arxiv_search(
     query: str,
-    max_results: int = 10,
+    max_results: int = DEFAULT_MAX_RESULTS,
     sort_by: str = "relevance",
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
@@ -268,24 +276,80 @@ def _parse_opensearch_total_results(xml_text: str) -> Optional[int]:
         return None
 
 
+def _normalize_abstract_mode(value: Any) -> str:
+    """Return a valid abstract_mode or raise ValueError."""
+    if value is None:
+        return DEFAULT_ABSTRACT_MODE
+    if not isinstance(value, str):
+        raise ValueError(
+            "abstract_mode must be one of: none, snippet, full "
+            f"(got {type(value).__name__})"
+        )
+    mode = value.strip().lower()
+    if mode not in ABSTRACT_MODES:
+        raise ValueError(
+            f"abstract_mode must be one of: none, snippet, full (got {value!r})"
+        )
+    return mode
+
+
+def _snippet_abstract(abstract: str, max_chars: int = ABSTRACT_SNIPPET_CHARS) -> str:
+    """Return a deterministic bounded abstract snippet, marked when truncated."""
+    if abstract.startswith(_EXTERNAL_CONTENT_PREFIX):
+        prefix = _EXTERNAL_CONTENT_PREFIX
+        body = abstract[len(_EXTERNAL_CONTENT_PREFIX) :]
+    else:
+        prefix = ""
+        body = abstract
+
+    if len(body) <= max_chars:
+        return abstract
+
+    # Fixed-length slice (no word-boundary heuristics) for stable output.
+    return prefix + body[:max_chars].rstrip() + _ABSTRACT_TRUNCATION_MARK
+
+
+def _apply_abstract_mode(
+    papers: List[Dict[str, Any]], abstract_mode: str
+) -> List[Dict[str, Any]]:
+    """Project paper dicts according to abstract_mode without mutating inputs."""
+    mode = _normalize_abstract_mode(abstract_mode)
+    projected: List[Dict[str, Any]] = []
+    for paper in papers:
+        item = dict(paper)
+        if mode == "none":
+            item.pop("abstract", None)
+        elif mode == "snippet":
+            abstract = item.get("abstract")
+            if isinstance(abstract, str):
+                item["abstract"] = _snippet_abstract(abstract)
+        # mode == "full": keep abstract as parsed
+        projected.append(item)
+    return projected
+
+
 def _build_search_response(
     papers: List[Dict[str, Any]],
     *,
     total_results: Optional[int] = None,
     has_more: Optional[bool] = None,
     start: int = 0,
+    abstract_mode: str = DEFAULT_ABSTRACT_MODE,
 ) -> Dict[str, Any]:
     """Assemble search JSON. Never report page size as total_results.
 
     Pagination mirrors read_paper / content helpers: ``start`` is the
     zero-based offset for this page and ``next_start`` is set when more
-    results remain (otherwise None).
+    results remain (otherwise None). ``abstract_mode`` is echoed so
+    clients can continue pagination with the same projection.
     """
     returned = len(papers)
     start = max(0, int(start))
+    mode = _normalize_abstract_mode(abstract_mode)
     response: Dict[str, Any] = {
         "returned": returned,
         "start": start,
+        "abstract_mode": mode,
         "papers": papers,
     }
     if total_results is not None:
@@ -336,7 +400,7 @@ def _parse_arxiv_atom_response(xml_text: str) -> List[Dict[str, Any]]:
 
             # Abstract/Summary
             summary_elem = entry.find("atom:summary", ARXIV_NS)
-            abstract = "[EXTERNAL CONTENT] " + (
+            abstract = _EXTERNAL_CONTENT_PREFIX + (
                 summary_elem.text.strip().replace("\n", " ")
                 if summary_elem is not None and summary_elem.text
                 else ""
@@ -396,16 +460,16 @@ search_tool = types.Tool(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     description=(
         "Search arXiv by query with optional categories, date range, sort, and pagination.\n\n"
-        "Query: prefer quoted phrases; field prefixes ti:/au:/abs:/cat:; AND/OR/ANDNOT. "
+        "Query: prefer quoted phrases; ti:/au:/abs:/cat:; AND/OR/ANDNOT. "
         "Unprefixed terms match title+abstract (not authors). "
-        "Use categories for relevance (e.g. cs.AI, cs.LG, cs.CL, cs.CV, cs.MA, cs.RO, "
-        "stat.ML, quant-ph). Full category catalog and worked examples: README "
-        "'search_papers query guide'.\n\n"
-        "Dates: YYYY-MM-DD via date_from/date_to. sort_by: relevance (default) or date "
-        "(newest first). max_results default 10 (cap 50). start default 0; responses "
-        "include total_results (corpus hits), returned, has_more, next_start.\n\n"
-        "arXiv enforces ~3s between requests (handled server-side). On rate-limit "
-        "errors wait ~60s before retrying."
+        "Use categories (cs.AI, cs.LG, cs.CL, cs.CV, cs.MA, cs.RO, stat.ML, quant-ph). "
+        "Catalog/examples: README 'search_papers query guide'.\n\n"
+        "Dates YYYY-MM-DD (date_from/date_to). sort_by relevance|date. "
+        "max_results default 5 (cap 50). abstract_mode none|snippet|full (default snippet). "
+        "start default 0; response: total_results, returned, has_more, next_start, "
+        "abstract_mode. Pass next_start with same abstract_mode. "
+        "Use get_abstract after compact search — not after abstract_mode=full.\n\n"
+        "arXiv ~3s between requests (server-side). On rate-limit wait ~60s."
     ),
     inputSchema={
         "type": "object",
@@ -419,7 +483,7 @@ search_tool = types.Tool(
             },
             "max_results": {
                 "type": "integer",
-                "description": "Maximum results to return (default: 10, max: 50).",
+                "description": "Maximum results to return (default: 5, max: 50).",
             },
             "start": {
                 "type": "integer",
@@ -427,6 +491,14 @@ search_tool = types.Tool(
                 "description": (
                     "Zero-based result offset (default: 0). Pass next_start from a "
                     "previous response to fetch the next page."
+                ),
+            },
+            "abstract_mode": {
+                "type": "string",
+                "enum": ["none", "snippet", "full"],
+                "description": (
+                    "Abstract projection (default snippet ~280 chars, marked if "
+                    "truncated; full=complete; none=omit)."
                 ),
             },
             "date_from": {
@@ -508,12 +580,21 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
     bug that breaks ``submittedDate`` ranges.
     """
     try:
-        max_results = min(int(arguments.get("max_results", 10)), settings.MAX_RESULTS)
+        max_results = min(
+            int(arguments.get("max_results", DEFAULT_MAX_RESULTS)),
+            settings.MAX_RESULTS,
+        )
         start_arg = arguments.get("start", 0)
         try:
             start = max(0, int(start_arg))
         except (TypeError, ValueError):
             start = 0
+        try:
+            abstract_mode = _normalize_abstract_mode(
+                arguments.get("abstract_mode", DEFAULT_ABSTRACT_MODE)
+            )
+        except ValueError as e:
+            return [types.TextContent(type="text", text=f"Error: {str(e)}")]
         base_query = arguments["query"]
         date_from_arg = arguments.get("date_from")
         date_to_arg = arguments.get("date_to")
@@ -521,7 +602,12 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
         sort_by_arg = arguments.get("sort_by", "relevance")
 
         logger.debug(
-            f"Starting search with query: '{base_query}', max_results: {max_results}, start: {start}"
+            "Starting search with query: %r, max_results: %s, start: %s, "
+            "abstract_mode: %s",
+            base_query,
+            max_results,
+            start,
+            abstract_mode,
         )
 
         # Validate categories if provided
@@ -544,10 +630,14 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 categories=categories,
                 start=start,
             )
+            results = _apply_abstract_mode(results, abstract_mode)
 
             logger.info(f"Search completed: {len(results)} results returned")
             response_data = _build_search_response(
-                results, total_results=total_results, start=start
+                results,
+                total_results=total_results,
+                start=start,
+                abstract_mode=abstract_mode,
             )
 
             return [

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -81,6 +81,7 @@ def test_search_papers_schema_semantics_preserved():
         "query",
         "max_results",
         "start",
+        "abstract_mode",
         "date_from",
         "date_to",
         "categories",
@@ -90,6 +91,8 @@ def test_search_papers_schema_semantics_preserved():
     assert props["max_results"]["type"] == "integer"
     assert props["start"]["type"] == "integer"
     assert props["start"]["minimum"] == 0
+    assert props["abstract_mode"]["type"] == "string"
+    assert props["abstract_mode"]["enum"] == ["none", "snippet", "full"]
     assert props["date_from"]["type"] == "string"
     assert props["date_to"]["type"] == "string"
     assert props["categories"]["type"] == "array"
@@ -103,6 +106,8 @@ def test_search_papers_schema_semantics_preserved():
     assert "YYYY-MM-DD" in desc
     assert "relevance" in desc and "date" in desc
     assert "next_start" in desc
+    assert "abstract_mode" in desc
+    assert "snippet" in desc
 
 
 def test_search_papers_description_reduced_vs_baseline():
@@ -143,5 +148,6 @@ async def test_tools_list_serialized_size_snapshot():
     # Soft ceiling: after shrinking search_papers, total list should stay well
     # under the pre-change ~16k measurement on main @94a1317.
     assert search_chars < 3000
-    assert total_chars < 14000
+    # Soft ceiling allows abstract_mode (#128) on top of the #131 shrink.
+    assert total_chars < 14500
     assert len(search.description) < 1500

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -6,11 +6,17 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from arxiv_mcp_server.tools import handle_search
 from arxiv_mcp_server.tools import search as search_module
 from arxiv_mcp_server.tools.search import (
+    DEFAULT_ABSTRACT_MODE,
+    DEFAULT_MAX_RESULTS,
+    ABSTRACT_SNIPPET_CHARS,
     _validate_categories,
     _raw_arxiv_search,
     _parse_arxiv_atom_response,
     _parse_opensearch_total_results,
     _build_search_response,
+    _apply_abstract_mode,
+    _snippet_abstract,
+    _normalize_abstract_mode,
     _scope_user_query,
     build_arxiv_search_query,
     build_arxiv_search_url,
@@ -703,3 +709,340 @@ def test_search_tool_schema_includes_start():
     assert "start" in props
     assert props["start"]["type"] == "integer"
     assert props["start"]["minimum"] == 0
+
+
+def test_search_tool_schema_includes_abstract_mode_and_defaults():
+    """Tool schema documents compact defaults and abstract_mode (#128)."""
+    from arxiv_mcp_server.tools.search import search_tool
+
+    props = search_tool.inputSchema["properties"]
+    assert "abstract_mode" in props
+    assert props["abstract_mode"]["enum"] == ["none", "snippet", "full"]
+    assert "default: 5" in props["max_results"]["description"]
+    assert "snippet" in props["abstract_mode"]["description"].lower()
+    assert DEFAULT_MAX_RESULTS == 5
+    assert DEFAULT_ABSTRACT_MODE == "snippet"
+    assert ABSTRACT_SNIPPET_CHARS == 280
+    desc = search_tool.description
+    assert "max_results default 5" in desc
+    assert "abstract_mode" in desc
+    # Do not push agents to get_abstract after a full-abstract search.
+    assert "not after abstract_mode=full" in desc  # avoid redundant get_abstract
+
+
+def test_normalize_abstract_mode_defaults_and_rejects_invalid():
+    assert _normalize_abstract_mode(None) == "snippet"
+    assert _normalize_abstract_mode("FULL") == "full"
+    assert _normalize_abstract_mode(" None ") == "none"
+    try:
+        _normalize_abstract_mode("summary")
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "abstract_mode" in str(e)
+
+
+def test_snippet_abstract_is_deterministic_bounded_and_marked():
+    """Snippets are fixed-length, stable, and marked when truncated."""
+    body = "A" * (ABSTRACT_SNIPPET_CHARS + 50)
+    full = "[EXTERNAL CONTENT] " + body
+    snip_a = _snippet_abstract(full)
+    snip_b = _snippet_abstract(full)
+    assert snip_a == snip_b
+    assert snip_a.startswith("[EXTERNAL CONTENT] ")
+    assert snip_a.endswith("… [truncated]")
+    # Body contribution before marker is exactly ABSTRACT_SNIPPET_CHARS (rstrip no-op on A's).
+    without_prefix = snip_a[len("[EXTERNAL CONTENT] ") :]
+    assert without_prefix[:ABSTRACT_SNIPPET_CHARS] == "A" * ABSTRACT_SNIPPET_CHARS
+    assert len(without_prefix) == ABSTRACT_SNIPPET_CHARS + len("… [truncated]")
+
+    short = "[EXTERNAL CONTENT] Short abstract."
+    assert _snippet_abstract(short) == short
+    assert "truncated" not in _snippet_abstract(short)
+
+
+def test_apply_abstract_mode_none_snippet_full():
+    long_body = "Word " * 200
+    papers = [
+        {
+            "id": "2301.00001",
+            "title": "T",
+            "authors": ["A"],
+            "abstract": "[EXTERNAL CONTENT] " + long_body,
+            "categories": ["cs.AI"],
+        }
+    ]
+    none_papers = _apply_abstract_mode(papers, "none")
+    assert "abstract" not in none_papers[0]
+    assert none_papers[0]["title"] == "T"
+
+    snip_papers = _apply_abstract_mode(papers, "snippet")
+    assert snip_papers[0]["abstract"].endswith("… [truncated]")
+    assert len(snip_papers[0]["abstract"]) < len(papers[0]["abstract"])
+
+    full_papers = _apply_abstract_mode(papers, "full")
+    assert full_papers[0]["abstract"] == papers[0]["abstract"]
+    # Inputs must not be mutated
+    assert "abstract" in papers[0]
+
+
+@pytest.mark.asyncio
+async def test_search_defaults_to_five_compact_snippets():
+    """Omitting max_results/abstract_mode yields ≤5 snippet results (#128)."""
+    long_summary = "Z" * (ABSTRACT_SNIPPET_CHARS + 40)
+    entries = []
+    for i in range(5):
+        n = i + 1
+        entries.append(f"""
+        <entry>
+            <id>http://arxiv.org/abs/2301.0000{n}v1</id>
+            <title>Test Paper {n}</title>
+            <summary>{long_summary}</summary>
+            <published>2023-01-0{n}T00:00:00Z</published>
+            <author><name>Test Author</name></author>
+            <arxiv:primary_category term="cs.AI"/>
+            <link title="pdf" href="http://arxiv.org/pdf/2301.0000{n}v1"/>
+        </entry>""")
+    xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom"
+          xmlns:arxiv="http://arxiv.org/schemas/atom"
+          xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+        <opensearch:totalResults>42</opensearch:totalResults>
+        {''.join(entries)}
+    </feed>"""
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await handle_search({"query": "transformers"})
+
+    from urllib.parse import parse_qs, urlparse
+
+    url = mock_client.get.call_args[0][0]
+    params = parse_qs(urlparse(url).query)
+    assert params["max_results"] == ["5"]
+    assert params["start"] == ["0"]
+
+    content = json.loads(result[0].text)
+    assert content["returned"] == 5
+    assert content["abstract_mode"] == "snippet"
+    assert content["total_results"] == 42
+    assert content["has_more"] is True
+    assert content["next_start"] == 5
+    assert len(content["papers"]) == 5
+    for paper in content["papers"]:
+        assert paper["abstract"].endswith("… [truncated]")
+        assert "title" in paper and "authors" in paper
+
+
+@pytest.mark.asyncio
+async def test_search_abstract_mode_none_omits_abstracts():
+    xml = _atom_feed_with_totals(entry_count=2, total_results=2)
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await handle_search(
+            {"query": "test", "max_results": 2, "abstract_mode": "none"}
+        )
+
+    content = json.loads(result[0].text)
+    assert content["abstract_mode"] == "none"
+    assert content["returned"] == 2
+    for paper in content["papers"]:
+        assert "abstract" not in paper
+        assert paper["title"]
+        assert paper["authors"]
+
+
+@pytest.mark.asyncio
+async def test_search_abstract_mode_full_keeps_complete_abstract():
+    long_summary = "Complete abstract body. " * 30
+    xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom"
+          xmlns:arxiv="http://arxiv.org/schemas/atom"
+          xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+        <opensearch:totalResults>1</opensearch:totalResults>
+        <entry>
+            <id>http://arxiv.org/abs/2301.00001v1</id>
+            <title>Full Mode Paper</title>
+            <summary>{long_summary}</summary>
+            <published>2023-01-01T00:00:00Z</published>
+            <author><name>Test Author</name></author>
+            <arxiv:primary_category term="cs.AI"/>
+            <link title="pdf" href="http://arxiv.org/pdf/2301.00001v1"/>
+        </entry>
+    </feed>"""
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await handle_search(
+            {"query": "test", "max_results": 1, "abstract_mode": "full"}
+        )
+
+    content = json.loads(result[0].text)
+    assert content["abstract_mode"] == "full"
+    abstract = content["papers"][0]["abstract"]
+    assert abstract.startswith("[EXTERNAL CONTENT] ")
+    assert "truncated" not in abstract
+    assert long_summary.strip().replace("\n", " ")[:40] in abstract.replace("\n", " ")
+
+
+@pytest.mark.asyncio
+async def test_search_legacy_explicit_max_results_and_full_abstract():
+    """Explicit legacy-style args still work (max_results=10, abstract_mode=full)."""
+    xml = _atom_feed_with_totals(entry_count=3, total_results=3)
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await handle_search(
+            {
+                "query": "legacy",
+                "max_results": 10,
+                "abstract_mode": "full",
+            }
+        )
+
+    from urllib.parse import parse_qs, urlparse
+
+    url = mock_client.get.call_args[0][0]
+    params = parse_qs(urlparse(url).query)
+    assert params["max_results"] == ["10"]
+
+    content = json.loads(result[0].text)
+    assert content["abstract_mode"] == "full"
+    assert content["returned"] == 3
+    assert content["papers"][0]["abstract"].startswith("[EXTERNAL CONTENT] ")
+
+
+@pytest.mark.asyncio
+async def test_search_continuation_preserves_abstract_mode_and_offset():
+    """Page 2 via next_start does not skip/dupe under a stable feed (#128/#186)."""
+    xml_page1 = _atom_feed_with_totals(entry_count=2, total_results=5)
+    xml_page1 = xml_page1.replace("2301.00001", "2103.10001").replace(
+        "2301.00002", "2103.10002"
+    )
+    xml_page2 = _atom_feed_with_totals(entry_count=2, total_results=5)
+    xml_page2 = xml_page2.replace("2301.00001", "2103.10003").replace(
+        "2301.00002", "2103.10004"
+    )
+    xml_page3 = _atom_feed_with_totals(entry_count=1, total_results=5)
+    xml_page3 = xml_page3.replace("2301.00001", "2103.10005")
+
+    pages = [xml_page1, xml_page2, xml_page3]
+    observed_starts = []
+
+    mock_client = AsyncMock()
+
+    async def capture_get(url, **kwargs):
+        from urllib.parse import parse_qs, urlparse
+
+        params = parse_qs(urlparse(url).query)
+        start = int(params["start"][0])
+        observed_starts.append(start)
+        resp = MagicMock()
+        resp.text = pages[len(observed_starts) - 1]
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    mock_client.get = AsyncMock(side_effect=capture_get)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        page1 = json.loads(
+            (
+                await handle_search(
+                    {
+                        "query": "page",
+                        "max_results": 2,
+                        "abstract_mode": "none",
+                    }
+                )
+            )[0].text
+        )
+        assert page1["start"] == 0
+        assert page1["next_start"] == 2
+        assert page1["abstract_mode"] == "none"
+        ids1 = [p["id"] for p in page1["papers"]]
+
+        page2 = json.loads(
+            (
+                await handle_search(
+                    {
+                        "query": "page",
+                        "max_results": 2,
+                        "start": page1["next_start"],
+                        "abstract_mode": page1["abstract_mode"],
+                    }
+                )
+            )[0].text
+        )
+        assert page2["start"] == 2
+        assert page2["next_start"] == 4
+        ids2 = [p["id"] for p in page2["papers"]]
+
+        page3 = json.loads(
+            (
+                await handle_search(
+                    {
+                        "query": "page",
+                        "max_results": 2,
+                        "start": page2["next_start"],
+                        "abstract_mode": "none",
+                    }
+                )
+            )[0].text
+        )
+        assert page3["start"] == 4
+        assert page3["has_more"] is False
+        assert page3["next_start"] is None
+        ids3 = [p["id"] for p in page3["papers"]]
+
+    assert observed_starts == [0, 2, 4]
+    all_ids = ids1 + ids2 + ids3
+    assert all_ids == [
+        "2103.10001",
+        "2103.10002",
+        "2103.10003",
+        "2103.10004",
+        "2103.10005",
+    ]
+    assert len(all_ids) == len(set(all_ids))
+
+
+@pytest.mark.asyncio
+async def test_search_empty_page_past_end():
+    """Empty upstream page: returned=0, has_more false, next_start null."""
+    xml = _atom_feed_with_totals(entry_count=0, total_results=10)
+    _, mock_client = _mock_httpx_response(xml)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await handle_search(
+            {
+                "query": "empty",
+                "max_results": 5,
+                "start": 50,
+                "abstract_mode": "snippet",
+            }
+        )
+
+    content = json.loads(result[0].text)
+    assert content["start"] == 50
+    assert content["returned"] == 0
+    assert content["papers"] == []
+    assert content["total_results"] == 10
+    assert content["has_more"] is False
+    assert content["next_start"] is None
+    assert content["abstract_mode"] == "snippet"
+
+
+@pytest.mark.asyncio
+async def test_search_invalid_abstract_mode_errors():
+    result = await handle_search({"query": "x", "abstract_mode": "brief"})
+    assert "Error:" in result[0].text
+    assert "abstract_mode" in result[0].text
+
+
+def test_build_search_response_echoes_abstract_mode():
+    papers = [{"id": "1"}]
+    payload = _build_search_response(papers, total_results=1, abstract_mode="full")
+    assert payload["abstract_mode"] == "full"
+    assert payload["next_start"] is None


### PR DESCRIPTION
## Summary
Implements #128: compact default search results with explicit abstract projection and pagination that continues to use `start` / `next_start` from #186.

- Default `max_results` **5** (was 10)
- New `abstract_mode`: `none` | `snippet` | `full` (default **`snippet`**, 280-char deterministic snippets marked `… [truncated]`)
- Response echoes `abstract_mode` alongside `total_results` / `returned` / `has_more` / `start` / `next_start`
- Full metadata retained; full abstracts via `abstract_mode=full`
- Schema/README no longer guide a redundant `get_abstract` after `abstract_mode=full`

Closes #128

## Test plan
- [x] Unit tests for all abstract modes, defaults, continuation, empty pages, legacy explicit args
- [x] `pytest tests/tools/test_search.py tests/test_tool_schemas.py tests/tools/test_alerts.py` (53 passed)
- [x] Black 26.1.0
- [x] Contents/Git API: remote `search.py` size matches local (22632 bytes)