### PR TITLE
fix: search_papers retry/backoff on arXiv 429 (#238)

### DIFF
--- a/src/arxiv_mcp_server/tools/search.py
+++ b/src/arxiv_mcp_server/tools/search.py
@@ -4,6 +4,7 @@ import json
 import logging
 import httpx
 import asyncio
+import random
 import xml.etree.ElementTree as ET
 from urllib.parse import quote
 from typing import Dict, Any, List, Optional
@@ -33,31 +34,142 @@ ARXIV_HEADERS = {
     )
 }
 
+# Retry/backoff for arXiv 429/503 — parity with citation_graph soft handling (#238).
+_MAX_RETRIES = 5
+_INITIAL_BACKOFF_SECONDS = 2.0
+_MAX_BACKOFF_SECONDS = 60.0
+_DEFAULT_RETRY_AFTER_SECONDS = 60.0
+RATE_LIMIT_MESSAGE = (
+    "arXiv is rate limiting this IP (HTTP 429). " "Please wait before retrying."
+)
+
+
+class ArxivRateLimitError(RuntimeError):
+    """Raised when arXiv keeps returning HTTP 429/503 after retries."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int = 429,
+        retry_after_seconds: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.retry_after_seconds = retry_after_seconds
+
+
+def _backoff_seconds(attempt: int, retry_after: str | None) -> float:
+    """Exponential backoff with jitter, honoring numeric Retry-After when present."""
+    delay = min(_INITIAL_BACKOFF_SECONDS * (2**attempt), _MAX_BACKOFF_SECONDS)
+    if retry_after:
+        try:
+            delay = min(max(delay, float(retry_after)), _MAX_BACKOFF_SECONDS)
+        except ValueError:
+            pass
+    # Full-ish jitter keeps concurrent clients from retrying in lockstep.
+    jittered = delay * (0.5 + random.random())
+    return min(jittered, _MAX_BACKOFF_SECONDS)
+
+
+def _parse_retry_after_seconds(retry_after: str | None) -> float | None:
+    """Parse a numeric Retry-After header value, if present."""
+    if not retry_after:
+        return None
+    try:
+        return float(retry_after)
+    except ValueError:
+        return None
+
+
+def _status_response(
+    status: str, message: str, **extra: Any
+) -> List[types.TextContent]:
+    """Return a structured {status, message} tool payload."""
+    payload: Dict[str, Any] = {"status": status, "message": message}
+    payload.update(extra)
+    return [types.TextContent(type="text", text=json.dumps(payload, indent=2))]
+
+
+def _error_response(message: str) -> List[types.TextContent]:
+    """Structured error payload used by search_papers failure paths."""
+    return _status_response("error", message)
+
+
+def _rate_limited_response(
+    message: str | None = None,
+    *,
+    retry_after_seconds: float | None = None,
+    status_code: int = 429,
+) -> List[types.TextContent]:
+    """Soft rate-limit result so callers can continue without a bare Error: stall."""
+    extra: Dict[str, Any] = {"http_status": status_code}
+    if retry_after_seconds is None:
+        retry_after_seconds = _DEFAULT_RETRY_AFTER_SECONDS
+    extra["retry_after_seconds"] = retry_after_seconds
+    return _status_response(
+        "rate_limited",
+        message or RATE_LIMIT_MESSAGE,
+        **extra,
+    )
+
 
 async def _rate_limited_get(client: httpx.AsyncClient, url: str) -> httpx.Response:
-    """Make an HTTP request through the process-wide arXiv request gate."""
+    """Make an HTTP request through the process-wide arXiv request gate.
+
+    Retries HTTP 429/503 with exponential backoff + jitter (citation_graph parity).
+    One additional retry on timeout only, independent of the rate-limit budget.
+    """
 
     async def request() -> httpx.Response:
-        for attempt in range(2):  # one retry on timeout only
-            try:
-                response = await client.get(url, headers=ARXIV_HEADERS)
-                if response.status_code in (429, 503):
-                    logger.warning(
-                        "arXiv rate limited (%s); not retrying", response.status_code
-                    )
-                    raise RuntimeError(
-                        f"arXiv is rate limiting this IP (HTTP {response.status_code}). "
-                        "Please wait 60 seconds before retrying."
-                    )
-                response.raise_for_status()
-                return response
-            except httpx.TimeoutException:
-                if attempt == 0:
-                    logger.warning("arXiv request timed out, retrying once")
-                    await asyncio.sleep(5.0)
-                else:
-                    raise
-        raise RuntimeError("arXiv request timed out after retry")
+        last_response: httpx.Response | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            response: httpx.Response | None = None
+            for timeout_attempt in range(2):
+                try:
+                    response = await client.get(url, headers=ARXIV_HEADERS)
+                    break
+                except httpx.TimeoutException:
+                    if timeout_attempt == 0:
+                        logger.warning("arXiv request timed out, retrying once")
+                        await asyncio.sleep(5.0)
+                    else:
+                        raise RuntimeError("arXiv request timed out after retry")
+            assert response is not None
+            if response.status_code in (429, 503):
+                last_response = response
+                if attempt == _MAX_RETRIES:
+                    break
+                wait = _backoff_seconds(attempt, response.headers.get("Retry-After"))
+                logger.warning(
+                    "arXiv %s; retrying in %.1fs (attempt %s/%s)",
+                    response.status_code,
+                    wait,
+                    attempt + 1,
+                    _MAX_RETRIES + 1,
+                )
+                await asyncio.sleep(wait)
+                continue
+            response.raise_for_status()
+            return response
+
+        status_code = last_response.status_code if last_response is not None else 429
+        retry_after = None
+        if last_response is not None:
+            retry_after = _parse_retry_after_seconds(
+                last_response.headers.get("Retry-After")
+            )
+        message = (
+            f"arXiv is rate limiting this IP (HTTP {status_code}). "
+            "Please wait 60 seconds before retrying."
+        )
+        raise ArxivRateLimitError(
+            message,
+            status_code=status_code,
+            retry_after_seconds=(
+                retry_after if retry_after is not None else _DEFAULT_RETRY_AFTER_SECONDS
+            ),
+        )
 
     return await ARXIV_RATE_LIMITER.run_async(request)
 
@@ -488,7 +600,8 @@ search_tool = types.Tool(
         "start default 0; response: total_results, returned, has_more, next_start, "
         "abstract_mode. Pass next_start with same abstract_mode. "
         "Use get_abstract after compact search — not after abstract_mode=full.\n\n"
-        "arXiv ~3s between requests (server-side). On rate-limit wait ~60s."
+        "arXiv ~3s between requests (server-side). Transient 429/503 are retried "
+        "with backoff; persistent rate limits return status=rate_limited."
     ),
     inputSchema={
         "type": "object",
@@ -613,7 +726,7 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 arguments.get("abstract_mode", DEFAULT_ABSTRACT_MODE)
             )
         except ValueError as e:
-            return [types.TextContent(type="text", text=f"Error: {str(e)}")]
+            return _error_response(str(e))
         base_query = arguments["query"]
         date_from_arg = arguments.get("date_from")
         date_to_arg = arguments.get("date_to")
@@ -639,12 +752,9 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
 
         # Validate categories if provided
         if categories and not _validate_categories(categories):
-            return [
-                types.TextContent(
-                    type="text",
-                    text="Error: Invalid category provided. Please check arXiv category names.",
-                )
-            ]
+            return _error_response(
+                "Invalid category provided. Please check arXiv category names."
+            )
 
         try:
             optimized_query = _optimize_query(base_query) if base_query.strip() else ""
@@ -671,16 +781,28 @@ async def handle_search(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 types.TextContent(type="text", text=json.dumps(response_data, indent=2))
             ]
 
+        except ArxivRateLimitError as e:
+            logger.warning("arXiv search rate limited after retries: %s", e)
+            return _rate_limited_response(
+                str(e),
+                retry_after_seconds=e.retry_after_seconds,
+                status_code=e.status_code,
+            )
         except httpx.HTTPStatusError as e:
             logger.error(f"arXiv API HTTP error: {e}")
-            return [
-                types.TextContent(
-                    type="text", text=f"Error: arXiv API HTTP error - {str(e)}"
-                )
-            ]
+            # Never leak upstream URLs (parity with get_abstract / #166).
+            status = e.response.status_code if e.response is not None else "unknown"
+            return _error_response(f"arXiv API HTTP error (HTTP {status})")
         except ValueError as e:
-            return [types.TextContent(type="text", text=f"Error: {str(e)}")]
+            return _error_response(str(e))
 
+    except ArxivRateLimitError as e:
+        logger.warning("arXiv search rate limited after retries: %s", e)
+        return _rate_limited_response(
+            str(e),
+            retry_after_seconds=e.retry_after_seconds,
+            status_code=e.status_code,
+        )
     except Exception as e:
         logger.error(f"Unexpected search error: {e}")
-        return [types.TextContent(type="text", text=f"Error: {str(e)}")]
+        return _error_response(str(e))

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -10,8 +10,10 @@ from arxiv_mcp_server.tools.search import (
     DEFAULT_MAX_RESULTS,
     ABSTRACT_SNIPPET_CHARS,
     SORT_BY_VALUES,
+    _MAX_RETRIES,
     _validate_categories,
     _raw_arxiv_search,
+    _rate_limited_get,
     _parse_arxiv_atom_response,
     _parse_opensearch_total_results,
     _build_search_response,
@@ -20,6 +22,7 @@ from arxiv_mcp_server.tools.search import (
     _normalize_abstract_mode,
     _normalize_sort_by,
     _scope_user_query,
+    _backoff_seconds,
     build_arxiv_search_query,
     build_arxiv_search_url,
 )
@@ -35,10 +38,12 @@ def disable_request_spacing_for_search_unit_tests(monkeypatch):
     monkeypatch.setattr(config, "_arxiv_client", None)
 
 
-def _mock_httpx_response(xml_text: str):
+def _mock_httpx_response(xml_text: str, *, status_code: int = 200, headers=None):
     """Patch httpx.AsyncClient to return an Atom feed body."""
     mock_response = MagicMock()
     mock_response.text = xml_text
+    mock_response.status_code = status_code
+    mock_response.headers = headers or {}
     mock_response.raise_for_status = MagicMock()
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_response)
@@ -175,7 +180,10 @@ async def test_search_with_invalid_dates():
         {"query": "test query", "date_from": "invalid-date", "max_results": 1}
     )
 
-    assert "Error:" in result[0].text
+    content = json.loads(result[0].text)
+    assert content["status"] == "error"
+    assert "Invalid date format" in content["message"]
+    assert not result[0].text.startswith("Error:")
 
 
 def test_validate_categories():
@@ -269,7 +277,10 @@ async def test_search_with_invalid_categories():
         }
     )
 
-    assert "Error: Invalid category" in result[0].text
+    content = json.loads(result[0].text)
+    assert content["status"] == "error"
+    assert "Invalid category" in content["message"]
+    assert not result[0].text.startswith("Error:")
 
 
 @pytest.mark.asyncio
@@ -297,15 +308,25 @@ async def test_search_arxiv_http_error():
     response = httpx.Response(500, request=request)
     error = httpx.HTTPStatusError("boom", request=request, response=response)
 
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.headers = {}
+    mock_response.raise_for_status.side_effect = error
+
     mock_client = AsyncMock()
-    mock_client.get = AsyncMock(side_effect=error)
+    mock_client.get = AsyncMock(return_value=mock_response)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
 
     with patch("httpx.AsyncClient", return_value=mock_client):
         result = await handle_search({"query": "test", "max_results": 1})
 
-        assert "arXiv API HTTP error" in result[0].text
+    content = json.loads(result[0].text)
+    assert content["status"] == "error"
+    assert "arXiv API HTTP error" in content["message"]
+    assert "HTTP 500" in content["message"]
+    assert "export.arxiv.org" not in result[0].text
+    assert not result[0].text.startswith("Error:")
 
 
 @pytest.mark.asyncio
@@ -1071,8 +1092,10 @@ async def test_search_empty_page_past_end():
 @pytest.mark.asyncio
 async def test_search_invalid_abstract_mode_errors():
     result = await handle_search({"query": "x", "abstract_mode": "brief"})
-    assert "Error:" in result[0].text
-    assert "abstract_mode" in result[0].text
+    content = json.loads(result[0].text)
+    assert content["status"] == "error"
+    assert "abstract_mode" in content["message"]
+    assert not result[0].text.startswith("Error:")
 
 
 def test_build_search_response_echoes_abstract_mode():
@@ -1109,3 +1132,126 @@ async def test_search_emits_content_warning_once_not_per_abstract():
     none_content = json.loads(none_result[0].text)
     assert "content_warning" not in none_content
     assert "abstract" not in none_content["papers"][0]
+
+
+@pytest.mark.asyncio
+async def test_search_no_criteria_returns_structured_error():
+    """Empty query with no filters must return {status, message} JSON (#238)."""
+    result = await handle_search({"query": "   "})
+    content = json.loads(result[0].text)
+    assert content["status"] == "error"
+    assert content["message"] == "No search criteria provided"
+    assert not result[0].text.startswith("Error:")
+
+
+def test_search_backoff_seconds_matches_citation_graph_pattern():
+    """Backoff ladder should use exponential delay with jitter (#238)."""
+    with patch.object(search_module.random, "random", return_value=0.5):
+        assert _backoff_seconds(0, None) == 2.0
+        assert _backoff_seconds(1, None) == 4.0
+        assert _backoff_seconds(2, None) == 8.0
+        assert _backoff_seconds(5, None) == 60.0
+
+    with patch.object(search_module.random, "random", return_value=0.0):
+        assert _backoff_seconds(0, None) == 1.0
+
+    with patch.object(search_module.random, "random", return_value=1.0):
+        assert _backoff_seconds(0, "45") == 60.0
+
+
+@pytest.mark.asyncio
+async def test_search_retries_on_429_then_succeeds():
+    """A transient arXiv 429 should be retried with backoff, then succeed (#238)."""
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.headers = {}
+    rate_limited.text = ""
+    rate_limited.raise_for_status = MagicMock()
+
+    xml = _atom_feed_with_totals(entry_count=1, total_results=1)
+    ok = MagicMock()
+    ok.status_code = 200
+    ok.headers = {}
+    ok.text = xml
+    ok.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[rate_limited, ok])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(search_module.asyncio, "sleep", new_callable=AsyncMock) as sleep,
+        patch.object(search_module.random, "random", return_value=0.5),
+    ):
+        result = await handle_search({"query": "transformers", "max_results": 1})
+
+    content = json.loads(result[0].text)
+    assert "papers" in content
+    assert content["returned"] == 1
+    assert mock_client.get.call_count == 2
+    sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_search_429_exhausted_returns_soft_rate_limited():
+    """Persistent arXiv 429s soft-fail as status=rate_limited JSON (#238)."""
+    attempts = _MAX_RETRIES + 1
+    rate_limited = MagicMock()
+    rate_limited.status_code = 429
+    rate_limited.headers = {"Retry-After": "30"}
+    rate_limited.text = ""
+    rate_limited.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=rate_limited)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(search_module.asyncio, "sleep", new_callable=AsyncMock) as sleep,
+        patch.object(search_module.random, "random", return_value=0.5),
+    ):
+        result = await handle_search({"query": "transformers", "max_results": 1})
+
+    content = json.loads(result[0].text)
+    assert content["status"] == "rate_limited"
+    assert "HTTP 429" in content["message"]
+    assert content["http_status"] == 429
+    assert content["retry_after_seconds"] == 30.0
+    assert not result[0].text.startswith("Error:")
+    assert mock_client.get.call_count == attempts
+    assert sleep.await_count == _MAX_RETRIES
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_get_retries_503_then_succeeds():
+    """503 follows the same retry path as 429 in the shared client (#238)."""
+    limited = MagicMock()
+    limited.status_code = 503
+    limited.headers = {}
+    limited.text = ""
+    limited.raise_for_status = MagicMock()
+
+    ok = MagicMock()
+    ok.status_code = 200
+    ok.headers = {}
+    ok.text = "<feed/>"
+    ok.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[limited, ok])
+
+    with (
+        patch.object(search_module.asyncio, "sleep", new_callable=AsyncMock) as sleep,
+        patch.object(search_module.random, "random", return_value=0.5),
+    ):
+        response = await _rate_limited_get(
+            mock_client, "https://export.arxiv.org/api/query"
+        )
+
+    assert response is ok
+    assert mock_client.get.call_count == 2
+    sleep.assert_awaited_once_with(2.0)


### PR DESCRIPTION
## Summary
- Add client-side retry/backoff with jitter on arXiv HTTP 429/503 in the shared `_rate_limited_get` path used by `search_papers` (citation_graph parity).
- Soft-fail exhausted rate limits as JSON `{status: "rate_limited", message, retry_after_seconds, ...}` instead of bare `Error:` text.
- Bring other `search_papers` failure paths (empty criteria, invalid category/dates/abstract_mode, HTTP errors) to `{status: "error", message}` JSON.

Closes #238

## Test plan
- [x] `uv run pytest tests/tools/test_search.py tests/tools/test_get_abstract.py tests/tools/test_export_citations.py tests/tools/test_citation_graph.py tests/test_mcp_tool_error_semantics.py --no-cov`
- [x] Black 26.1.0 on changed files
- [ ] Manual: rapid `search_papers` during a 429 window returns `status=rate_limited` after retries (no bare `Error:` stall)