### PR TITLE
fix: parse bare/numbered headings in paper outlines (#209)

### DIFF
--- a/src/arxiv_mcp_server/tools/paper_outline.py
+++ b/src/arxiv_mcp_server/tools/paper_outline.py
@@ -3,7 +3,8 @@
 Section IDs use hierarchical counters (``1``, ``1.1``, ``1.1.1``), matching the
 LaTeX outline tools. Missing heading levels insert ``0`` placeholders (e.g. an
 ``h3`` after an ``h1`` becomes ``1.0.1``). Duplicate titles remain distinct via
-those counters. Papers with no ATX headings expose a synthetic section ``1``.
+those counters. Papers with no recognized headings (ATX, numbered, or common
+bare arXiv section titles) expose a synthetic section ``1``.
 """
 
 from __future__ import annotations
@@ -46,9 +47,51 @@ DEFAULT_PASSAGE_CHARS = 800
 MAX_PASSAGE_CHARS = 2000
 MAX_SECTION_COUNT = 2000
 
-# ATX headings only; setext headings are uncommon in arXiv markdown conversions.
-_ATX_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$", re.MULTILINE)
+# Heading styles seen in arXiv markdown (ATX, numbered, bare HTML titles).
+_ATX_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$")
+_NUMBERED_HEADING_RE = re.compile(r"^(\d+(?:\.\d+){0,5})[ \t]+(.+?)[ \t]*$")
 _FENCE_RE = re.compile(r"^```")
+_MAX_BARE_TITLE_CHARS = 80
+
+# Common standalone section titles from arXiv HTML→md conversions.
+_BARE_SECTION_TITLES = frozenset(
+    {
+        "abstract",
+        "introduction",
+        "background",
+        "related work",
+        "related works",
+        "method",
+        "methods",
+        "methodology",
+        "approach",
+        "experiment",
+        "experiments",
+        "experimental setup",
+        "experimental results",
+        "result",
+        "results",
+        "discussion",
+        "discussions",
+        "conclusion",
+        "conclusions",
+        "future work",
+        "limitations",
+        "reference",
+        "references",
+        "appendix",
+        "appendices",
+        "acknowledgement",
+        "acknowledgements",
+        "acknowledgment",
+        "acknowledgments",
+        "bibliography",
+        "notation",
+        "preliminaries",
+        "problem formulation",
+        "problem statement",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -118,8 +161,44 @@ def _mask_fenced_code(content: str) -> str:
     return "".join(chars)
 
 
+def _match_heading_line(line: str) -> tuple[int, str] | None:
+    """Return (level, title) for a heading line, or None if not a heading.
+
+    Preference: ATX > numbered > bare known section titles. Bare titles must be
+    short standalone lines (no trailing prose).
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    atx = _ATX_HEADING_RE.match(stripped)
+    if atx:
+        title = atx.group(2).strip()
+        if title:
+            return len(atx.group(1)), title
+        return None
+
+    numbered = _NUMBERED_HEADING_RE.match(stripped)
+    if numbered:
+        numbering = numbered.group(1)
+        title = numbered.group(2).strip()
+        # Reject numbered list items that look like long prose.
+        if title and len(stripped) <= _MAX_BARE_TITLE_CHARS:
+            if re.match(r"[A-Za-z]", title):
+                level = min(6, numbering.count(".") + 1)
+                return level, title
+
+    if len(stripped) <= _MAX_BARE_TITLE_CHARS:
+        # Allow optional trailing colon or period on bare titles.
+        candidate = stripped.rstrip(":.").strip()
+        if candidate.casefold() in _BARE_SECTION_TITLES:
+            return 1, candidate
+
+    return None
+
+
 def parse_markdown_sections(content: str) -> list[MdSection]:
-    """Parse ATX headings into hierarchical sections with stable IDs.
+    """Parse ATX, numbered, and bare arXiv headings into hierarchical sections.
 
     Section body runs from the heading start through the character before the
     next heading of the same or higher level (lower or equal level number).
@@ -131,20 +210,30 @@ def parse_markdown_sections(content: str) -> list[MdSection]:
     raw: list[tuple[int, str, str, int]] = []
     counters = [0, 0, 0, 0, 0, 0]
 
-    for match in _ATX_HEADING_RE.finditer(masked):
+    offset = 0
+    in_fence = False
+    for line in masked.splitlines(keepends=True):
         if len(raw) >= MAX_SECTION_COUNT:
             break
-        level = len(match.group(1))
-        title = match.group(2).strip()
-        if not title:
+        stripped = line.lstrip(" \t")
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            offset += len(line)
             continue
-        # Map match offsets back to original content (same length as masked).
-        start = match.start()
-        counters[level - 1] += 1
-        for index in range(level, 6):
-            counters[index] = 0
-        section_id = ".".join(str(value) for value in counters[:level])
-        raw.append((level, section_id, title, start))
+        if not in_fence:
+            logical = line[:-1] if line.endswith("\n") else line
+            if logical.endswith("\r"):
+                logical = logical[:-1]
+            matched = _match_heading_line(logical)
+            if matched is not None:
+                level, title = matched
+                start = offset
+                counters[level - 1] += 1
+                for index in range(level, 6):
+                    counters[index] = 0
+                section_id = ".".join(str(value) for value in counters[:level])
+                raw.append((level, section_id, title, start))
+        offset += len(line)
 
     if not raw:
         return [MdSection("1", 1, "(document)", 0, len(content))]
@@ -291,7 +380,7 @@ def search_passages(
                 "match_end": match_end,
                 "section_id": section.section_id if section else None,
                 "section_title": section.title if section else None,
-                "excerpt": _CONTENT_WARNING + excerpt,
+                "excerpt": excerpt,
                 "excerpt_chars": len(excerpt),
             }
         )

--- a/tests/tools/test_paper_outline.py
+++ b/tests/tools/test_paper_outline.py
@@ -200,7 +200,8 @@ async def test_search_passages_and_empty(patch_storage):
     assert "start" in passage and "end" in passage
     assert "match_start" in passage and "match_end" in passage
     assert passage["section_id"] is not None
-    assert "UNTRUSTED EXTERNAL CONTENT" in passage["excerpt"]
+    assert "UNTRUSTED EXTERNAL CONTENT" not in passage["excerpt"]
+    assert "table" in passage["excerpt"].casefold()
 
     empty = await handle_search_paper_text({"paper_id": "2505.13525", "query": ""})
     empty_result = json.loads(empty[0].text)
@@ -234,3 +235,177 @@ async def test_not_found_and_no_heading_paper(patch_storage):
     )
     assert section["status"] == "success"
     assert "no headings here" in section["content"]
+
+
+BARE_HTML_PAPER = """Attention Is All You Need
+
+Abstract
+
+The dominant sequence transduction models are based on complex recurrent.
+
+Introduction
+
+Recurrent neural networks, long short-term memory and gated recurrent.
+
+Background
+
+The goal of reducing sequential computation forms the foundation.
+
+Related Work
+
+The Transformer is the first transduction model relying entirely.
+
+Methods
+
+We propose a new architecture.
+
+Experiments
+
+This section describes our experimental setup.
+
+Results
+
+On the WMT 2014 English-to-German translation task.
+
+Discussion
+
+In this work we presented the Transformer.
+
+Conclusion
+
+We are excited about the future of attention-based models.
+
+References
+
+[1] Someone et al.
+"""
+
+
+NUMBERED_PAPER = """1 Introduction
+
+Intro body about transformers.
+
+2 Background
+
+Background body.
+
+3 Model Architecture
+
+Top-level model section.
+
+3.1 Attention
+
+Scaled dot-product attention.
+
+3.2 Multi-Head Attention
+
+Multi-head details.
+
+4 Experiments
+
+Experiment body.
+
+4.1 Training
+
+Training details.
+"""
+
+
+def test_parse_bare_arxiv_html_titles():
+    sections = parse_markdown_sections(BARE_HTML_PAPER)
+    titles = [s.title for s in sections]
+    assert "(document)" not in titles
+    for expected in (
+        "Abstract",
+        "Introduction",
+        "Background",
+        "Related Work",
+        "Methods",
+        "Experiments",
+        "Results",
+        "Discussion",
+        "Conclusion",
+        "References",
+    ):
+        assert expected in titles, f"missing {expected}"
+    # Paper title line should not become a section.
+    assert "Attention Is All You Need" not in titles
+    intro = next(s for s in sections if s.title == "Introduction")
+    body = BARE_HTML_PAPER[intro.start : intro.end]
+    assert "Recurrent neural networks" in body
+    assert "Background" in body  # heading line included in span start
+    # Sibling boundary: Results text should not leak into Introduction.
+    assert "WMT 2014" not in body
+
+
+def test_parse_numbered_headings():
+    sections = parse_markdown_sections(NUMBERED_PAPER)
+    by_title = {s.title: s for s in sections}
+    assert by_title["Introduction"].section_id == "1"
+    assert by_title["Introduction"].level == 1
+    assert by_title["Background"].section_id == "2"
+    assert by_title["Model Architecture"].section_id == "3"
+    assert by_title["Attention"].section_id == "3.1"
+    assert by_title["Attention"].level == 2
+    assert by_title["Multi-Head Attention"].section_id == "3.2"
+    assert by_title["Experiments"].section_id == "4"
+    assert by_title["Training"].section_id == "4.1"
+    attention = by_title["Attention"]
+    body = NUMBERED_PAPER[attention.start : attention.end]
+    assert "Scaled dot-product" in body
+    assert "Multi-head details" not in body
+
+
+def test_parse_atx_still_preferred_over_bare():
+    md = """# Introduction
+
+Prose mentioning Background in a sentence should not split.
+
+Background
+
+Real bare section after ATX.
+"""
+    sections = parse_markdown_sections(md)
+    titles = [s.title for s in sections]
+    assert titles[0] == "Introduction"
+    assert "Background" in titles
+    assert sections[0].level == 1
+
+
+@pytest.mark.asyncio
+async def test_bare_title_read_section_and_search_clean(patch_storage):
+    _write_paper(patch_storage, "1706.03762", BARE_HTML_PAPER)
+    outline = json.loads(
+        (await handle_get_paper_outline({"paper_id": "1706.03762"}))[0].text
+    )
+    assert outline["status"] == "success"
+    assert outline["total_sections"] >= 8
+    titles = [s["title"] for s in outline["sections"]]
+    assert "Introduction" in titles
+    assert titles != ["(document)"]
+
+    section = json.loads(
+        (
+            await handle_read_paper_section(
+                {"paper_id": "1706.03762", "section_id": "Introduction"}
+            )
+        )[0].text
+    )
+    assert section["status"] == "success"
+    assert "Recurrent neural networks" in section["content"]
+
+    search = json.loads(
+        (
+            await handle_search_paper_text(
+                {
+                    "paper_id": "1706.03762",
+                    "query": "transduction",
+                    "passage_chars": 200,
+                }
+            )
+        )[0].text
+    )
+    assert search["returned_passages"] >= 1
+    excerpt = search["passages"][0]["excerpt"]
+    assert "UNTRUSTED EXTERNAL CONTENT" not in excerpt
+    assert "transduction" in excerpt.casefold()

--- a/tests/tools/test_paper_outline.py
+++ b/tests/tools/test_paper_outline.py
@@ -333,9 +333,11 @@ def test_parse_bare_arxiv_html_titles():
     intro = next(s for s in sections if s.title == "Introduction")
     body = BARE_HTML_PAPER[intro.start : intro.end]
     assert "Recurrent neural networks" in body
-    assert "Background" in body  # heading line included in span start
+    assert body.lstrip().startswith("Introduction")
     # Sibling boundary: Results text should not leak into Introduction.
     assert "WMT 2014" not in body
+    bg = next(s for s in sections if s.title == "Background")
+    assert BARE_HTML_PAPER[bg.start : bg.end].lstrip().startswith("Background")
 
 
 def test_parse_numbered_headings():


### PR DESCRIPTION
## Summary
- Extend `parse_markdown_sections` to recognize ATX headings, numbered headings (`1 Introduction`, `3.2 Attention`), and common bare arXiv HTML→md section titles (`Abstract`, `Introduction`, `Background`, …) on short standalone lines.
- Stop prepending the UNTRUSTED EXTERNAL CONTENT warning onto `search_paper_text` passage excerpts (section reads still use the warning via `add_content_payload`).
- Add fixtures/tests for bare HTML extracts (1706.03762-style), numbered headings, ATX regression, and clean search excerpts.

## Why
HTML→md downloads have no `#` headings, so outline collapsed to synthetic `(document)` and `read_paper_section("Introduction")` failed.

## Test plan
- [x] Unit: bare titles → Introduction etc. in outline
- [x] Unit: numbered headings get hierarchical IDs
- [x] Unit: ATX `SAMPLE_PAPER` still works
- [x] Unit: search excerpts omit UNTRUSTED prefix
- [ ] Live retest: download `1706.03762` HTML extract and assert outline sections (parent)

Closes #209