### PR TITLE
fix: check_alerts unknown topic returns not-found

### DIFF
--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -78,6 +78,7 @@ check_alerts_tool = types.Tool(
         "re-hit the boundary); last_checked tracks the newest returned paper. When the page is "
         "not full, last_checked becomes now and the drain cursor resets. "
         "Use watch_topic to register topics before calling this. "
+        "Returns a clear not-found error if a topic is provided but no matching watch exists. "
         "Returns a summary with new paper counts, has_more, and full paper metadata per topic."
     ),
     inputSchema={
@@ -294,6 +295,20 @@ async def handle_check_alerts(arguments: Dict[str, Any]) -> List[types.TextConte
         payload = _load_watches()
         all_topics = payload.get("topics", [])
         topics = _filter_by_topic(all_topics, selected_topic)
+
+        # A specific topic that matches nothing must not look like "no new papers".
+        if selected_topic is not None and not topics:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "status": "error",
+                            "message": f"Watch not found: {selected_topic}",
+                        }
+                    ),
+                )
+            ]
 
         now_iso = _now_iso()
         alerts: List[Dict[str, Any]] = []

--- a/tests/tools/test_alerts.py
+++ b/tests/tools/test_alerts.py
@@ -194,6 +194,65 @@ async def test_unwatch_topic_removes_watch_and_errors_when_missing(alerts_test_e
     assert "not found" in missing["message"].lower()
 
 
+@pytest.mark.asyncio
+async def test_check_alerts_unknown_topic_returns_not_found(
+    monkeypatch, alerts_test_env
+):
+    """Regression #221: unknown topic must error, not silent empty success."""
+
+    async def _fail_search(**kwargs):
+        raise AssertionError("check_alerts must not search when watch is missing")
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _fail_search)
+
+    await alerts_module.handle_watch_topic({"topic": "real"})
+
+    missing = json.loads(
+        (await alerts_module.handle_check_alerts({"topic": "definitely-missing"}))[
+            0
+        ].text
+    )
+    assert missing["status"] == "error"
+    assert "not found" in missing["message"].lower()
+    assert "definitely-missing" in missing["message"]
+    assert "checked_topics" not in missing
+    assert "alerts" not in missing
+
+    # Existing watch must still be intact (no save / mutate on not-found).
+    listed = json.loads((await alerts_module.handle_list_watches({}))[0].text)
+    assert listed["watch_count"] == 1
+    assert listed["watches"][0]["topic"] == "real"
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_omit_topic_empty_watches_still_success(alerts_test_env):
+    """Omitting topic with no watches remains empty success (check-all unchanged)."""
+    result = json.loads((await alerts_module.handle_check_alerts({}))[0].text)
+    assert result["status"] == "success"
+    assert result["checked_topics"] == 0
+    assert result["alerts"] == []
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_known_topic_still_succeeds(monkeypatch, alerts_test_env):
+    """A matching topic still returns success with alerts (possibly empty)."""
+
+    async def _mock_empty(**kwargs):
+        return ([], 0)
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _mock_empty)
+
+    await alerts_module.handle_watch_topic({"topic": "real", "max_results": 5})
+    result = json.loads(
+        (await alerts_module.handle_check_alerts({"topic": "real"}))[0].text
+    )
+    assert result["status"] == "success"
+    assert result["checked_topics"] == 1
+    assert len(result["alerts"]) == 1
+    assert result["alerts"][0]["topic"] == "real"
+    assert result["alerts"][0]["new_paper_count"] == 0
+
+
 def test_list_and_unwatch_tool_annotations():
     """list_watches is read-only; unwatch_topic is a write."""
     assert alerts_module.list_watches_tool.annotations.readOnlyHint is True


### PR DESCRIPTION
## Summary
- If `check_alerts` is called with a `topic` and the filtered watch list is empty, return `status=error` / `Watch not found: …` (same class as `unwatch_topic`) before any success payload.
- Omitting `topic` (check all watches) still returns success with `checked_topics=0` and empty `alerts` when nothing is watched.
- Matching topics continue to return success with alerts (including empty new-paper lists).

Closes #221

## Test plan
- [x] `test_check_alerts_unknown_topic_returns_not_found`
- [x] `test_check_alerts_omit_topic_empty_watches_still_success`
- [x] `test_check_alerts_known_topic_still_succeeds`
- [x] Full `tests/tools/test_alerts.py` (17 passed)
- [x] Black 26.1.0