### PR TITLE
docs: clarify watch_topic categories omit vs clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,24 @@ The server currently exposes 19 tools.
 | `get_paper_latex_section` | Read one bounded LaTeX section | Select by outline ID or exact title |
 | `citation_graph` | Fetch references and citing papers | Remote Semantic Scholar API; optional `SEMANTIC_SCHOLAR_API_KEY` |
 | `export_citations` | Export BibTeX for one or more arXiv IDs | Authoritative arXiv metadata |
-| `watch_topic` | Save or update an arXiv topic watch | Stored locally |
+| `watch_topic` | Save or update an arXiv topic watch | Stored locally; omit `categories` to preserve on update, `categories: []` to clear |
 | `list_watches` | List saved topic watches | Read-only; does not advance last_checked |
 | `check_alerts` | Check saved watches for new papers | Returns papers since the last check |
 | `unwatch_topic` | Delete a saved topic watch | Exact topic match; not-found if missing |
 | `semantic_search` | Search downloaded papers by semantic similarity | Requires `[pro]` |
 | `reindex` | Rebuild the local semantic index | Requires `[pro]` |
+
+### Research alerts (`watch_topic`)
+
+Save standing topic watches with `watch_topic`, inspect them with `list_watches`, poll with `check_alerts`, and remove with `unwatch_topic`.
+
+When updating an existing watch (same `topic` string):
+
+- **Omit** `categories` → **preserve** the stored category filters (and other fields you leave unchanged).
+- Pass **`categories: []`** → **clear** category filters.
+- Pass a non-empty list → replace the stored filters.
+
+Create path: omitting `categories` stores an empty list (no category filter).
 
 ### search_papers query guide
 

--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -34,6 +34,7 @@ watch_topic_tool = types.Tool(
         "The topic string uses the same query syntax as search_papers (quoted phrases, field specifiers, boolean operators). "
         'Examples: \'"diffusion models" AND ti:"video generation"\', \'au:"LeCun" AND cs.LG\'. '
         "Calling watch_topic with the same topic string updates the existing watch rather than creating a duplicate. "
+        "On update, omit categories to preserve existing filters; pass categories: [] to clear them. "
         "Pair with check_alerts to poll for new papers."
     ),
     inputSchema={
@@ -51,7 +52,12 @@ watch_topic_tool = types.Tool(
             "categories": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional arXiv category filter (e.g. ['cs.LG', 'cs.AI']). Narrows results to specific fields.",
+                "description": (
+                    "Optional arXiv category filter (e.g. ['cs.LG', 'cs.AI']). "
+                    "Narrows results to specific fields. "
+                    "On update, omit this field to preserve existing categories; "
+                    "pass an empty array [] to clear them."
+                ),
             },
             "max_results": {
                 "type": "integer",


### PR DESCRIPTION
## Summary
- Document that omitting `categories` on `watch_topic` **update** preserves existing filters (behavior from #222).
- Document that `categories: []` **clears** category filters.
- Update MCP tool description / schema text and README (tools table + Research alerts section).

Docs-only; no behavior change.

Closes #245

## Test plan
- [x] Confirmed #222 preserve/clear semantics remain in `handle_watch_topic`
- [x] README Research alerts section states omit → preserve, `[]` → clear
- [x] `watch_topic` tool description and `categories` schema description match
- [ ] Skim rendered README on GitHub