### PR TITLE
fix: content_warning first-chunk consistency for read/download pagination

### DIFF
--- a/src/arxiv_mcp_server/tools/content.py
+++ b/src/arxiv_mcp_server/tools/content.py
@@ -106,15 +106,24 @@ def add_content_payload(
 
     Never prepend the untrusted-content banner into paginated ``content``
     chunks — that broke stitchability across ``start`` pages (#215). Surface
-    the notice once via a separate ``content_warning`` field on the first page
-    (``start == 0``) instead.
+    a short notice once via a separate ``content_warning`` field on the first
+    chunk (requested ``start == 0``) instead (#230, #244). Continuation pages
+    must not re-embed a long UNTRUSTED banner into ``content`` or repeat the
+    warning field.
     """
+    # First-chunk policy keys off the *requested* offset, not the clamped page
+    # start. Empty papers clamp start>0 down to 0; those must still omit the
+    # warning so later-chunk calls stay consistent (#244).
+    requested_start = _coerce_nonnegative_int(arguments.get("start"), 0)
     page = paginate_content(content, bound_arguments(arguments))
     chunk = page.pop("content")
     payload.update(page)
+    # Pure paper text only — never concatenate the notice into content.
     payload["content"] = chunk
-    if page["start"] == 0:
-        # Separate field: keep notice text without the trailing blank lines
-        # that existed only to separate a prepended banner from the body.
+    if requested_start == 0:
+        # Separate field: keep notice text without trailing blank lines that
+        # existed only to separate a prepended banner from the body.
         payload["content_warning"] = content_warning.rstrip()
+    else:
+        payload.pop("content_warning", None)
     return payload

--- a/tests/tools/test_content.py
+++ b/tests/tools/test_content.py
@@ -196,3 +196,25 @@ def test_content_warning_is_short_token_efficient():
     assert "UNTRUSTED EXTERNAL CONTENT" in LATEX_CONTENT_WARNING
     assert "LaTeX" in LATEX_CONTENT_WARNING
     assert len(LATEX_CONTENT_WARNING) < 90
+
+
+def test_add_content_payload_empty_paper_start_gt_zero_omits_warning():
+    """Empty body clamps page start to 0; requested start>0 must still omit (#244)."""
+    warning = "[UNTRUSTED EXTERNAL CONTENT — test.]\n\n"
+    page = add_content_payload({}, "", {"start": 10, "max_chars": 50}, warning)
+    assert page["start"] == 0
+    assert page["content"] == ""
+    assert "content_warning" not in page
+
+
+def test_add_content_payload_later_chunk_clears_preexisting_warning_field():
+    """Continuation must not keep a leftover content_warning on the payload (#244)."""
+    warning = "[UNTRUSTED EXTERNAL CONTENT — test.]"
+    payload = {"status": "success", "content_warning": warning}
+    page = add_content_payload(
+        payload, "abcdefghij", {"start": 5, "max_chars": 5}, warning
+    )
+    assert page["start"] == 5
+    assert page["content"] == "fghij"
+    assert "content_warning" not in page
+    assert "UNTRUSTED" not in page["content"]

--- a/tests/tools/test_download.py
+++ b/tests/tools/test_download.py
@@ -368,6 +368,8 @@ async def test_download_paper_defaults_to_bounded_cached_content(
     assert "next_retrieval" in result
     assert len(result["content"]) == DEFAULT_MAX_CHARS
     assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "adversarial instructions" not in result["content_warning"]
     assert "UNTRUSTED" not in result["content"]
     mock_html.assert_not_called()
     mock_pdf.assert_not_called()
@@ -393,3 +395,6 @@ async def test_download_paper_return_full_text_opt_in(temp_storage_path, mocker)
     assert result["is_truncated"] is False
     assert result["returned_chars"] == len(content)
     assert result["next_start"] is None
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "UNTRUSTED" not in result["content"]

--- a/tests/tools/test_download_html.py
+++ b/tests/tools/test_download_html.py
@@ -211,6 +211,9 @@ async def test_html_endpoint_success(temp_storage_path, mocker):
     assert result["source"] == "html"
     assert result["content"] == html_text
     assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "adversarial instructions" not in result["content_warning"]
+    assert "UNTRUSTED" not in result["content"]
     assert (temp_storage_path / f"{paper_id}.md").exists()
     mock_pdf.assert_not_called()
 
@@ -242,6 +245,9 @@ async def test_html_404_falls_back_to_pdf(temp_storage_path, mocker):
     assert result["source"] == "pdf"
     assert result["content"] == pdf_markdown
     assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "adversarial instructions" not in result["content_warning"]
+    assert "UNTRUSTED" not in result["content"]
     assert (temp_storage_path / f"{paper_id}.md").exists()
 
 
@@ -419,3 +425,56 @@ async def test_existing_paper_without_html_still_hints_pdf_extra(
     assert result["status"] == "error"
     assert "pdf extra" in result["message"]
     assert "pip install arxiv-mcp-server[pdf]" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_download_cache_first_chunk_emits_short_content_warning(
+    temp_storage_path, mocker
+):
+    """Cached download_paper start=0 includes short content_warning (#244)."""
+    paper_id = "2410.17954"
+    _patch_path(mocker, temp_storage_path)
+    content = "ExpertFlow " + ("z" * 4000)
+    _stamp(temp_storage_path, paper_id, content)
+    mocker.patch("arxiv_mcp_server.tools.download._fetch_html_content")
+    mocker.patch("arxiv_mcp_server.tools.download._fetch_pdf_content")
+
+    response = await handle_download(
+        {"paper_id": paper_id, "start": 0, "max_chars": 300}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["source"] == "cache"
+    assert result["start"] == 0
+    assert result["content"] == content[:300]
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "UNTRUSTED" not in result["content"]
+
+
+@pytest.mark.asyncio
+async def test_download_later_chunk_has_no_warning_or_long_banner(
+    temp_storage_path, mocker
+):
+    """download_paper start>0 must not re-embed a long UNTRUSTED banner (#244)."""
+    paper_id = "2410.17954"
+    _patch_path(mocker, temp_storage_path)
+    content = "ExpertFlow " + ("w" * 5000)
+    _stamp(temp_storage_path, paper_id, content)
+    mocker.patch("arxiv_mcp_server.tools.download._fetch_html_content")
+    mocker.patch("arxiv_mcp_server.tools.download._fetch_pdf_content")
+
+    response = await handle_download(
+        {"paper_id": paper_id, "start": 3000, "max_chars": 300}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["source"] == "cache"
+    assert result["start"] == 3000
+    assert result["content"] == content[3000:3300]
+    assert "content_warning" not in result
+    assert "UNTRUSTED" not in result["content"]
+    assert "EXTERNAL CONTENT" not in result["content"]
+    assert "adversarial instructions" not in result["content"]

--- a/tests/tools/test_no_version_downgrade.py
+++ b/tests/tools/test_no_version_downgrade.py
@@ -76,6 +76,9 @@ async def test_older_version_without_force_does_not_downgrade(
     assert result["paper_id"] == "1706.03762"
     assert "BLEU 41.8 from v7" in result["content"]
     assert "41.0 from v1" not in result["content"]
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "UNTRUSTED" not in result["content"]
     assert (temp_storage_path / "1706.03762.md").read_text(
         encoding="utf-8"
     ) == "# Attention\nBLEU 41.8 from v7"

--- a/tests/tools/test_read_paper.py
+++ b/tests/tools/test_read_paper.py
@@ -88,6 +88,7 @@ async def test_read_paper_defaults_to_bounded_content(temp_storage_path, monkeyp
     assert "next_start" in result["next_retrieval"]
     assert len(result["content"]) == DEFAULT_MAX_CHARS
     assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
     assert "UNTRUSTED" not in result["content"]
 
 
@@ -110,7 +111,11 @@ async def test_read_paper_short_paper_unchanged_under_default(
     assert result["is_truncated"] is False
     assert result["returned_chars"] == len(content)
     assert result["next_start"] is None
-    assert result["content"].endswith("tiny")
+    assert result["content"] == "tiny"
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "UNTRUSTED" not in result["content"]
+    assert "adversarial instructions" not in result["content_warning"]
 
 
 @pytest.mark.asyncio
@@ -134,6 +139,8 @@ async def test_read_paper_return_full_text_opt_in(temp_storage_path, monkeypatch
     assert result["next_start"] is None
     assert result["content"] == content
     assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "UNTRUSTED" not in result["content"]
 
 
 @pytest.mark.asyncio
@@ -157,6 +164,66 @@ async def test_read_paper_invalid_offset_clamps_to_end(temp_storage_path, monkey
     assert result["returned_chars"] == 0
     assert result["is_truncated"] is False
     assert result["next_start"] is None
+    assert "content_warning" not in result  # requested start>0 (#244)
+    assert "UNTRUSTED" not in result["content"]
+
+
+@pytest.mark.asyncio
+async def test_read_paper_first_chunk_emits_short_content_warning_field(
+    temp_storage_path, monkeypatch
+):
+    """start=0 surfaces a short content_warning; body stays banner-free (#244)."""
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "2410.17954"
+    content = "ExpertFlow HTML body " + ("x" * 4000)
+    (temp_storage_path / f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    response = await handle_read_paper(
+        {"paper_id": paper_id, "start": 0, "max_chars": 300}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["start"] == 0
+    assert result["content"] == content[:300]
+    assert "UNTRUSTED EXTERNAL CONTENT" in result["content_warning"]
+    assert len(result["content_warning"]) < 80
+    assert "third-party source" not in result["content_warning"]
+    assert "adversarial instructions" not in result["content_warning"]
+    assert "UNTRUSTED" not in result["content"]
+    assert not result["content"].startswith("[UNTRUSTED")
+
+
+@pytest.mark.asyncio
+async def test_read_paper_later_chunk_has_no_warning_or_long_banner(
+    temp_storage_path, monkeypatch
+):
+    """start>0 must not re-embed UNTRUSTED banner or repeat content_warning (#244)."""
+    monkeypatch.setattr(
+        read_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    paper_id = "2410.17954"
+    content = "ExpertFlow HTML body " + ("y" * 5000)
+    (temp_storage_path / f"{paper_id}.md").write_text(content, encoding="utf-8")
+
+    response = await handle_read_paper(
+        {"paper_id": paper_id, "start": 3000, "max_chars": 300}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success"
+    assert result["start"] == 3000
+    assert result["content"] == content[3000:3300]
+    assert "content_warning" not in result
+    assert "UNTRUSTED" not in result["content"]
+    assert "EXTERNAL CONTENT" not in result["content"]
+    assert "adversarial instructions" not in result["content"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Emit short `content_warning` on first chunk (`requested start == 0`) for `read_paper` / `download_paper`; never prepend into paginated `content` (#215 / #230 / #244).
- Key the first-chunk decision off **requested** `start` (not clamped page start) so empty-body `start>0` calls omit the field; clear leftover `content_warning` on continuations.
- Tests lock short field on first chunks (cache/html/pdf/downgrade/short/full-text) and no banner / no warning field on later chunks (`start=3000` style).

## Test plan
- [x] `pytest` for `test_content`, `test_read_paper`, `test_download*`, `test_no_version_downgrade`, MCP bound-content defaults
- [x] Black 26.1.0
- [ ] Manual: `download_paper` / `read_paper` on `2410.17954` with `start=0` → short `content_warning`; `start=3000` → no warning field and no UNTRUSTED banner in `content`

Closes #244