### PR TITLE
fix: clearer read_paper error when requested version is not cached

### DIFF
--- a/src/arxiv_mcp_server/tools/list_papers.py
+++ b/src/arxiv_mcp_server/tools/list_papers.py
@@ -157,6 +157,29 @@ def resolve_stored_stem(
     return None
 
 
+def cached_storage_labels(
+    paper_id: str, storage_path: Optional[Path] = None
+) -> list[str]:
+    """Return display labels for locally cached stems of this paper.
+
+    Used when a requested version is missing so callers can name what *is*
+    on disk (bare key with sidecar version, and/or legacy versioned stems).
+    """
+    requested = normalize_arxiv_id(paper_id) if paper_id else ""
+    if not requested or not is_valid_arxiv_id(requested):
+        return []
+    bare = bare_arxiv_id(requested)
+    group = _stems_for_bare_id(bare, storage_path=storage_path)
+    labels: list[str] = []
+    for stem in sorted(group, key=lambda s: (arxiv_version_number(s), s)):
+        if stem == bare:
+            ver = _sidecar_arxiv_version(stem, storage_path)
+            labels.append(f"{bare} ({ver})" if ver else bare)
+        else:
+            labels.append(stem)
+    return labels
+
+
 def list_papers() -> list[str]:
     """List stored paper IDs, deduped to one bare ID per paper.
 

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -13,7 +13,11 @@ from .arxiv_ids import (
     parse_arxiv_id,
 )
 from .content import add_content_payload, CONTENT_WARNING
-from .list_papers import _sidecar_arxiv_version, resolve_stored_stem
+from .list_papers import (
+    _sidecar_arxiv_version,
+    cached_storage_labels,
+    resolve_stored_stem,
+)
 
 settings = Settings()
 
@@ -66,6 +70,29 @@ read_tool = types.Tool(
 )
 
 
+def _missing_paper_message(
+    display: str, paper_id: str | None, storage_path: Path
+) -> str:
+    """Build a not-found error; mention local cache when a sibling version exists."""
+    base = f"Paper {display} not found in storage."
+    download_hint = "You may need to download it first using download_paper."
+    if not paper_id:
+        return f"{base} {download_hint}"
+
+    labels = cached_storage_labels(paper_id, storage_path)
+    if not labels:
+        return f"{base} {download_hint}"
+
+    cached = ", ".join(labels)
+    req_ver = arxiv_version_suffix(paper_id)
+    if req_ver:
+        return (
+            f"{base} Requested version {req_ver} is not cached locally; "
+            f"found: {cached}. {download_hint}"
+        )
+    return f"{base} Locally cached related files: {cached}. {download_hint}"
+
+
 async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent]:
     """Handle requests to read a paper's content."""
     try:
@@ -76,11 +103,8 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
             # that still match an on-disk stem via resolve.
             paper_id = normalize_arxiv_id(raw_id)
 
-        resolved = (
-            resolve_stored_stem(paper_id, Path(settings.STORAGE_PATH))
-            if paper_id
-            else None
-        )
+        storage = Path(settings.STORAGE_PATH)
+        resolved = resolve_stored_stem(paper_id, storage) if paper_id else None
         if resolved is None:
             display = paper_id or (
                 raw_id.strip() if isinstance(raw_id, str) else raw_id
@@ -91,9 +115,8 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
                     text=json.dumps(
                         {
                             "status": "error",
-                            "message": (
-                                f"Paper {display} not found in storage. "
-                                "You may need to download it first using download_paper."
+                            "message": _missing_paper_message(
+                                display, paper_id, storage
                             ),
                         }
                     ),
@@ -101,14 +124,12 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
             ]
 
         # Get paper content
-        content = Path(settings.STORAGE_PATH, f"{resolved}.md").read_text(
-            encoding="utf-8"
-        )
+        content = (storage / f"{resolved}.md").read_text(encoding="utf-8")
 
         bare = bare_arxiv_id(resolved)
-        version = _sidecar_arxiv_version(
-            resolved, Path(settings.STORAGE_PATH)
-        ) or arxiv_version_suffix(resolved)
+        version = _sidecar_arxiv_version(resolved, storage) or arxiv_version_suffix(
+            resolved
+        )
         read_payload = {
             "status": "success",
             "paper_id": bare,

--- a/tests/tools/test_read_paper.py
+++ b/tests/tools/test_read_paper.py
@@ -157,3 +157,83 @@ async def test_read_paper_invalid_offset_clamps_to_end(temp_storage_path, monkey
     assert result["returned_chars"] == 0
     assert result["is_truncated"] is False
     assert result["next_start"] is None
+
+
+@pytest.mark.asyncio
+async def test_read_paper_missing_version_names_cached_bare_sidecar(
+    temp_storage_path, monkeypatch
+):
+    """When bare+v2 is cached, read_paper(v1) names what is local (#243)."""
+    from arxiv_mcp_server.tools.list_papers import save_paper_metadata
+
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper = "2410.17954"
+    (temp_storage_path / f"{paper}.md").write_text("# Body v2", encoding="utf-8")
+    save_paper_metadata(
+        paper,
+        title="Cached Paper",
+        authors=["A"],
+        published="2024-10-01T00:00:00Z",
+        arxiv_version="v2",
+        path=temp_storage_path / f"{paper}.meta.json",
+    )
+
+    response = await handle_read_paper({"paper_id": f"{paper}v1", "max_chars": 1000})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "error"
+    message = result["message"]
+    assert f"{paper}v1" in message
+    assert "v1 is not cached locally" in message
+    assert f"{paper} (v2)" in message
+    assert "download_paper" in message
+    # Must not claim success or auto-return another version's body.
+    assert "content" not in result
+
+
+@pytest.mark.asyncio
+async def test_read_paper_missing_version_names_legacy_versioned_stem(
+    temp_storage_path, monkeypatch
+):
+    """Legacy on-disk v2 key is mentioned when v1 is requested (#243)."""
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper = "2410.17954"
+    (temp_storage_path / f"{paper}v2.md").write_text("# Legacy v2", encoding="utf-8")
+
+    response = await handle_read_paper({"paper_id": f"{paper}v1"})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "error"
+    message = result["message"]
+    assert f"{paper}v1" in message
+    assert "v1 is not cached locally" in message
+    assert f"{paper}v2" in message
+    assert "download_paper" in message
+
+
+@pytest.mark.asyncio
+async def test_read_paper_totally_missing_keeps_generic_message(
+    temp_storage_path, monkeypatch
+):
+    """No related cache → keep the original generic not-found wording."""
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    response = await handle_read_paper({"paper_id": "2410.17954v1"})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "error"
+    assert result["message"] == (
+        "Paper 2410.17954v1 not found in storage. "
+        "You may need to download it first using download_paper."
+    )


### PR DESCRIPTION
## Summary
- When `read_paper` requests a version that is not in local cache but a related bare/versioned file is present, return an error that names the missing version and what *is* cached.
- Keep the generic not-found message when nothing related is cached.
- Do **not** auto-fetch other versions (feature HOLD).

## Test plan
- [x] `pytest tests/tools/test_read_paper.py` (includes #243 cases: bare+sidecar v2, legacy v2 stem, totally missing)
- [x] Related versioned-storage / no-downgrade / list_papers tests
- [x] Black 26.1.0

Closes #243