### PR TITLE
fix: preserve watch_topic categories when omitted on update

### DIFF
--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -240,7 +240,6 @@ async def handle_watch_topic(arguments: Dict[str, Any]) -> List[types.TextConten
         if not topic:
             return [types.TextContent(type="text", text="Error: topic is required")]
 
-        categories = arguments.get("categories") or []
         max_results = min(int(arguments.get("max_results", 10)), settings.MAX_RESULTS)
 
         payload = _load_watches()
@@ -248,6 +247,15 @@ async def handle_watch_topic(arguments: Dict[str, Any]) -> List[types.TextConten
         existing_index = next(
             (idx for idx, item in enumerate(topics) if item.get("topic") == topic), None
         )
+
+        # On update, only replace categories when the key is present so omitted
+        # categories preserve the stored filters. Explicit [] still clears.
+        if "categories" in arguments:
+            categories = arguments.get("categories") or []
+        elif existing_index is not None:
+            categories = topics[existing_index].get("categories") or []
+        else:
+            categories = []
 
         record = {
             "topic": topic,

--- a/tests/tools/test_alerts.py
+++ b/tests/tools/test_alerts.py
@@ -34,6 +34,86 @@ async def test_watch_topic_persists_topic(alerts_test_env):
 
 
 @pytest.mark.asyncio
+async def test_watch_topic_update_omitted_categories_preserved(alerts_test_env):
+    """Regression #222: update with only max_results must keep categories."""
+    create = await alerts_module.handle_watch_topic(
+        {
+            "topic": "wipe-demo",
+            "categories": ["cs.LG", "cs.AI"],
+            "max_results": 3,
+        }
+    )
+    created = json.loads(create[0].text)["topic"]
+    assert created["categories"] == ["cs.LG", "cs.AI"]
+    assert created["max_results"] == 3
+
+    # Simulate a prior check so last_checked is set and must be preserved.
+    payload = alerts_module._load_watches()
+    payload["topics"][0]["last_checked"] = "2024-06-01T00:00:00+00:00"
+    alerts_module._save_watches(payload)
+
+    update = await alerts_module.handle_watch_topic(
+        {"topic": "wipe-demo", "max_results": 7}
+    )
+    updated = json.loads(update[0].text)["topic"]
+    assert updated["categories"] == ["cs.LG", "cs.AI"]
+    assert updated["max_results"] == 7
+    assert updated["last_checked"] == "2024-06-01T00:00:00+00:00"
+
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["categories"] == ["cs.LG", "cs.AI"]
+    assert stored["max_results"] == 7
+    assert stored["last_checked"] == "2024-06-01T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_watch_topic_update_explicit_empty_categories_clears(alerts_test_env):
+    """Regression #222: explicit categories=[] still clears on update."""
+    await alerts_module.handle_watch_topic(
+        {
+            "topic": "wipe-demo",
+            "categories": ["cs.LG", "cs.AI"],
+            "max_results": 3,
+        }
+    )
+    update = await alerts_module.handle_watch_topic(
+        {"topic": "wipe-demo", "categories": [], "max_results": 7}
+    )
+    updated = json.loads(update[0].text)["topic"]
+    assert updated["categories"] == []
+    assert updated["max_results"] == 7
+
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["categories"] == []
+
+
+@pytest.mark.asyncio
+async def test_watch_topic_update_explicit_categories_replaces(alerts_test_env):
+    """Regression #222: passing a new categories list replaces stored filters."""
+    await alerts_module.handle_watch_topic(
+        {"topic": "wipe-demo", "categories": ["cs.LG"], "max_results": 3}
+    )
+    update = await alerts_module.handle_watch_topic(
+        {"topic": "wipe-demo", "categories": ["cs.AI", "stat.ML"]}
+    )
+    updated = json.loads(update[0].text)["topic"]
+    assert updated["categories"] == ["cs.AI", "stat.ML"]
+
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["categories"] == ["cs.AI", "stat.ML"]
+
+
+@pytest.mark.asyncio
+async def test_watch_topic_create_without_categories_defaults_empty(alerts_test_env):
+    """Create path unchanged: omitted categories still defaults to []."""
+    response = await alerts_module.handle_watch_topic({"topic": "fresh-topic"})
+    payload = json.loads(response[0].text)
+    assert payload["topic"]["categories"] == []
+    stored = alerts_module._load_watches()["topics"][0]
+    assert stored["categories"] == []
+
+
+@pytest.mark.asyncio
 async def test_check_alerts_returns_new_papers(monkeypatch, alerts_test_env):
     """check_alerts should return new papers and update last_checked."""
 


### PR DESCRIPTION
## Summary
- On `watch_topic` update, only replace `categories` when the `categories` key is present in arguments.
- Omitted `categories` (e.g. bumping `max_results` alone) preserves existing filters and `last_checked`.
- Explicit `categories: []` (or a new list) still updates categories when passed; create path unchanged.

Closes #222

## Test plan
- [x] `test_watch_topic_update_omitted_categories_preserved`
- [x] `test_watch_topic_update_explicit_empty_categories_clears`
- [x] `test_watch_topic_update_explicit_categories_replaces`
- [x] `test_watch_topic_create_without_categories_defaults_empty`
- [x] Full `tests/tools/test_alerts.py` (18 passed)
- [x] Black 26.1.0