### PR TITLE
fix: check_alerts readOnlyHint=False (mutates last_checked)

### DIFF
--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -65,7 +65,9 @@ watch_topic_tool = types.Tool(
 
 check_alerts_tool = types.Tool(
     name="check_alerts",
-    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    annotations=ToolAnnotations(
+        readOnlyHint=False, idempotentHint=False, openWorldHint=True
+    ),
     description=(
         "Check all saved topic watches for newly published papers since the last check. "
         "Omitting the topic parameter runs ALL saved watches and returns new papers for each. "

--- a/tests/tools/test_alerts.py
+++ b/tests/tools/test_alerts.py
@@ -198,3 +198,10 @@ def test_list_and_unwatch_tool_annotations():
     """list_watches is read-only; unwatch_topic is a write."""
     assert alerts_module.list_watches_tool.annotations.readOnlyHint is True
     assert alerts_module.unwatch_topic_tool.annotations.readOnlyHint is False
+
+
+def test_check_alerts_tool_annotations_not_readonly():
+    """check_alerts mutates last_checked, so it must not be marked read-only."""
+    ann = alerts_module.check_alerts_tool.annotations
+    assert ann.readOnlyHint is False
+    assert ann.idempotentHint is False


### PR DESCRIPTION
## Summary
`check_alerts` updates each watch's `last_checked` timestamp, but was annotated `readOnlyHint=True`. MCP clients may treat that as safe to cache/replay.

- Set `readOnlyHint=False` and `idempotentHint=False` on `check_alerts`
- Leave `list_watches` read-only
- Add a small annotation regression test

Closes #216

## Test plan
- [x] Black 26.1.0 on touched files
- [ ] `pytest tests/tools/test_alerts.py::test_check_alerts_tool_annotations_not_readonly`
- [ ] Confirm `list_watches` annotations still `readOnlyHint=True`