### PR TITLE
fix: surface untrusted content warning once outside paginated body

### DIFF
--- a/src/arxiv_mcp_server/tools/content.py
+++ b/src/arxiv_mcp_server/tools/content.py
@@ -94,9 +94,19 @@ def add_content_payload(
     arguments: dict[str, Any],
     content_warning: str,
 ) -> dict[str, Any]:
-    """Add paginated (bounded-by-default) content fields to a JSON payload."""
+    """Add paginated (bounded-by-default) content fields to a JSON payload.
+
+    Never prepend the untrusted-content banner into paginated ``content``
+    chunks — that broke stitchability across ``start`` pages (#215). Surface
+    the notice once via a separate ``content_warning`` field on the first page
+    (``start == 0``) instead.
+    """
     page = paginate_content(content, bound_arguments(arguments))
     chunk = page.pop("content")
     payload.update(page)
-    payload["content"] = content_warning + chunk
+    payload["content"] = chunk
+    if page["start"] == 0:
+        # Separate field: keep notice text without the trailing blank lines
+        # that existed only to separate a prepended banner from the body.
+        payload["content_warning"] = content_warning.rstrip()
     return payload

--- a/tests/test_mcp_bound_content_defaults.py
+++ b/tests/test_mcp_bound_content_defaults.py
@@ -53,9 +53,10 @@ async def test_mcp_read_paper_default_response_is_size_bounded(
     assert payload["next_start"] == DEFAULT_MAX_CHARS
     assert "next_retrieval" in payload
 
-    # Paper body (excluding the fixed untrusted-content warning) is bounded.
-    body = payload["content"].split("\n\n", 1)[1]
-    assert len(body) == DEFAULT_MAX_CHARS
+    # Paper body is bounded; untrusted notice is a separate first-page field (#215).
+    assert len(payload["content"]) == DEFAULT_MAX_CHARS
+    assert "UNTRUSTED EXTERNAL CONTENT" in payload["content_warning"]
+    assert "UNTRUSTED" not in payload["content"]
 
     # Whole MCP text payload must stay well under a naive full-paper dump.
     # Full paper JSON would be >50k; default chunk should be roughly warning +

--- a/tests/tools/test_content.py
+++ b/tests/tools/test_content.py
@@ -132,5 +132,52 @@ def test_add_content_payload_applies_default_bound_and_preserves_metadata():
     assert payload["next_start"] == DEFAULT_MAX_CHARS
     assert payload["is_truncated"] is True
     assert payload["next_retrieval"]
-    assert payload["content"].startswith(warning)
-    assert payload["content"][len(warning) :] == content[:DEFAULT_MAX_CHARS]
+    # First page: warning is a separate field; content is pure paper text (#215).
+    assert payload["content_warning"] == warning.rstrip()
+    assert payload["content"] == content[:DEFAULT_MAX_CHARS]
+    assert not payload["content"].startswith("[WARN]")
+
+
+def test_add_content_payload_omits_warning_on_continuation_pages():
+    """Continuation pages must not re-emit the untrusted banner (#215)."""
+    content = "abcdefghijklmnopqrstuvwxyz"
+    warning = "[UNTRUSTED EXTERNAL CONTENT — test.]\n\n"
+
+    first = add_content_payload({}, content, {"max_chars": 10}, warning)
+    assert first["start"] == 0
+    assert first["content"] == "abcdefghij"
+    assert first["content_warning"] == warning.rstrip()
+    assert "UNTRUSTED" not in first["content"]
+
+    second = add_content_payload({}, content, {"start": 10, "max_chars": 10}, warning)
+    assert second["start"] == 10
+    assert second["content"] == "klmnopqrst"
+    assert "content_warning" not in second
+    assert not second["content"].startswith("[UNTRUSTED")
+
+    third = add_content_payload({}, content, {"start": 20, "max_chars": 10}, warning)
+    assert third["start"] == 20
+    assert third["content"] == "uvwxyz"
+    assert "content_warning" not in third
+
+
+def test_add_content_payload_stitched_pages_are_contiguous_paper_text():
+    """Stitching start=0,10,20 with max_chars=10 yields the original paper (#215)."""
+    content = "abcdefghijklmnopqrstuvwxyz"
+    warning = "[UNTRUSTED EXTERNAL CONTENT — test.]\n\n"
+    chunks = []
+    start = 0
+    while True:
+        page = add_content_payload(
+            {}, content, {"start": start, "max_chars": 10}, warning
+        )
+        chunks.append(page["content"])
+        assert "UNTRUSTED" not in page["content"]
+        if page["start"] == 0:
+            assert "content_warning" in page
+        else:
+            assert "content_warning" not in page
+        if page["next_start"] is None:
+            break
+        start = page["next_start"]
+    assert "".join(chunks) == content

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -366,8 +366,9 @@ async def test_download_paper_defaults_to_bounded_cached_content(
     assert result["is_truncated"] is True
     assert result["next_start"] == DEFAULT_MAX_CHARS
     assert "next_retrieval" in result
-    body = result["content"].split("\n\n", 1)[1]
-    assert len(body) == DEFAULT_MAX_CHARS
+    assert len(result["content"]) == DEFAULT_MAX_CHARS
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert "UNTRUSTED" not in result["content"]
     mock_html.assert_not_called()
     mock_pdf.assert_not_called()
 

--- a/tests/tools/test_download_html.py
+++ b/tests/tools/test_download_html.py
@@ -182,8 +182,9 @@ async def test_download_cache_supports_content_pagination(temp_storage_path, moc
     assert result["returned_chars"] == 5
     assert result["next_start"] == 15
     assert result["is_truncated"] is True
-    chunk = result["content"].split("\n\n", 1)[1]
-    assert chunk == "klmno"
+    assert result["content"] == "klmno"
+    assert "content_warning" not in result  # start>0: no banner (#215)
+    assert "UNTRUSTED" not in result["content"]
     mock_httpx.assert_not_called()
     mock_pdf.assert_not_called()
 
@@ -207,8 +208,8 @@ async def test_html_endpoint_success(temp_storage_path, mocker):
 
     assert result["status"] == "success"
     assert result["source"] == "html"
-    assert result["content"].endswith(html_text)
-    assert result["content"].startswith("[UNTRUSTED EXTERNAL CONTENT")
+    assert result["content"] == html_text
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
     assert (temp_storage_path / f"{paper_id}.md").exists()
     mock_pdf.assert_not_called()
 
@@ -238,8 +239,8 @@ async def test_html_404_falls_back_to_pdf(temp_storage_path, mocker):
 
     assert result["status"] == "success"
     assert result["source"] == "pdf"
-    assert result["content"].endswith(pdf_markdown)
-    assert result["content"].startswith("[UNTRUSTED EXTERNAL CONTENT")
+    assert result["content"] == pdf_markdown
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
     assert (temp_storage_path / f"{paper_id}.md").exists()
 
 

--- a/tests/tools/test_paper_outline.py
+++ b/tests/tools/test_paper_outline.py
@@ -171,7 +171,8 @@ async def test_read_section_bounds_and_invalid(patch_storage):
     assert result["status"] == "success"
     assert result["is_truncated"] is True
     assert result["returned_chars"] == 100
-    assert "UNTRUSTED EXTERNAL CONTENT" in result["content"]
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert "UNTRUSTED" not in result["content"]
     assert result["next_start"] == 100
 
     bad = await handle_read_paper_section(

--- a/tests/tools/test_read_paper.py
+++ b/tests/tools/test_read_paper.py
@@ -32,8 +32,9 @@ async def test_read_paper_supports_content_pagination(temp_storage_path, monkeyp
     assert result["returned_chars"] == 10
     assert result["next_start"] == 15
     assert result["is_truncated"] is True
-    chunk = result["content"].split("\n\n", 1)[1]
-    assert chunk == "fghijklmno"
+    assert result["content"] == "fghijklmno"
+    assert "content_warning" not in result  # start>0: no banner (#215)
+    assert "UNTRUSTED" not in result["content"]
 
 
 @pytest.mark.asyncio
@@ -85,8 +86,9 @@ async def test_read_paper_defaults_to_bounded_content(temp_storage_path, monkeyp
     assert result["next_start"] == DEFAULT_MAX_CHARS
     assert result["is_truncated"] is True
     assert "next_start" in result["next_retrieval"]
-    body = result["content"].split("\n\n", 1)[1]
-    assert len(body) == DEFAULT_MAX_CHARS
+    assert len(result["content"]) == DEFAULT_MAX_CHARS
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert "UNTRUSTED" not in result["content"]
 
 
 @pytest.mark.asyncio
@@ -130,8 +132,8 @@ async def test_read_paper_return_full_text_opt_in(temp_storage_path, monkeypatch
     assert result["is_truncated"] is False
     assert result["returned_chars"] == len(content)
     assert result["next_start"] is None
-    body = result["content"].split("\n\n", 1)[1]
-    assert body == content
+    assert result["content"] == content
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Stop prepending the `[UNTRUSTED EXTERNAL CONTENT…]` banner into every paginated `content` chunk from `add_content_payload` (shared by `read_paper`, `download_paper`, section/LaTeX content paths).
- Surface the notice once via a separate `content_warning` field when `start == 0`; continuation pages (`start > 0`) return pure paper text so agents can stitch cleanly.
- Update unit/integration tests for first-page warning field, no banner on later pages, and contiguous stitch of `start=0,10,20` chunks.

## Why
#209 only quieted `search_paper_text` excerpts. Pagination still did `payload["content"] = content_warning + chunk` on every page, so small `max_chars` windows were mostly banner and stitched pages were corrupted.

## Test plan
- [x] `pytest` for `test_content`, `test_read_paper`, `test_download*`, `test_paper_outline`, MCP bound-content defaults
- [x] Black 26.1.0
- [ ] Manual: `read_paper(start=0/300/600, max_chars=300)` on a downloaded paper — first page has `content_warning`; later pages' `content` has no UNTRUSTED prefix; concat equals contiguous paper text

Closes #215