### PR TITLE
fix(search): reject invalid sort_by values (#242)

### DIFF
--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -23,6 +23,7 @@ DEFAULT_MAX_RESULTS = 5
 DEFAULT_ABSTRACT_MODE = "snippet"
 ABSTRACT_SNIPPET_CHARS = 280
 ABSTRACT_MODES = ("none", "snippet", "full")
+SORT_BY_VALUES = ("relevance", "date")
 _ABSTRACT_TRUNCATION_MARK = "… [truncated]"
 
 ARXIV_HEADERS = {
@@ -295,6 +296,24 @@ def _normalize_abstract_mode(value: Any) -> str:
             f"abstract_mode must be one of: none, snippet, full (got {value!r})"
         )
     return mode
+
+
+def _normalize_sort_by(value: Any) -> str:
+    """Return a valid sort_by or raise ValueError.
+
+    Only the documented values ``relevance`` and ``date`` are accepted.
+    Aliases such as ``submittedDate`` are intentionally rejected (HOLD).
+    """
+    if value is None:
+        return "relevance"
+    if not isinstance(value, str):
+        allowed = ", ".join(SORT_BY_VALUES)
+        raise ValueError(f"Invalid sort_by value {value!r}. Allowed values: {allowed}")
+    sort_by = value.strip().lower()
+    if sort_by not in SORT_BY_VALUES:
+        allowed = ", ".join(SORT_BY_VALUES)
+        raise ValueError(f"Invalid sort_by value {value!r}. Allowed values: {allowed}")
+    return sort_by
 
 
 def _snippet_abstract(abstract: str, max_chars: int = ABSTRACT_SNIPPET_CHARS) -> str:
@@ -599,7 +618,15 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
         date_from_arg = arguments.get("date_from")
         date_to_arg = arguments.get("date_to")
         categories = arguments.get("categories")
-        sort_by_arg = arguments.get("sort_by", "relevance")
+        try:
+            sort_by_arg = _normalize_sort_by(arguments.get("sort_by", "relevance"))
+        except ValueError as e:
+            return [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps({"status": "error", "message": str(e)}),
+                )
+            ]
 
         logger.debug(
             "Starting search with query: %r, max_results: %s, start: %s, "

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -9,6 +9,7 @@ from arxiv_mcp_server.tools.search import (
     DEFAULT_ABSTRACT_MODE,
     DEFAULT_MAX_RESULTS,
     ABSTRACT_SNIPPET_CHARS,
+    SORT_BY_VALUES,
     _validate_categories,
     _raw_arxiv_search,
     _parse_arxiv_atom_response,
@@ -17,6 +18,7 @@ from arxiv_mcp_server.tools.search import (
     _apply_abstract_mode,
     _snippet_abstract,
     _normalize_abstract_mode,
+    _normalize_sort_by,
     _scope_user_query,
     build_arxiv_search_query,
     build_arxiv_search_url,
@@ -385,6 +387,39 @@ async def test_search_sort_by_date():
 
         url = mock_client.get.call_args[0][0]
         assert parse_qs(urlparse(url).query)["sortBy"] == ["submittedDate"]
+
+
+def test_normalize_sort_by_defaults_and_rejects_invalid():
+    """Only documented sort_by values are accepted (#242)."""
+    assert _normalize_sort_by(None) == "relevance"
+    assert _normalize_sort_by("relevance") == "relevance"
+    assert _normalize_sort_by("DATE") == "date"
+    assert SORT_BY_VALUES == ("relevance", "date")
+
+    with pytest.raises(ValueError) as exc:
+        _normalize_sort_by("notarealsort")
+    assert "notarealsort" in str(exc.value)
+    assert "relevance" in str(exc.value)
+    assert "date" in str(exc.value)
+
+    # Aliases such as submittedDate stay on HOLD — reject, do not map.
+    with pytest.raises(ValueError) as exc:
+        _normalize_sort_by("submittedDate")
+    assert "submittedDate" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_search_invalid_sort_by_returns_json_error():
+    """Unknown sort_by is rejected with structured JSON (#242)."""
+    result = await handle_search(
+        {"query": "MoE", "max_results": 1, "sort_by": "notarealsort"}
+    )
+    content = json.loads(result[0].text)
+    assert content["status"] == "error"
+    assert "notarealsort" in content["message"]
+    assert "relevance" in content["message"]
+    assert "date" in content["message"]
+    assert "papers" not in content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Runtime-validate `search_papers` `sort_by` to only allow documented values: `relevance`, `date`.
- Unknown values (e.g. `notarealsort`) now return structured JSON `{"status":"error","message":"..."}` naming the invalid value and listing allowed values.
- Does **not** add `submittedDate` or other aliases (feature HOLD per #242).

## Test plan
- [x] `pytest tests/tools/test_search.py` (43 passed)
- [x] New unit test for `_normalize_sort_by` (rejects unknowns + `submittedDate`)
- [x] New integration test: `sort_by=notarealsort` → JSON error, no papers
- [x] Black 26.1.0

Closes #242