### PR TITLE
fix: dedupe overlapping search_paper_text passages (Closes #228)

### DIFF
--- a/src/arxiv_mcp_server/tools/paper_outline.py
+++ b/src/arxiv_mcp_server/tools/paper_outline.py
@@ -335,6 +335,77 @@ def _coerce_passage_chars(value: Any) -> int:
         return DEFAULT_PASSAGE_CHARS
 
 
+# Near-duplicate passages: windows shifted by ~80–160 chars share most text.
+PASSAGE_OVERLAP_THRESHOLD = 0.5
+# Cap candidate scan so pathological queries (e.g. single letter) stay cheap.
+MAX_PASSAGE_CANDIDATES = 500
+
+
+def _passage_overlap_ratio(a_start: int, a_end: int, b_start: int, b_end: int) -> float:
+    """Fraction of the shorter window that overlaps the other (0..1)."""
+    overlap = max(0, min(a_end, b_end) - max(a_start, b_start))
+    if overlap == 0:
+        return 0.0
+    shorter = min(a_end - a_start, b_end - b_start)
+    return overlap / shorter if shorter else 0.0
+
+
+def _passages_heavily_overlap(
+    candidate: dict[str, Any], selected: list[dict[str, Any]]
+) -> bool:
+    for prior in selected:
+        if (
+            _passage_overlap_ratio(
+                candidate["start"],
+                candidate["end"],
+                prior["start"],
+                prior["end"],
+            )
+            > PASSAGE_OVERLAP_THRESHOLD
+        ):
+            return True
+    return False
+
+
+def _select_diverse_passages(
+    candidates: list[dict[str, Any]], max_passages: int
+) -> list[dict[str, Any]]:
+    """Pick up to max_passages preferring new sections, then fill non-overlaps."""
+    if max_passages <= 0 or not candidates:
+        return []
+
+    selected: list[dict[str, Any]] = []
+    seen_sections: set[str] = set()
+
+    # Pass 1: one (non-overlapping) hit per section when possible.
+    for cand in candidates:
+        if len(selected) >= max_passages:
+            break
+        sid = cand.get("section_id")
+        if sid is not None and sid in seen_sections:
+            continue
+        if _passages_heavily_overlap(cand, selected):
+            continue
+        selected.append(cand)
+        if sid is not None:
+            seen_sections.add(sid)
+
+    # Pass 2: fill remaining slots with any non-overlapping later hits.
+    if len(selected) < max_passages:
+        selected_ids = {id(p) for p in selected}
+        for cand in candidates:
+            if len(selected) >= max_passages:
+                break
+            if id(cand) in selected_ids:
+                continue
+            if _passages_heavily_overlap(cand, selected):
+                continue
+            selected.append(cand)
+
+    selected.sort(key=lambda p: (p["match_start"], p["start"]))
+    return selected
+
+
 def search_passages(
     content: str,
     sections: list[MdSection],
@@ -343,7 +414,11 @@ def search_passages(
     max_passages: int,
     passage_chars: int,
 ) -> list[dict[str, Any]]:
-    """Return bounded case-insensitive substring matches with source coordinates."""
+    """Return bounded case-insensitive substring matches with source coordinates.
+
+    Suppresses high-overlap near-duplicates and prefers section-diverse hits
+    while still respecting ``max_passages``.
+    """
     if not query:
         return []
     haystack = content.casefold()
@@ -351,11 +426,11 @@ def search_passages(
     if not needle:
         return []
 
-    results: list[dict[str, Any]] = []
+    candidates: list[dict[str, Any]] = []
     search_from = 0
     half = max(32, passage_chars // 2)
 
-    while len(results) < max_passages:
+    while len(candidates) < MAX_PASSAGE_CANDIDATES:
         idx = haystack.find(needle, search_from)
         if idx < 0:
             break
@@ -372,7 +447,7 @@ def search_passages(
 
         section = _section_for_offset(sections, idx)
         excerpt = content[excerpt_start:excerpt_end]
-        results.append(
+        candidates.append(
             {
                 "start": excerpt_start,
                 "end": excerpt_end,
@@ -384,10 +459,11 @@ def search_passages(
                 "excerpt_chars": len(excerpt),
             }
         )
-        # Advance past this match to avoid duplicates; allow nearby later hits.
+        # Advance past this match; nearby later hits become candidates for
+        # overlap/section filtering below.
         search_from = match_end if match_end > search_from else search_from + 1
 
-    return results
+    return _select_diverse_passages(candidates, max_passages)
 
 
 outline_tool = types.Tool(
@@ -446,7 +522,8 @@ search_text_tool = types.Tool(
     annotations=ToolAnnotations(readOnlyHint=True),
     description=(
         "Search a downloaded paper for bounded matching passages with "
-        "section/source offsets. Lightweight substring search; no Torch."
+        "section/source offsets. Suppresses high-overlap near-duplicates and "
+        "prefers section-diverse hits. Lightweight substring search; no Torch."
     ),
     inputSchema={
         "type": "object",

--- a/tests/tools/test_paper_outline.py
+++ b/tests/tools/test_paper_outline.py
@@ -12,6 +12,7 @@ from arxiv_mcp_server.tools.paper_outline import (
     handle_read_paper_section,
     handle_search_paper_text,
     parse_markdown_sections,
+    search_passages,
 )
 
 SAMPLE_PAPER = """# Introduction
@@ -214,6 +215,88 @@ async def test_search_passages_and_empty(patch_storage):
     )
     miss_result = json.loads(miss[0].text)
     assert miss_result["returned_passages"] == 0
+
+
+def _overlap_ratio(a: dict, b: dict) -> float:
+    overlap = max(0, min(a["end"], b["end"]) - max(a["start"], b["start"]))
+    if overlap == 0:
+        return 0.0
+    shorter = min(a["end"] - a["start"], b["end"] - b["start"])
+    return overlap / shorter if shorter else 0.0
+
+
+def test_search_passages_dedupes_overlapping_windows():
+    """Nearby repeats of the same term must not flood max_passages."""
+    # Cluster "routing" hits ~100 chars apart in one section (repro pattern).
+    filler = "x" * 80
+    abstract = (
+        f"Abstract discusses routing {filler} then routing again {filler} "
+        f"with more routing {filler} and routing once more {filler} "
+        f"final routing mention."
+    )
+    methods = "Methods use routing for expert selection in MoE layers."
+    results = "Results show routing improves latency under load."
+    conclusion = "Conclusion: routing is the key bottleneck."
+    related = "Related work compares routing heuristics."
+    md = (
+        f"# Abstract\n\n{abstract}\n\n"
+        f"# Methods\n\n{methods}\n\n"
+        f"# Results\n\n{results}\n\n"
+        f"# Related Work\n\n{related}\n\n"
+        f"# Conclusion\n\n{conclusion}\n"
+    )
+    sections = parse_markdown_sections(md)
+    passages = search_passages(
+        md, sections, "routing", max_passages=5, passage_chars=400
+    )
+    assert 1 <= len(passages) <= 5
+    # Pairwise windows must not be near-duplicates.
+    for i, a in enumerate(passages):
+        for b in passages[i + 1 :]:
+            assert _overlap_ratio(a, b) <= 0.5, (a["start"], b["start"])
+    # Prefer distinct sections over five abstract near-duplicates.
+    section_ids = {p["section_id"] for p in passages if p["section_id"]}
+    assert len(section_ids) >= min(4, len(passages))
+
+
+def test_search_passages_respects_max_passages_after_dedupe():
+    md = "\n\n".join(
+        f"# Section {i}\n\nUnique routing topic {i} discussion." for i in range(1, 12)
+    )
+    sections = parse_markdown_sections(md)
+    passages = search_passages(
+        md, sections, "routing", max_passages=3, passage_chars=120
+    )
+    assert len(passages) == 3
+    assert len({p["section_id"] for p in passages}) == 3
+
+
+@pytest.mark.asyncio
+async def test_search_paper_text_dedupes_via_handler(patch_storage):
+    filler = "y" * 90
+    body = (
+        f"# Abstract\n\nrouting {filler} routing {filler} routing\n\n"
+        f"# Methods\n\nWe study routing strategies.\n\n"
+        f"# Results\n\nrouting wins on latency.\n"
+    )
+    _write_paper(patch_storage, "2410.17954", body)
+    response = await handle_search_paper_text(
+        {
+            "paper_id": "2410.17954",
+            "query": "routing",
+            "max_passages": 5,
+            "passage_chars": 300,
+        }
+    )
+    result = json.loads(response[0].text)
+    assert result["status"] == "success"
+    assert result["returned_passages"] == len(result["passages"]) <= 5
+    passages = result["passages"]
+    assert len(passages) >= 2
+    for i, a in enumerate(passages):
+        for b in passages[i + 1 :]:
+            assert _overlap_ratio(a, b) <= 0.5
+    assert len({p["section_id"] for p in passages}) >= 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Collect substring match candidates, then suppress high-overlap near-duplicate windows (overlap ratio > 0.5 relative to the shorter excerpt).
- Prefer section-diverse hits first, then fill remaining `max_passages` slots with any non-overlapping matches; results stay in document order.
- Caps candidate scan for pathological queries; updates `search_paper_text` description.

Closes #228

## Test plan
- [x] `tests/tools/test_paper_outline.py` — overlap dedupe + section diversity + max_passages + handler path
- [x] `tests/test_tool_schemas.py`
- [x] Black 26.1.0
- [ ] Manual: download `2410.17954`, `search_paper_text query="routing" max_passages=5` — no near-duplicate shifted abstracts