### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "arxiv-mcp-server",
   "displayName": "arXiv MCP Server",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Search, download, read, and analyze arXiv papers through MCP.",
   "author": {
     "name": "Joseph Blazick"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "arxiv-mcp-server",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Search arXiv, read bounded full text and original LaTeX, follow citations, and monitor research topics through MCP.",
   "author": {
     "name": "Joseph Blazick",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "arxiv-mcp-server",
   "display_name": "ArXiv MCP Server",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Search, download, and analyze arXiv papers via MCP.",
   "author": {
     "name": "Joseph Blazick",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arxiv-mcp-server"
-version = "0.6.3"
+version = "0.7.0"
 description = "A flexible arXiv search and analysis service with MCP protocol support"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.blazickjp/arxiv-mcp-server",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Search arXiv papers, download full text, semantic search, citation graphs, and alerts via MCP.",
   "repository": {
     "url": "https://github.com/blazickjp/arxiv-mcp-server",
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "arxiv-mcp-server",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "arxiv-mcp-server"
-version = "0.6.3"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Bump package/release metadata from 0.6.3 → 0.7.0 (`pyproject.toml`, `uv.lock`, `server.json`, `manifest.json`, Codex/Claude plugin manifests)
- Prepares annotated tag + GitHub Release for v0.7.0 after merge

## Test plan
- [ ] CI green on this PR
- [ ] `tests/test_release_metadata.py` confirms synchronized versions