### PR TITLE
fix: strip versioned arXiv IDs in citation_graph S2 lookup (#211)

### DIFF
--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -13,7 +13,12 @@ import mcp.types as types
 from mcp.types import ToolAnnotations
 
 from ..config import Settings
-from .arxiv_ids import is_valid_arxiv_id, normalize_arxiv_id
+from .arxiv_ids import (
+    arxiv_version_suffix,
+    bare_arxiv_id,
+    is_valid_arxiv_id,
+    normalize_arxiv_id,
+)
 
 logger = logging.getLogger("arxiv-mcp-server")
 settings = Settings()
@@ -166,8 +171,11 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
                 types.TextContent(type="text", text="Error: invalid arXiv ID format")
             ]
 
+        # Semantic Scholar indexes bare arXiv IDs only; strip vN for lookup.
+        bare_id = bare_arxiv_id(paper_id)
+        requested_version = arxiv_version_suffix(paper_id)
         limit = _bound_max_citations(arguments.get("max_citations"))
-        s2_paper_identifier = quote(f"ARXIV:{paper_id}", safe=":")
+        s2_paper_identifier = quote(f"ARXIV:{bare_id}", safe=":")
         paper_url = f"{SEMANTIC_SCHOLAR_API_URL}/paper/{s2_paper_identifier}"
         citations_url = f"{paper_url}/citations"
         references_url = f"{paper_url}/references"
@@ -186,18 +194,23 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
             _neighbor_papers(references_response.json(), "citedPaper")
         )
 
+        paper_meta = {
+            "paper_id": payload.get("paperId"),
+            "arxiv_id": bare_id,
+            "title": payload.get("title", ""),
+            "year": payload.get("year"),
+            "authors": [
+                author.get("name", "") for author in payload.get("authors", [])
+            ],
+            "external_ids": payload.get("externalIds") or {},
+        }
+        if requested_version is not None:
+            paper_meta["requested_arxiv_id"] = paper_id
+            paper_meta["requested_version"] = requested_version
+
         result = {
             "status": "success",
-            "paper": {
-                "paper_id": payload.get("paperId"),
-                "arxiv_id": paper_id,
-                "title": payload.get("title", ""),
-                "year": payload.get("year"),
-                "authors": [
-                    author.get("name", "") for author in payload.get("authors", [])
-                ],
-                "external_ids": payload.get("externalIds") or {},
-            },
+            "paper": paper_meta,
             "citation_count": len(citations),
             "reference_count": len(references),
             "citation_total": payload.get("citationCount"),
@@ -216,11 +229,21 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
         if exc.response is not None and exc.response.status_code == 429:
             logger.error("Semantic Scholar rate limited: %s", exc)
             return [types.TextContent(type="text", text=f"Error: {RATE_LIMIT_MESSAGE}")]
-        logger.error("Semantic Scholar HTTP error: %s", exc)
+        status = exc.response.status_code if exc.response is not None else None
+        # Never leak upstream status lines / URLs (issue #166 class).
+        logger.error("Semantic Scholar HTTP error: status=%s", status)
+        if status == 404:
+            return [
+                types.TextContent(
+                    type="text",
+                    text="Error: paper not found on Semantic Scholar",
+                )
+            ]
+        detail = f" (HTTP {status})" if status is not None else ""
         return [
             types.TextContent(
                 type="text",
-                text=f"Error: Semantic Scholar API HTTP error - {str(exc)}",
+                text=f"Error: Semantic Scholar API HTTP error{detail}",
             )
         ]
     except Exception as exc:

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -105,10 +105,15 @@ async def test_citation_graph_success():
 
 @pytest.mark.asyncio
 async def test_citation_graph_http_error():
-    """Citation graph should surface HTTP API errors."""
+    """Citation graph should surface HTTP API errors without leaking S2 URLs."""
     mock_response = MagicMock()
     mock_response.status_code = 500
-    mock_response.raise_for_status.side_effect = Exception("boom")
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Client error '500 Internal Server Error' for url "
+        "'https://api.semanticscholar.org/graph/v1/paper/ARXIV:2401.12345'",
+        request=MagicMock(),
+        response=mock_response,
+    )
 
     mock_client = _mock_async_client([mock_response])
 
@@ -116,6 +121,9 @@ async def test_citation_graph_http_error():
         response = await handle_citation_graph({"paper_id": "2401.12345"})
 
     assert response[0].text.startswith("Error:")
+    assert "semanticscholar.org" not in response[0].text
+    assert "https://" not in response[0].text
+    assert "HTTP 500" in response[0].text
 
 
 @pytest.mark.asyncio
@@ -228,3 +236,83 @@ async def test_citation_graph_neighbors_include_arxiv_id_from_external_ids():
     neighbor_fields = mock_client.get.call_args_list[1].kwargs["params"]["fields"]
     assert neighbor_fields == citation_graph_module.NEIGHBOR_FIELDS
     assert "externalIds" in neighbor_fields
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "paper_id,expected_version",
+    [("1706.03762v1", "v1"), ("1706.03762v7", "v7")],
+)
+async def test_citation_graph_strips_version_for_s2_lookup(paper_id, expected_version):
+    """Versioned arXiv IDs must query Semantic Scholar with the bare ARXIV id."""
+    paper_payload = {
+        **PAPER_PAYLOAD,
+        "externalIds": {"ArXiv": "1706.03762"},
+    }
+    mock_client = _mock_async_client(
+        [
+            _json_response(paper_payload),
+            _json_response(CITATIONS_PAYLOAD),
+            _json_response(REFERENCES_PAYLOAD),
+        ]
+    )
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        response = await handle_citation_graph({"paper_id": paper_id})
+
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    assert payload["paper"]["arxiv_id"] == "1706.03762"
+    assert payload["paper"]["requested_arxiv_id"] == paper_id
+    assert payload["paper"]["requested_version"] == expected_version
+
+    paper_url = mock_client.get.call_args_list[0].args[0]
+    assert paper_url.endswith("/paper/ARXIV:1706.03762")
+    assert expected_version not in paper_url.split("/paper/", 1)[1]
+    assert (
+        mock_client.get.call_args_list[1]
+        .args[0]
+        .endswith("/paper/ARXIV:1706.03762/citations")
+    )
+    assert (
+        mock_client.get.call_args_list[2]
+        .args[0]
+        .endswith("/paper/ARXIV:1706.03762/references")
+    )
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_bare_id_omits_requested_version_fields():
+    """Bare IDs should not invent requested_version metadata."""
+    mock_client = _mock_async_client(_success_responses())
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        response = await handle_citation_graph({"paper_id": "2401.12345"})
+
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "success"
+    assert payload["paper"]["arxiv_id"] == "2401.12345"
+    assert "requested_arxiv_id" not in payload["paper"]
+    assert "requested_version" not in payload["paper"]
+    assert mock_client.get.call_args_list[0].args[0].endswith("/paper/ARXIV:2401.12345")
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_404_does_not_leak_s2_url():
+    """404 responses must not expose the Semantic Scholar request URL."""
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Client error '404 Not Found' for url "
+        "'https://api.semanticscholar.org/graph/v1/paper/ARXIV:1706.03762v1'",
+        request=MagicMock(),
+        response=mock_response,
+    )
+    mock_client = _mock_async_client([mock_response])
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        response = await handle_citation_graph({"paper_id": "1706.03762v1"})
+
+    assert response[0].text == "Error: paper not found on Semantic Scholar"
+    assert "semanticscholar.org" not in response[0].text
+    assert "https://" not in response[0].text


### PR DESCRIPTION
## Summary
- Use `bare_arxiv_id` when building the Semantic Scholar `ARXIV:` externalId so versioned ids from download/list/search (`1706.03762v1`, `v7`, …) no longer 404.
- When a `vN` suffix was requested, include `requested_arxiv_id` / `requested_version` on the paper payload; `arxiv_id` remains the bare lookup id.
- Return HTTP errors without embedding Semantic Scholar URLs (issue #166 class).

## Why
Agents commonly pass versioned stems from other tools. S2 only knows bare arXiv ids, so `ARXIV:1706.03762v1` hard-failed while `ARXIV:1706.03762` worked.

## Test plan
- [x] Unit: versioned `paper_id` hits `/paper/ARXIV:<bare>` (parametrized v1/v7)
- [x] Unit: response echoes `requested_version` / `requested_arxiv_id` only when versioned
- [x] Unit: bare id omits requested_* fields and keeps prior success shape
- [x] Unit: 404/500 errors omit `semanticscholar.org` / `https://`
- [x] `uv run pytest tests/tools/test_citation_graph.py` (10 passed)
- [x] Black 26.1.0 check on changed files

Closes #211