### PR TITLE
fix: prevent silent version downgrade of bare-ID cache (#206)

### DIFF
--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -14,6 +14,7 @@ from ..config import Settings, get_arxiv_client
 from ..arxiv_api import ARXIV_RATE_LIMITER, stream_pdf_to_path
 from .content import add_content_payload
 from .arxiv_ids import (
+    arxiv_version_number,
     arxiv_version_suffix,
     bare_arxiv_id,
     parse_arxiv_id,
@@ -443,6 +444,38 @@ def _cache_satisfies_request(storage_stem: str, requested_id: str) -> bool:
     return stored_ver is not None and stored_ver == req_ver
 
 
+def _would_downgrade_cached_version(storage_stem: str, requested_id: str) -> bool:
+    """True when *requested_id* is an older arXiv version than the bare cache.
+
+    Used to block silent downgrades of the bare-ID store without force=true
+    (issue #206). Unknown stored versions never count as a downgrade.
+    """
+    req_ver = arxiv_version_suffix(requested_id)
+    if req_ver is None:
+        return False
+    stored_ver = _read_arxiv_version(storage_stem)
+    if stored_ver is None:
+        return False
+    return arxiv_version_number(req_ver) < arxiv_version_number(stored_ver)
+
+
+def _response_version_fields(
+    storage_stem: str, *, fallback_version: str | None = None
+) -> Dict[str, Any]:
+    """Build ``arxiv_version`` / ``versioned_id`` fields for tool responses."""
+    bare = bare_arxiv_id(storage_stem)
+    version = (
+        _read_arxiv_version(storage_stem)
+        or fallback_version
+        or arxiv_version_suffix(storage_stem)
+    )
+    fields: Dict[str, Any] = {}
+    if version:
+        fields["arxiv_version"] = version
+        fields["versioned_id"] = f"{bare}{version}"
+    return fields
+
+
 def _wants_force_refresh(arguments: Dict[str, Any]) -> bool:
     """Return True when the caller asked to overwrite a cached paper."""
     return bool(arguments.get("force") or arguments.get("refresh"))
@@ -463,7 +496,7 @@ download_tool = types.Tool(
         "one call cannot return an unbounded paper body. When is_truncated is "
         "true, call again with start=next_start (see next_retrieval) to "
         "continue, or pass return_full_text=true for the entire remaining "
-        "paper. Set force=true to re-fetch and overwrite a cached paper."
+        "paper. Set force=true to re-fetch and overwrite a cached paper (required to replace a newer stored arXiv version with an older one)."
     ),
     inputSchema={
         "type": "object",
@@ -499,8 +532,9 @@ download_tool = types.Tool(
                 "type": "boolean",
                 "description": (
                     "If true, re-download and overwrite the local markdown and "
-                    "metadata sidecar even if the paper is already cached. "
-                    "Default false."
+                    "metadata sidecar even if the paper is already cached, "
+                    "including when replacing a newer stored arXiv version with "
+                    "an older one. Default false."
                 ),
             },
         },
@@ -738,13 +772,48 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
                     resolved = legacy
             if resolved:
                 content = get_paper_path(resolved, ".md").read_text(encoding="utf-8")
+                cache_payload = {
+                    "status": "success",
+                    "message": "Paper already available (returned from cache)",
+                    "paper_id": storage_id,
+                    "source": "cache",
+                }
+                cache_payload.update(_response_version_fields(resolved))
                 payload = add_content_payload(
-                    {
-                        "status": "success",
-                        "message": "Paper already available (returned from cache)",
-                        "paper_id": storage_id,
-                        "source": "cache",
-                    },
+                    cache_payload,
+                    content,
+                    arguments,
+                    _CONTENT_WARNING,
+                )
+                return [
+                    types.TextContent(
+                        type="text",
+                        text=json.dumps(payload),
+                    )
+                ]
+
+            # Bare-ID storage: refuse silent downgrade of a newer cached version
+            # (#206). Keep the newer content and return a clear cache status.
+            if md_path.exists() and _would_downgrade_cached_version(
+                storage_id, paper_id
+            ):
+                content = md_path.read_text(encoding="utf-8")
+                stored_ver = _read_arxiv_version(storage_id)
+                refuse_payload = {
+                    "status": "success",
+                    "message": (
+                        f"Kept newer cached version {stored_ver}; refused to "
+                        f"overwrite with older requested version "
+                        f"{requested_version} without force=true"
+                    ),
+                    "paper_id": storage_id,
+                    "source": "cache",
+                    "downgrade_refused": True,
+                    "requested_version": requested_version,
+                }
+                refuse_payload.update(_response_version_fields(storage_id))
+                payload = add_content_payload(
+                    refuse_payload,
                     content,
                     arguments,
                     _CONTENT_WARNING,
@@ -772,13 +841,17 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
             _cleanup_versioned_aliases(storage_id)
             # Best-effort index; the tracked task is drained at shutdown.
             _track_index_task(_run_index_by_id(storage_id))
+            html_payload = {
+                "status": "success",
+                "message": "Paper fetched from arXiv HTML endpoint",
+                "paper_id": storage_id,
+                "source": "html",
+            }
+            html_payload.update(
+                _response_version_fields(storage_id, fallback_version=requested_version)
+            )
             payload = add_content_payload(
-                {
-                    "status": "success",
-                    "message": "Paper fetched from arXiv HTML endpoint",
-                    "paper_id": storage_id,
-                    "source": "html",
-                },
+                html_payload,
                 html_text,
                 arguments,
                 _CONTENT_WARNING,
@@ -831,13 +904,21 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
         # Best-effort index; the tracked task is drained at shutdown.
         _track_index_task(_run_index_from_result(arxiv_result))
 
+        pdf_payload = {
+            "status": "success",
+            "message": "Paper fetched via PDF conversion",
+            "paper_id": storage_id,
+            "source": "pdf",
+        }
+        pdf_payload.update(
+            _response_version_fields(
+                storage_id,
+                fallback_version=requested_version
+                or _version_from_arxiv_result(arxiv_result),
+            )
+        )
         payload = add_content_payload(
-            {
-                "status": "success",
-                "message": "Paper fetched via PDF conversion",
-                "paper_id": storage_id,
-                "source": "pdf",
-            },
+            pdf_payload,
             markdown,
             arguments,
             _CONTENT_WARNING,

--- a/src/arxiv_mcp_server/tools/list_papers.py
+++ b/src/arxiv_mcp_server/tools/list_papers.py
@@ -28,7 +28,8 @@ list_tool = types.Tool(
     annotations=ToolAnnotations(readOnlyHint=True),
     description=(
         "List all papers that have been downloaded and stored locally via download_paper. "
-        "Returns id, title, authors, and published from local metadata — no live re-fetch. "
+        "Returns id, title, authors, published, and arxiv_version/versioned_id "
+        "from local metadata — no live re-fetch. "
         "Set compact=true to return arXiv IDs only. "
         "Returns an empty list if no papers have been downloaded yet. "
         "Workflow: search_papers -> download_paper -> list_papers -> read_paper."
@@ -40,7 +41,7 @@ list_tool = types.Tool(
                 "type": "boolean",
                 "description": (
                     "If true, return arXiv IDs only. Default is full local metadata "
-                    "(id, title, authors, published)."
+                    "(id, title, authors, published, arxiv_version, versioned_id)."
                 ),
             }
         },
@@ -216,6 +217,30 @@ def _title_from_markdown(paper_id: str) -> Optional[str]:
     return None
 
 
+def _version_fields_for_stem(
+    stem: str, data: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Return arxiv_version / versioned_id for a stored stem when known."""
+    bare = bare_arxiv_id(stem)
+    version = None
+    if isinstance(data, dict):
+        raw = data.get("arxiv_version")
+        if isinstance(raw, str) and raw.strip():
+            normalized = raw.strip().lower()
+            if not normalized.startswith("v"):
+                normalized = f"v{normalized}"
+            if normalized[1:].isdigit():
+                version = normalized
+    if version is None:
+        version = _sidecar_arxiv_version(stem) or arxiv_version_suffix(stem)
+    fields: Dict[str, Any] = {"arxiv_version": version}
+    if version:
+        fields["versioned_id"] = f"{bare}{version}"
+    else:
+        fields["versioned_id"] = None
+    return fields
+
+
 def load_paper_metadata(paper_id: str) -> Dict[str, Any]:
     """Load local metadata for a stored paper without hitting the network."""
     bare = bare_arxiv_id(paper_id)
@@ -231,18 +256,22 @@ def load_paper_metadata(paper_id: str) -> Dict[str, Any]:
                 authors = data.get("authors") or []
                 if not isinstance(authors, list):
                     authors = []
-                return {
+                payload = {
                     "id": bare,
                     "title": data.get("title") or None,
                     "authors": [str(author) for author in authors],
                     "published": data.get("published") or None,
                 }
-    return {
+                payload.update(_version_fields_for_stem(stem, data))
+                return payload
+    payload = {
         "id": bare,
         "title": _title_from_markdown(stem),
         "authors": [],
         "published": None,
     }
+    payload.update(_version_fields_for_stem(stem))
+    return payload
 
 
 async def handle_list_papers(

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -6,9 +6,14 @@ from typing import Dict, Any, List
 import mcp.types as types
 from mcp.types import ToolAnnotations
 from ..config import Settings
-from .arxiv_ids import bare_arxiv_id, normalize_arxiv_id, parse_arxiv_id
+from .arxiv_ids import (
+    arxiv_version_suffix,
+    bare_arxiv_id,
+    normalize_arxiv_id,
+    parse_arxiv_id,
+)
 from .content import add_content_payload
-from .list_papers import resolve_stored_stem
+from .list_papers import _sidecar_arxiv_version, resolve_stored_stem
 
 settings = Settings()
 
@@ -106,11 +111,18 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
             encoding="utf-8"
         )
 
+        bare = bare_arxiv_id(resolved)
+        version = _sidecar_arxiv_version(
+            resolved, Path(settings.STORAGE_PATH)
+        ) or arxiv_version_suffix(resolved)
+        read_payload = {
+            "status": "success",
+            "paper_id": bare,
+            "arxiv_version": version,
+            "versioned_id": f"{bare}{version}" if version else None,
+        }
         payload = add_content_payload(
-            {
-                "status": "success",
-                "paper_id": bare_arxiv_id(resolved),
-            },
+            read_payload,
             content,
             arguments,
             _CONTENT_WARNING,

--- a/tests/tools/test_list_papers.py
+++ b/tests/tools/test_list_papers.py
@@ -61,12 +61,12 @@ async def test_list_papers_returns_local_metadata(storage):
 
     assert payload["total_papers"] == 2
     by_id = {paper["id"]: paper for paper in payload["papers"]}
-    assert by_id["1706.03762"] == {
-        "id": "1706.03762",
-        "title": "Attention Is All You Need",
-        "authors": ["Ashish Vaswani", "Noam Shazeer"],
-        "published": "2017-06-12T17:57:34Z",
-    }
+    assert by_id["1706.03762"]["id"] == "1706.03762"
+    assert by_id["1706.03762"]["title"] == "Attention Is All You Need"
+    assert by_id["1706.03762"]["authors"] == ["Ashish Vaswani", "Noam Shazeer"]
+    assert by_id["1706.03762"]["published"] == "2017-06-12T17:57:34Z"
+    assert by_id["1706.03762"]["arxiv_version"] is None
+    assert by_id["1706.03762"]["versioned_id"] is None
     assert by_id["2608.18261"]["authors"] == ["Ada Lovelace"]
 
 
@@ -108,6 +108,8 @@ async def test_list_papers_uses_markdown_title_without_network(storage, mocker):
             "title": "Cached Title",
             "authors": [],
             "published": None,
+            "arxiv_version": None,
+            "versioned_id": None,
         }
     ]
     httpx_get.assert_not_called()

--- a/tests/tools/test_no_version_downgrade.py
+++ b/tests/tools/test_no_version_downgrade.py
@@ -1,0 +1,208 @@
+"""Bare-ID cache must not silently downgrade versions (#206)."""
+
+import json
+
+import pytest
+
+from arxiv_mcp_server.tools import download as download_module
+from arxiv_mcp_server.tools import list_papers as list_papers_module
+from arxiv_mcp_server.tools import read_paper as read_module
+from arxiv_mcp_server.tools.download import EXTRACTOR_VERSION, handle_download
+from arxiv_mcp_server.tools.list_papers import handle_list_papers, save_paper_metadata
+from arxiv_mcp_server.tools.read_paper import handle_read_paper
+
+
+def _patch_download_path(mocker, storage):
+    mocker.patch.object(
+        download_module,
+        "get_paper_path",
+        side_effect=lambda pid, suffix=".md": storage / f"{pid}{suffix}",
+    )
+
+
+def _patch_list_storage(mocker, storage):
+    mocker.patch.object(
+        list_papers_module.settings,
+        "_get_storage_path_from_args",
+        return_value=storage,
+    )
+
+
+def _patch_read_storage(monkeypatch, storage):
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: storage,
+    )
+
+
+def _seed_versioned_cache(storage, version, body):
+    (storage / "1706.03762.md").write_text(body, encoding="utf-8")
+    save_paper_metadata(
+        "1706.03762",
+        title="Attention Is All You Need",
+        authors=["Ashish Vaswani"],
+        published="2017-06-12T00:00:00Z",
+        extractor_version=EXTRACTOR_VERSION,
+        arxiv_version=version,
+        path=storage / "1706.03762.meta.json",
+    )
+
+
+@pytest.mark.asyncio
+async def test_older_version_without_force_does_not_downgrade(
+    temp_storage_path, mocker
+):
+    """v7 then v1 without force keeps v7 content and reports refusal."""
+    _patch_download_path(mocker, temp_storage_path)
+    _seed_versioned_cache(temp_storage_path, "v7", "# Attention\nBLEU 41.8 from v7")
+
+    mock_html = mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value="# Attention\nBLEU 41.0 from v1",
+    )
+    mock_pdf = mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    response = await handle_download({"paper_id": "1706.03762v1"})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["source"] == "cache"
+    assert result["downgrade_refused"] is True
+    assert result["requested_version"] == "v1"
+    assert result["arxiv_version"] == "v7"
+    assert result["versioned_id"] == "1706.03762v7"
+    assert result["paper_id"] == "1706.03762"
+    assert "BLEU 41.8 from v7" in result["content"]
+    assert "41.0 from v1" not in result["content"]
+    assert (temp_storage_path / "1706.03762.md").read_text(
+        encoding="utf-8"
+    ) == "# Attention\nBLEU 41.8 from v7"
+    sidecar = json.loads(
+        (temp_storage_path / "1706.03762.meta.json").read_text(encoding="utf-8")
+    )
+    assert sidecar["arxiv_version"] == "v7"
+    mock_html.assert_not_called()
+    mock_pdf.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_older_version_with_force_may_replace(temp_storage_path, mocker):
+    """force=true may replace a newer bare-ID cache with an older version."""
+    _patch_download_path(mocker, temp_storage_path)
+    _seed_versioned_cache(temp_storage_path, "v7", "# Attention\nBLEU 41.8 from v7")
+
+    mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value="# Attention\nBLEU 41.0 from v1",
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_arxiv_metadata",
+        return_value={
+            "title": "Attention Is All You Need",
+            "authors": ["Ashish Vaswani"],
+            "published": "2017-06-12T00:00:00Z",
+            "arxiv_version": "v1",
+        },
+    )
+    mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    response = await handle_download({"paper_id": "1706.03762v1", "force": True})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["source"] == "html"
+    assert result.get("downgrade_refused") is not True
+    assert result["arxiv_version"] == "v1"
+    assert result["versioned_id"] == "1706.03762v1"
+    assert "BLEU 41.0 from v1" in result["content"]
+    sidecar = json.loads(
+        (temp_storage_path / "1706.03762.meta.json").read_text(encoding="utf-8")
+    )
+    assert sidecar["arxiv_version"] == "v1"
+    assert "41.0 from v1" in (temp_storage_path / "1706.03762.md").read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.mark.asyncio
+async def test_newer_version_without_force_may_upgrade(temp_storage_path, mocker):
+    """Requesting a newer version replaces an older bare-ID cache without force."""
+    _patch_download_path(mocker, temp_storage_path)
+    _seed_versioned_cache(temp_storage_path, "v1", "# Attention\nold v1 body")
+
+    mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value="# Attention\nupgraded v7 body",
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_arxiv_metadata",
+        return_value={
+            "title": "Attention Is All You Need",
+            "authors": ["Ashish Vaswani"],
+            "published": "2017-06-12T00:00:00Z",
+            "arxiv_version": "v7",
+        },
+    )
+    mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    response = await handle_download({"paper_id": "1706.03762v7"})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["source"] == "html"
+    assert result["arxiv_version"] == "v7"
+    assert result["versioned_id"] == "1706.03762v7"
+    assert "upgraded v7 body" in result["content"]
+    sidecar = json.loads(
+        (temp_storage_path / "1706.03762.meta.json").read_text(encoding="utf-8")
+    )
+    assert sidecar["arxiv_version"] == "v7"
+
+
+@pytest.mark.asyncio
+async def test_bare_download_cache_hit_discloses_stored_version(
+    temp_storage_path, mocker
+):
+    """Bare download with force=false serves the latest stored version and echoes it."""
+    _patch_download_path(mocker, temp_storage_path)
+    _seed_versioned_cache(temp_storage_path, "v7", "# Attention\nstored v7")
+
+    mock_html = mocker.patch.object(download_module, "_fetch_html_content")
+    mock_pdf = mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    response = await handle_download({"paper_id": "1706.03762"})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["source"] == "cache"
+    assert result["arxiv_version"] == "v7"
+    assert result["versioned_id"] == "1706.03762v7"
+    assert "stored v7" in result["content"]
+    mock_html.assert_not_called()
+    mock_pdf.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_and_read_include_version(temp_storage_path, mocker, monkeypatch):
+    """list_papers and read_paper echo arxiv_version / versioned_id."""
+    _patch_list_storage(mocker, temp_storage_path)
+    _patch_read_storage(monkeypatch, temp_storage_path)
+    _seed_versioned_cache(temp_storage_path, "v7", "# Attention\nbody")
+
+    listed = json.loads((await handle_list_papers({}))[0].text)
+    assert listed["total_papers"] == 1
+    paper = listed["papers"][0]
+    assert paper["id"] == "1706.03762"
+    assert paper["arxiv_version"] == "v7"
+    assert paper["versioned_id"] == "1706.03762v7"
+
+    read = json.loads((await handle_read_paper({"paper_id": "1706.03762"}))[0].text)
+    assert read["status"] == "success"
+    assert read["arxiv_version"] == "v7"
+    assert read["versioned_id"] == "1706.03762v7"

--- a/tests/tools/test_versioned_storage_keys.py
+++ b/tests/tools/test_versioned_storage_keys.py
@@ -62,6 +62,8 @@ async def test_versioned_download_stores_under_bare_id(temp_storage_path, mocker
 
     assert result["status"] == "success"
     assert result["paper_id"] == "1706.03762"
+    assert result["arxiv_version"] == "v7"
+    assert result["versioned_id"] == "1706.03762v7"
     assert (temp_storage_path / "1706.03762.md").exists()
     assert not (temp_storage_path / "1706.03762v7.md").exists()
 
@@ -105,6 +107,8 @@ async def test_bare_read_finds_versioned_download(
     payload = json.loads(read[0].text)
     assert payload["status"] == "success"
     assert payload["paper_id"] == "1706.03762"
+    assert payload["arxiv_version"] == "v7"
+    assert payload["versioned_id"] == "1706.03762v7"
     assert "Transformer body" in payload["content"]
 
 
@@ -144,6 +148,8 @@ async def test_list_papers_prefers_latest_legacy_version_only(
     assert payload["total_papers"] == 1
     assert payload["papers"][0]["id"] == "1706.03762"
     assert payload["papers"][0]["title"] == "v7"
+    assert payload["papers"][0]["arxiv_version"] == "v7"
+    assert payload["papers"][0]["versioned_id"] == "1706.03762v7"
 
 
 @pytest.mark.asyncio
@@ -161,6 +167,8 @@ async def test_bare_read_resolves_legacy_versioned_only_storage(
     payload = json.loads(read[0].text)
     assert payload["status"] == "success"
     assert payload["paper_id"] == "1706.03762"
+    assert payload["arxiv_version"] == "v7"
+    assert payload["versioned_id"] == "1706.03762v7"
     assert "legacy only content" in payload["content"]
 
 


### PR DESCRIPTION
## Summary
Fixes #206: after bare-ID storage (#202), `download_paper("…v1")` could silently overwrite a newer cached version (e.g. v7) because a version mismatch was treated as a cache miss.

## Behavior chosen
**Keep newer + clear status** (clearest UX for agents):
- Without `force=true`, refuse to overwrite a newer stored arXiv version with an older requested one.
- Keep the newer cache content and return `status=success`, `source=cache`, `downgrade_refused=true`, plus a clear message naming both versions.
- `force=true` may still replace (intentional downgrade).
- Requesting a **newer** version still upgrades without force.
- Bare-ID downloads continue to prefer / disclose the latest stored content.
- `download_paper` / `read_paper` / `list_papers` echo `arxiv_version` and `versioned_id` when known.

## Changes
- `download.py`: compare requested vs sidecar `arxiv_version` before overwrite; surface version fields on responses.
- `list_papers.py` / `read_paper.py`: include `arxiv_version` / `versioned_id` in responses.
- Tests: v7→v1 without force must not downgrade; with force may replace; list/read include version.

## Test plan
- [x] `pytest tests/tools/test_no_version_downgrade.py tests/tools/test_versioned_storage_keys.py tests/tools/test_list_papers.py tests/tools/test_read_paper.py tests/tools/test_download_force.py tests/tools/test_download_sidecar.py --no-cov` (31 passed)
- [x] Black 26.1.0
- [x] Contents API sizes verified against local files

Closes #206