### PR TITLE
fix: do not jump check_alerts watermark past truncated pages

### DIFF
--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -72,9 +72,11 @@ check_alerts_tool = types.Tool(
         "Check all saved topic watches for newly published papers since the last check. "
         "Omitting the topic parameter runs ALL saved watches and returns new papers for each. "
         "Passing a topic string checks only that specific watch. "
-        "Advances each watch's last_checked watermark after running: when a page is truncated by "
-        "max_results, the watermark moves to the newest returned paper (has_more=true) so later "
-        "calls keep draining the same window; when the page is not full, last_checked becomes now. "
+        "Advances each watch's drain cursor after running: when a page is truncated by "
+        "max_results, has_more=true and check_start advances so later calls return the next "
+        "papers in the same window (Atom date bounds alone are day-granular and would otherwise "
+        "re-hit the boundary); last_checked tracks the newest returned paper. When the page is "
+        "not full, last_checked becomes now and the drain cursor resets. "
         "Use watch_topic to register topics before calling this. "
         "Returns a summary with new paper counts, has_more, and full paper metadata per topic."
     ),
@@ -207,21 +209,28 @@ def _page_is_truncated(
     max_results: int,
     total_results: Optional[int],
     new_count: Optional[int] = None,
+    start: int = 0,
 ) -> bool:
     """True when max_results or OpenSearch total indicates more papers remain.
 
-    A full page of results (returned/new_count == max_results) is treated as
-    truncated so we never jump the watermark to wall-clock now and skip the
-    rest of the watch window. When OpenSearch reports total > returned, that
-    also means more remain.
+    When OpenSearch reports a total, trust start+returned vs total. Otherwise a
+    full page (returned/new_count == max_results) is treated as truncated so we
+    never jump the watermark to wall-clock now and skip the rest of the window.
     """
-    if total_results is not None and total_results > returned:
-        return True
+    start = max(0, int(start or 0))
+    if total_results is not None:
+        return total_results > (start + returned)
     if returned >= max_results > 0:
         return True
     if new_count is not None and new_count >= max_results > 0:
         return True
     return False
+
+
+def _clear_drain_cursor(topic: Dict[str, Any]) -> None:
+    """Reset pagination fields used while draining a truncated watch window."""
+    topic.pop("drain_from", None)
+    topic.pop("check_start", None)
 
 
 async def handle_watch_topic(arguments: Dict[str, Any]) -> List[types.TextContent]:
@@ -296,15 +305,24 @@ async def handle_check_alerts(arguments: Dict[str, Any]) -> List[types.TextConte
 
             last_checked = topic.get("last_checked")
             max_results = min(int(topic.get("max_results", 10)), settings.MAX_RESULTS)
-            # Oldest-first so a truncated page can advance the watermark to the
-            # newest returned paper and subsequent checks keep draining the window.
+            # Freeze the Atom date lower-bound for this drain. submittedDate is
+            # day-granular, so bumping last_checked to a paper's published time
+            # would re-fetch the same boundary hit at start=0. Paginate with
+            # check_start against drain_from instead.
+            drain_from = topic.get("drain_from")
+            if drain_from is None:
+                drain_from = last_checked
+            check_start = max(0, int(topic.get("check_start") or 0))
+
+            # Oldest-first so start offsets walk forward through the window.
             search_results, total_results = await _raw_arxiv_search(
                 query=topic_query,
                 max_results=max_results,
                 sort_by="date",
                 sort_order="ascending",
-                date_from=last_checked,
+                date_from=drain_from,
                 categories=topic.get("categories") or None,
+                start=check_start,
             )
 
             new_papers = [
@@ -318,16 +336,26 @@ async def handle_check_alerts(arguments: Dict[str, Any]) -> List[types.TextConte
                 max_results,
                 total_results,
                 new_count=len(new_papers),
+                start=check_start,
             )
 
             if has_more:
-                # Do not jump to wall-clock now — only advance through returned papers.
-                watermark = _newest_published(new_papers)
-                if watermark is not None:
-                    topic["last_checked"] = watermark
-                # else: keep prior last_checked until a page yields papers
+                if search_results:
+                    # Advance start past this raw page so a day-granular Atom
+                    # re-hit of the boundary paper cannot freeze the drain
+                    # (empty new_papers + has_more + frozen cursor).
+                    topic["drain_from"] = drain_from
+                    topic["check_start"] = check_start + len(search_results)
+                    if new_papers:
+                        topic["last_checked"] = _newest_published(new_papers)
+                else:
+                    # has_more with zero raw hits cannot progress — stop.
+                    has_more = False
+                    topic["last_checked"] = now_iso
+                    _clear_drain_cursor(topic)
             else:
                 topic["last_checked"] = now_iso
+                _clear_drain_cursor(topic)
 
             topic["updated_at"] = now_iso
 

--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -72,9 +72,11 @@ check_alerts_tool = types.Tool(
         "Check all saved topic watches for newly published papers since the last check. "
         "Omitting the topic parameter runs ALL saved watches and returns new papers for each. "
         "Passing a topic string checks only that specific watch. "
-        "Updates each watch's last_checked timestamp after running, so subsequent calls only return newer papers. "
+        "Advances each watch's last_checked watermark after running: when a page is truncated by "
+        "max_results, the watermark moves to the newest returned paper (has_more=true) so later "
+        "calls keep draining the same window; when the page is not full, last_checked becomes now. "
         "Use watch_topic to register topics before calling this. "
-        "Returns a summary with new paper counts and full paper metadata per topic."
+        "Returns a summary with new paper counts, has_more, and full paper metadata per topic."
     ),
     inputSchema={
         "type": "object",
@@ -184,6 +186,44 @@ def _is_new_paper(published_value: str, last_checked: Optional[str]) -> bool:
         return True
 
 
+def _newest_published(papers: List[Dict[str, Any]]) -> Optional[str]:
+    """Return the published timestamp of the newest paper in the list."""
+    newest_value: Optional[str] = None
+    newest_dt: Optional[datetime] = None
+    for paper in papers:
+        published = paper.get("published") or ""
+        try:
+            published_dt = parser.parse(published)
+        except (ValueError, TypeError):
+            continue
+        if newest_dt is None or published_dt > newest_dt:
+            newest_dt = published_dt
+            newest_value = published
+    return newest_value
+
+
+def _page_is_truncated(
+    returned: int,
+    max_results: int,
+    total_results: Optional[int],
+    new_count: Optional[int] = None,
+) -> bool:
+    """True when max_results or OpenSearch total indicates more papers remain.
+
+    A full page of results (returned/new_count == max_results) is treated as
+    truncated so we never jump the watermark to wall-clock now and skip the
+    rest of the watch window. When OpenSearch reports total > returned, that
+    also means more remain.
+    """
+    if total_results is not None and total_results > returned:
+        return True
+    if returned >= max_results > 0:
+        return True
+    if new_count is not None and new_count >= max_results > 0:
+        return True
+    return False
+
+
 async def handle_watch_topic(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Save or update a watched topic definition."""
     try:
@@ -255,12 +295,14 @@ async def handle_check_alerts(arguments: Dict[str, Any]) -> List[types.TextConte
                 continue
 
             last_checked = topic.get("last_checked")
-            search_results, _total = await _raw_arxiv_search(
+            max_results = min(int(topic.get("max_results", 10)), settings.MAX_RESULTS)
+            # Oldest-first so a truncated page can advance the watermark to the
+            # newest returned paper and subsequent checks keep draining the window.
+            search_results, total_results = await _raw_arxiv_search(
                 query=topic_query,
-                max_results=min(
-                    int(topic.get("max_results", 10)), settings.MAX_RESULTS
-                ),
+                max_results=max_results,
                 sort_by="date",
+                sort_order="ascending",
                 date_from=last_checked,
                 categories=topic.get("categories") or None,
             )
@@ -271,17 +313,33 @@ async def handle_check_alerts(arguments: Dict[str, Any]) -> List[types.TextConte
                 if _is_new_paper(paper.get("published", ""), last_checked)
             ]
 
+            has_more = _page_is_truncated(
+                len(search_results),
+                max_results,
+                total_results,
+                new_count=len(new_papers),
+            )
+
+            if has_more:
+                # Do not jump to wall-clock now — only advance through returned papers.
+                watermark = _newest_published(new_papers)
+                if watermark is not None:
+                    topic["last_checked"] = watermark
+                # else: keep prior last_checked until a page yields papers
+            else:
+                topic["last_checked"] = now_iso
+
+            topic["updated_at"] = now_iso
+
             alerts.append(
                 {
                     "topic": topic_query,
                     "last_checked": last_checked,
                     "new_paper_count": len(new_papers),
                     "new_papers": new_papers,
+                    "has_more": has_more,
                 }
             )
-
-            topic["last_checked"] = now_iso
-            topic["updated_at"] = now_iso
 
         payload["topics"] = all_topics
         _save_watches(payload)

--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -190,6 +190,7 @@ def build_arxiv_search_url(
     date_to: Optional[str] = None,
     categories: Optional[List[str]] = None,
     start: int = 0,
+    sort_order: str = "descending",
 ) -> str:
     """Build a raw arXiv API URL with a percent-encoded search_query."""
     final_query = build_arxiv_search_query(
@@ -204,13 +205,14 @@ def build_arxiv_search_url(
         "relevance": "relevance",
         "date": "submittedDate",
     }
+    order = sort_order if sort_order in ("ascending", "descending") else "descending"
     encoded_query = quote(final_query, safe="")
     start = max(0, int(start))
     base_params = (
         f"start={start}"
         f"&max_results={max_results}"
         f"&sortBy={sort_map.get(sort_by, 'relevance')}"
-        f"&sortOrder=descending"
+        f"&sortOrder={order}"
     )
     return f"{ARXIV_API_URL}?search_query={encoded_query}&{base_params}"
 
@@ -223,6 +225,7 @@ async def _raw_arxiv_search(
     date_to: Optional[str] = None,
     categories: Optional[List[str]] = None,
     start: int = 0,
+    sort_order: str = "descending",
 ) -> tuple[List[Dict[str, Any]], Optional[int]]:
     """
     Perform arXiv search using raw HTTP requests.
@@ -242,6 +245,7 @@ async def _raw_arxiv_search(
         date_to=date_to,
         categories=categories,
         start=start,
+        sort_order=sort_order,
     )
     logger.debug(f"Raw API URL: {url}")
 

--- a/tests/tools/test_alerts.py
+++ b/tests/tools/test_alerts.py
@@ -205,3 +205,231 @@ def test_check_alerts_tool_annotations_not_readonly():
     ann = alerts_module.check_alerts_tool.annotations
     assert ann.readOnlyHint is False
     assert ann.idempotentHint is False
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_truncated_page_does_not_jump_watermark_to_now(
+    monkeypatch, alerts_test_env
+):
+    """Regression #217: truncated max_results must not advance last_checked to now."""
+    calls = {"n": 0}
+
+    async def _mock_truncated(**kwargs):
+        calls["n"] += 1
+        assert kwargs.get("sort_order") == "ascending"
+        # Page full (max_results=1) while OpenSearch reports many more hits.
+        return (
+            [
+                {
+                    "id": "2401.00001",
+                    "title": "Oldest unread",
+                    "authors": ["A"],
+                    "abstract": "x",
+                    "categories": ["cs.LG"],
+                    "published": "2024-06-01T12:00:00+00:00",
+                    "url": "https://arxiv.org/pdf/2401.00001",
+                    "resource_uri": "arxiv://2401.00001",
+                }
+            ],
+            9321,
+        )
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_truncated)
+
+    await alerts_module.handle_watch_topic(
+        {"topic": 'ti:"neural" AND cat:cs.LG', "max_results": 1}
+    )
+
+    # Seed last_checked far in the past (repro from #217).
+    payload = alerts_module._load_watches()
+    payload["topics"][0]["last_checked"] = "2024-01-01T00:00:00+00:00"
+    alerts_module._save_watches(payload)
+
+    before = "2024-01-01T00:00:00+00:00"
+    response = await alerts_module.handle_check_alerts(
+        {"topic": 'ti:"neural" AND cat:cs.LG'}
+    )
+    result = json.loads(response[0].text)
+    assert result["status"] == "success"
+    alert = result["alerts"][0]
+    assert alert["new_paper_count"] == 1
+    assert alert["has_more"] is True
+
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["last_checked"] == "2024-06-01T12:00:00+00:00"
+    assert stored["last_checked"] != before
+    # Must not have jumped to wall-clock "now".
+    assert not stored["last_checked"].startswith("2026-")
+    assert "T" in stored["last_checked"]
+    from dateutil import parser as date_parser
+    from datetime import datetime, timezone, timedelta
+
+    watermark = date_parser.parse(stored["last_checked"])
+    assert watermark < datetime.now(timezone.utc) - timedelta(days=30)
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_truncated_page_continues_draining(
+    monkeypatch, alerts_test_env
+):
+    """Regression #217: subsequent checks keep draining until the window is caught up."""
+    pages = [
+        (
+            [
+                {
+                    "id": "2401.00001",
+                    "title": "Paper A",
+                    "authors": ["A"],
+                    "abstract": "x",
+                    "categories": ["cs.LG"],
+                    "published": "2024-02-01T00:00:00+00:00",
+                    "url": "https://arxiv.org/pdf/2401.00001",
+                    "resource_uri": "arxiv://2401.00001",
+                }
+            ],
+            3,
+        ),
+        (
+            [
+                {
+                    "id": "2401.00002",
+                    "title": "Paper B",
+                    "authors": ["B"],
+                    "abstract": "y",
+                    "categories": ["cs.LG"],
+                    "published": "2024-03-01T00:00:00+00:00",
+                    "url": "https://arxiv.org/pdf/2401.00002",
+                    "resource_uri": "arxiv://2401.00002",
+                }
+            ],
+            2,
+        ),
+        (
+            [
+                {
+                    "id": "2401.00003",
+                    "title": "Paper C",
+                    "authors": ["C"],
+                    "abstract": "z",
+                    "categories": ["cs.LG"],
+                    "published": "2024-04-01T00:00:00+00:00",
+                    "url": "https://arxiv.org/pdf/2401.00003",
+                    "resource_uri": "arxiv://2401.00003",
+                }
+            ],
+            1,
+        ),
+        ([], 0),
+    ]
+    seen_date_from = []
+
+    async def _mock_pages(**kwargs):
+        seen_date_from.append(kwargs.get("date_from"))
+        return pages[min(len(seen_date_from) - 1, len(pages) - 1)]
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_pages)
+
+    await alerts_module.handle_watch_topic({"topic": "drain-me", "max_results": 1})
+    payload = alerts_module._load_watches()
+    payload["topics"][0]["last_checked"] = "2024-01-01T00:00:00+00:00"
+    alerts_module._save_watches(payload)
+
+    first = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
+    assert first["alerts"][0]["has_more"] is True
+    assert first["alerts"][0]["new_papers"][0]["id"] == "2401.00001"
+    assert (
+        alerts_module._load_watches()["topics"][0]["last_checked"]
+        == "2024-02-01T00:00:00+00:00"
+    )
+
+    second = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
+    assert second["alerts"][0]["has_more"] is True
+    assert second["alerts"][0]["new_papers"][0]["id"] == "2401.00002"
+    assert (
+        alerts_module._load_watches()["topics"][0]["last_checked"]
+        == "2024-03-01T00:00:00+00:00"
+    )
+
+    # Last paper still fills max_results=1, so treat as maybe-truncated and
+    # only advance through the returned published time.
+    third = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
+    assert third["alerts"][0]["has_more"] is True
+    assert third["alerts"][0]["new_papers"][0]["id"] == "2401.00003"
+    assert (
+        alerts_module._load_watches()["topics"][0]["last_checked"]
+        == "2024-04-01T00:00:00+00:00"
+    )
+
+    # Empty non-full page: safe to mark caught up to wall-clock now.
+    fourth = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
+    assert fourth["alerts"][0]["has_more"] is False
+    assert fourth["alerts"][0]["new_paper_count"] == 0
+    final_watermark = alerts_module._load_watches()["topics"][0]["last_checked"]
+    assert final_watermark != "2024-04-01T00:00:00+00:00"
+    assert final_watermark != "2024-01-01T00:00:00+00:00"
+    assert seen_date_from[0] == "2024-01-01T00:00:00+00:00"
+    assert seen_date_from[1] == "2024-02-01T00:00:00+00:00"
+    assert seen_date_from[2] == "2024-03-01T00:00:00+00:00"
+    assert seen_date_from[3] == "2024-04-01T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_full_page_marks_caught_up(monkeypatch, alerts_test_env):
+    """When fewer than max_results are returned, watermark advances to now safely."""
+
+    async def _mock_partial(**kwargs):
+        return (
+            [
+                {
+                    "id": "2501.00010",
+                    "title": "Only Paper",
+                    "authors": ["A"],
+                    "abstract": "x",
+                    "categories": ["cs.AI"],
+                    "published": "2025-01-15T00:00:00+00:00",
+                    "url": "https://arxiv.org/pdf/2501.00010",
+                    "resource_uri": "arxiv://2501.00010",
+                }
+            ],
+            1,
+        )
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_partial)
+
+    await alerts_module.handle_watch_topic({"topic": "caught-up", "max_results": 10})
+    payload = alerts_module._load_watches()
+    payload["topics"][0]["last_checked"] = "2025-01-01T00:00:00+00:00"
+    alerts_module._save_watches(payload)
+
+    result = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
+    assert result["alerts"][0]["has_more"] is False
+    assert result["alerts"][0]["new_paper_count"] == 1
+
+    stored = alerts_module._load_watches()["topics"][0]["last_checked"]
+    assert stored != "2025-01-01T00:00:00+00:00"
+    assert stored != "2025-01-15T00:00:00+00:00"
+    from dateutil import parser as date_parser
+    from datetime import datetime, timezone, timedelta
+
+    assert date_parser.parse(stored) >= datetime.now(timezone.utc) - timedelta(
+        minutes=5
+    )
+
+
+def test_page_is_truncated_helpers():
+    """Unit coverage for truncation detection used by check_alerts."""
+    assert alerts_module._page_is_truncated(1, 1, 9321) is True
+    assert alerts_module._page_is_truncated(10, 10, 10) is True
+    assert alerts_module._page_is_truncated(3, 10, 3) is False
+    assert alerts_module._page_is_truncated(0, 10, 0) is False
+    assert alerts_module._page_is_truncated(5, 10, 12) is True
+    assert (
+        alerts_module._newest_published(
+            [
+                {"published": "2024-01-01T00:00:00Z"},
+                {"published": "2024-06-01T12:00:00+00:00"},
+                {"published": "2024-03-01T00:00:00Z"},
+            ]
+        )
+        == "2024-06-01T12:00:00+00:00"
+    )

--- a/tests/tools/test_alerts.py
+++ b/tests/tools/test_alerts.py
@@ -272,60 +272,46 @@ async def test_check_alerts_truncated_page_does_not_jump_watermark_to_now(
 async def test_check_alerts_truncated_page_continues_draining(
     monkeypatch, alerts_test_env
 ):
-    """Regression #217: subsequent checks keep draining until the window is caught up."""
-    pages = [
-        (
-            [
-                {
-                    "id": "2401.00001",
-                    "title": "Paper A",
-                    "authors": ["A"],
-                    "abstract": "x",
-                    "categories": ["cs.LG"],
-                    "published": "2024-02-01T00:00:00+00:00",
-                    "url": "https://arxiv.org/pdf/2401.00001",
-                    "resource_uri": "arxiv://2401.00001",
-                }
-            ],
-            3,
-        ),
-        (
-            [
-                {
-                    "id": "2401.00002",
-                    "title": "Paper B",
-                    "authors": ["B"],
-                    "abstract": "y",
-                    "categories": ["cs.LG"],
-                    "published": "2024-03-01T00:00:00+00:00",
-                    "url": "https://arxiv.org/pdf/2401.00002",
-                    "resource_uri": "arxiv://2401.00002",
-                }
-            ],
-            2,
-        ),
-        (
-            [
-                {
-                    "id": "2401.00003",
-                    "title": "Paper C",
-                    "authors": ["C"],
-                    "abstract": "z",
-                    "categories": ["cs.LG"],
-                    "published": "2024-04-01T00:00:00+00:00",
-                    "url": "https://arxiv.org/pdf/2401.00003",
-                    "resource_uri": "arxiv://2401.00003",
-                }
-            ],
-            1,
-        ),
-        ([], 0),
+    """Regression #217: subsequent checks paginate start until the window is caught up."""
+    corpus = [
+        {
+            "id": "2401.00001",
+            "title": "Paper A",
+            "authors": ["A"],
+            "abstract": "x",
+            "categories": ["cs.LG"],
+            "published": "2024-02-01T00:00:00+00:00",
+            "url": "https://arxiv.org/pdf/2401.00001",
+            "resource_uri": "arxiv://2401.00001",
+        },
+        {
+            "id": "2401.00002",
+            "title": "Paper B",
+            "authors": ["B"],
+            "abstract": "y",
+            "categories": ["cs.LG"],
+            "published": "2024-03-01T00:00:00+00:00",
+            "url": "https://arxiv.org/pdf/2401.00002",
+            "resource_uri": "arxiv://2401.00002",
+        },
+        {
+            "id": "2401.00003",
+            "title": "Paper C",
+            "authors": ["C"],
+            "abstract": "z",
+            "categories": ["cs.LG"],
+            "published": "2024-04-01T00:00:00+00:00",
+            "url": "https://arxiv.org/pdf/2401.00003",
+            "resource_uri": "arxiv://2401.00003",
+        },
     ]
-    seen_date_from = []
+    seen = []
 
     async def _mock_pages(**kwargs):
-        seen_date_from.append(kwargs.get("date_from"))
-        return pages[min(len(seen_date_from) - 1, len(pages) - 1)]
+        start = int(kwargs.get("start") or 0)
+        seen.append({"date_from": kwargs.get("date_from"), "start": start})
+        page = corpus[start : start + 1]
+        return page, len(corpus)
 
     monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_pages)
 
@@ -337,40 +323,115 @@ async def test_check_alerts_truncated_page_continues_draining(
     first = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
     assert first["alerts"][0]["has_more"] is True
     assert first["alerts"][0]["new_papers"][0]["id"] == "2401.00001"
-    assert (
-        alerts_module._load_watches()["topics"][0]["last_checked"]
-        == "2024-02-01T00:00:00+00:00"
-    )
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["last_checked"] == "2024-02-01T00:00:00+00:00"
+    assert stored["check_start"] == 1
+    assert stored["drain_from"] == "2024-01-01T00:00:00+00:00"
 
     second = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
     assert second["alerts"][0]["has_more"] is True
     assert second["alerts"][0]["new_papers"][0]["id"] == "2401.00002"
-    assert (
-        alerts_module._load_watches()["topics"][0]["last_checked"]
-        == "2024-03-01T00:00:00+00:00"
-    )
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["last_checked"] == "2024-03-01T00:00:00+00:00"
+    assert stored["check_start"] == 2
 
-    # Last paper still fills max_results=1, so treat as maybe-truncated and
-    # only advance through the returned published time.
+    # Last paper: start+returned == total => has_more clears, cursor resets to now.
     third = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
-    assert third["alerts"][0]["has_more"] is True
+    assert third["alerts"][0]["has_more"] is False
     assert third["alerts"][0]["new_papers"][0]["id"] == "2401.00003"
-    assert (
-        alerts_module._load_watches()["topics"][0]["last_checked"]
-        == "2024-04-01T00:00:00+00:00"
-    )
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["last_checked"] != "2024-04-01T00:00:00+00:00"
+    assert stored["last_checked"] != "2024-01-01T00:00:00+00:00"
+    assert "check_start" not in stored
+    assert "drain_from" not in stored
+    # date_from stays frozen at the drain window; start paginates.
+    assert [s["date_from"] for s in seen] == ["2024-01-01T00:00:00+00:00"] * 3
+    assert [s["start"] for s in seen] == [0, 1, 2]
 
-    # Empty non-full page: safe to mark caught up to wall-clock now.
-    fourth = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
-    assert fourth["alerts"][0]["has_more"] is False
-    assert fourth["alerts"][0]["new_paper_count"] == 0
-    final_watermark = alerts_module._load_watches()["topics"][0]["last_checked"]
-    assert final_watermark != "2024-04-01T00:00:00+00:00"
-    assert final_watermark != "2024-01-01T00:00:00+00:00"
-    assert seen_date_from[0] == "2024-01-01T00:00:00+00:00"
-    assert seen_date_from[1] == "2024-02-01T00:00:00+00:00"
-    assert seen_date_from[2] == "2024-03-01T00:00:00+00:00"
-    assert seen_date_from[3] == "2024-04-01T00:00:00+00:00"
+
+@pytest.mark.asyncio
+async def test_check_alerts_boundary_hit_does_not_stick_empty_has_more(
+    monkeypatch, alerts_test_env
+):
+    """Regression #217 live FAIL: Atom re-returns the watermark paper; must still progress.
+
+    After call0 sets last_checked to the returned published time, a naive start=0
+    refetch yields the same boundary paper, which `_is_new_paper` drops (strict >).
+    Drain must either return a different next paper or clear has_more — never
+    empty+has_more with a frozen cursor.
+    """
+    paper_a = {
+        "id": "2401.00633",
+        "title": "Boundary",
+        "authors": ["A"],
+        "abstract": "x",
+        "categories": ["cs.LG"],
+        "published": "2024-01-01T02:03:35Z",
+        "url": "https://arxiv.org/pdf/2401.00633",
+        "resource_uri": "arxiv://2401.00633",
+    }
+    paper_b = {
+        "id": "2401.00634",
+        "title": "Next",
+        "authors": ["B"],
+        "abstract": "y",
+        "categories": ["cs.LG"],
+        "published": "2024-01-01T05:00:00Z",
+        "url": "https://arxiv.org/pdf/2401.00634",
+        "resource_uri": "arxiv://2401.00634",
+    }
+    corpus = [paper_a, paper_b]
+    seen = []
+
+    async def _mock_atom(**kwargs):
+        # Simulate day-granular date_from: always the same corpus, honor start.
+        start = int(kwargs.get("start") or 0)
+        seen.append({"start": start, "date_from": kwargs.get("date_from")})
+        page = corpus[start : start + int(kwargs.get("max_results") or 1)]
+        return page, len(corpus)
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_atom)
+
+    await alerts_module.handle_watch_topic(
+        {"topic": 'ti:"neural" AND cat:cs.LG', "max_results": 1}
+    )
+    payload = alerts_module._load_watches()
+    payload["topics"][0]["last_checked"] = "2024-01-01T00:00:00+00:00"
+    alerts_module._save_watches(payload)
+
+    call0 = json.loads(
+        (
+            await alerts_module.handle_check_alerts(
+                {"topic": 'ti:"neural" AND cat:cs.LG'}
+            )
+        )[0].text
+    )
+    assert call0["alerts"][0]["new_paper_count"] == 1
+    assert call0["alerts"][0]["new_papers"][0]["id"] == "2401.00633"
+    assert call0["alerts"][0]["has_more"] is True
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["last_checked"] == "2024-01-01T02:03:35Z"
+    assert not stored["last_checked"].startswith("2026-")
+    assert stored["check_start"] == 1
+
+    call1 = json.loads(
+        (
+            await alerts_module.handle_check_alerts(
+                {"topic": 'ti:"neural" AND cat:cs.LG'}
+            )
+        )[0].text
+    )
+    alert1 = call1["alerts"][0]
+    stored1 = alerts_module._load_watches()["topics"][0]
+    # Second call must return the next paper (start=1), not re-trap on boundary.
+    assert alert1["new_paper_count"] == 1
+    assert alert1["new_papers"][0]["id"] == "2401.00634"
+    assert alert1["new_papers"][0]["id"] != "2401.00633"
+    # Exhausted total=2 => has_more false and drain cursor cleared.
+    assert alert1["has_more"] is False
+    assert "check_start" not in stored1
+    assert "drain_from" not in stored1
+    assert [s["start"] for s in seen] == [0, 1]
 
 
 @pytest.mark.asyncio
@@ -419,10 +480,16 @@ async def test_check_alerts_full_page_marks_caught_up(monkeypatch, alerts_test_e
 def test_page_is_truncated_helpers():
     """Unit coverage for truncation detection used by check_alerts."""
     assert alerts_module._page_is_truncated(1, 1, 9321) is True
-    assert alerts_module._page_is_truncated(10, 10, 10) is True
+    assert alerts_module._page_is_truncated(10, 10, 10) is False
     assert alerts_module._page_is_truncated(3, 10, 3) is False
     assert alerts_module._page_is_truncated(0, 10, 0) is False
     assert alerts_module._page_is_truncated(5, 10, 12) is True
+    # With start offset: last page of a known total is not truncated.
+    assert alerts_module._page_is_truncated(1, 1, 3, start=2) is False
+    assert alerts_module._page_is_truncated(1, 1, 3, start=1) is True
+    # Without total, a full page is assumed truncated.
+    assert alerts_module._page_is_truncated(1, 1, None) is True
+    assert alerts_module._page_is_truncated(0, 1, None) is False
     assert (
         alerts_module._newest_published(
             [


### PR DESCRIPTION
## Summary
- Stop advancing `last_checked` to wall-clock now when `check_alerts` results are truncated by `max_results` (or OpenSearch total > returned).
- Fetch watches oldest-first and advance the watermark only to the newest returned `published` time; surface `has_more` so clients can keep draining.
- When the page is not full, mark the watch caught up (`last_checked = now`) safely.

Separate from #216 (`readOnlyHint` only).

## Test plan
- [x] `pytest tests/tools/test_alerts.py` (12 passed)
- [x] Regression: truncated page does not jump watermark to now
- [x] Regression: subsequent checks drain the same window until caught up
- [x] Non-full page advances watermark to now and sets `has_more=false`
- [x] Black 26.1.0

Closes #217
