### PR TITLE
fix(export_citations): dedupe bare + versioned IDs of same paper

### DIFF
--- a/src/arxiv_mcp_server/tools/export_citations.py
+++ b/src/arxiv_mcp_server/tools/export_citations.py
@@ -3,7 +3,9 @@
 Scoped per maintainer request in issue #41: BibTeX only (RIS/CSL-JSON are follow-up
 work), one ``export_citations`` tool over one or more validated arXiv IDs, metadata
 taken from the arXiv API (never model-generated), version suffixes preserved where the
-caller supplies them, deterministic citation keys, and no heavy formatting dependency.
+caller supplies them, bare+versioned forms of the same paper collapsed to one entry
+(preferring the versioned id), deterministic citation keys, and no heavy formatting
+dependency.
 """
 
 import json
@@ -67,6 +69,11 @@ def _ascii_token(value: str) -> str:
 def _base_id(paper_id: str) -> str:
     """Strip a trailing version suffix, keeping the bare arXiv identifier."""
     return bare_arxiv_id(paper_id)
+
+
+def _bares_with_versioned_sibling(ids: List[str]) -> set:
+    """Bare ids that also appear versioned in *ids* (for #241 collapse)."""
+    return {_base_id(i) for i in ids if _VERSION_SUFFIX.search(i)}
 
 
 def _year_of(published: str) -> str:
@@ -228,6 +235,10 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
             if is_valid_arxiv_id(candidate):
                 valid_ids.append(candidate)
         metadata = await _fetch_metadata(valid_ids) if valid_ids else {}
+        # Drop bare ids when a versioned form of the same paper is also
+        # requested so we emit one BibTeX entry (prefer versioned) (#241).
+        # Distinct versioned ids (v1 + v7) are kept separately (#212).
+        bare_superseded = _bares_with_versioned_sibling(valid_ids)
 
         results: List[Dict[str, Any]] = []
         used_keys: set = set()
@@ -241,6 +252,11 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
                         "error": "invalid arXiv ID format",
                     }
                 )
+                continue
+            if (
+                not _VERSION_SUFFIX.search(candidate)
+                and _base_id(candidate) in bare_superseded
+            ):
                 continue
             # Prefer the exact versioned key so batching multiple versions of
             # one paper does not collapse to a single bare-id entry (#212).

--- a/tests/tools/test_export_citations.py
+++ b/tests/tools/test_export_citations.py
@@ -432,6 +432,82 @@ async def test_bare_id_resolves_to_latest_when_versions_batched(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_bare_and_versioned_same_paper_one_bibtex(monkeypatch):
+    """Bare + versioned of the same paper emit one BibTeX entry (#241).
+
+    Prefer the versioned id when mixed; either order must collapse to one entry.
+    Distinct versioned ids of the same paper remain separate (#212).
+    """
+    paper = _paper(
+        "2410.17954",
+        "ExpertFlow: Adaptive Expert Scheduling",
+        ["Yuan He"],
+        published="2024-10-23T00:00:00Z",
+        versioned_id="2410.17954v2",
+    )
+    _stub_metadata(monkeypatch, [paper])
+
+    for paper_ids in (
+        ["2410.17954", "2410.17954v2"],
+        ["2410.17954v2", "2410.17954"],
+    ):
+        payload = await _run({"paper_ids": paper_ids})
+        assert payload["status"] == "success", paper_ids
+        assert payload["bibtex"].count("@misc{") == 1, paper_ids
+        assert payload["count"]["succeeded"] == 1, paper_ids
+        assert payload["count"]["failed"] == 0, paper_ids
+        assert len(payload["results"]) == 1, paper_ids
+        assert payload["results"][0]["paper_id"] == "2410.17954v2"
+        assert "eprint = {2410.17954v2}" in payload["bibtex"]
+        assert "he2024expertflowa" not in payload["bibtex"]
+        assert payload["results"][0]["key"] == "he2024expertflow"
+
+
+@pytest.mark.asyncio
+async def test_bare_dropped_when_two_versions_also_requested(monkeypatch):
+    """Bare + v1 + v7 keeps both versions, drops bare (#241 + #212)."""
+    v7 = _paper(
+        "1706.03762",
+        "Attention Is All You Need",
+        ["Ashish Vaswani"],
+        published="2023-08-02T00:00:00Z",
+        versioned_id="1706.03762v7",
+    )
+    v1 = _paper(
+        "1706.03762",
+        "Attention Is All You Need",
+        ["Ashish Vaswani"],
+        published="2017-06-12T00:00:00Z",
+        versioned_id="1706.03762v1",
+    )
+
+    async def _fake(ids):
+        return {"1706.03762v7": v7, "1706.03762v1": v1, "1706.03762": v7}
+
+    monkeypatch.setattr(ec, "_fetch_metadata", _fake)
+    payload = await _run({"paper_ids": ["1706.03762", "1706.03762v7", "1706.03762v1"]})
+    assert payload["status"] == "success"
+    assert payload["bibtex"].count("@misc{") == 2
+    assert [r["paper_id"] for r in payload["results"]] == [
+        "1706.03762v7",
+        "1706.03762v1",
+    ]
+
+
+def test_bares_with_versioned_sibling_helper():
+    assert ec._bares_with_versioned_sibling(["2410.17954", "2410.17954v2"]) == {
+        "2410.17954"
+    }
+    assert ec._bares_with_versioned_sibling(["2410.17954v2", "2410.17954"]) == {
+        "2410.17954"
+    }
+    assert ec._bares_with_versioned_sibling(["1706.03762v7", "1706.03762v1"]) == {
+        "1706.03762"
+    }
+    assert ec._bares_with_versioned_sibling(["2401.00001", "2401.00002"]) == set()
+
+
+@pytest.mark.asyncio
 async def test_fetch_metadata_keeps_each_versioned_entry(monkeypatch):
     """Atom returning v7 and v1 must index both; bare maps to latest (#212)."""
     from unittest.mock import AsyncMock, MagicMock

--- a/tests/tools/test_paper_id_normalize.py
+++ b/tests/tools/test_paper_id_normalize.py
@@ -207,7 +207,7 @@ async def test_http_status_error_does_not_leak_upstream_url(mocker):
 
 @pytest.mark.asyncio
 async def test_export_citations_normalizes_wrappers(monkeypatch):
-    """Wrappers such as arxiv: and abs URLs are stripped before fetch (#162)."""
+    """Wrappers normalize; bare+versioned collapse; invalid still reported (#162, #241)."""
     requested = []
     _stub_metadata(
         monkeypatch,
@@ -230,9 +230,16 @@ async def test_export_citations_normalizes_wrappers(monkeypatch):
             ]
         }
     )
+    # Fetch still sees both normalized valid ids; results drop superseded bare (#241).
     assert requested == ["1706.03762v7", "1706.03762"]
     assert payload["status"] == "partial"
+    assert payload["count"]["requested"] == 3
+    assert payload["count"]["succeeded"] == 1
+    assert payload["count"]["failed"] == 1
+    assert len(payload["results"]) == 2
     assert payload["results"][0]["status"] == "success"
     assert payload["results"][0]["paper_id"] == "1706.03762v7"
     assert "eprint = {1706.03762v7}" in payload["results"][0]["bibtex"]
-    assert payload["results"][2]["error"] == "invalid arXiv ID format"
+    assert payload["bibtex"].count("@misc{") == 1
+    assert payload["results"][1]["paper_id"] == "not-a-paper"
+    assert payload["results"][1]["error"] == "invalid arXiv ID format"


### PR DESCRIPTION
## Summary
- Collapse bare + versioned forms of the same arXiv id in `export_citations` so only one BibTeX entry is emitted
- Prefer the versioned id when mixed; keep distinct versions (v1 + v7) separate (#212)
- Add regression tests for both input orders and bare + two versions

Closes #241.

## Test plan
- [x] `black==26.1.0` on touched files
- [x] `pytest tests/tools/test_export_citations.py tests/tools/test_citation_graph.py` (39 passed)