### PR TITLE
fix(alerts): check_alerts returns JSON rate_limited on arXiv 429

### DIFF
--- a/src/arxiv_mcp_server/tools/alerts.py
+++ b/src/arxiv_mcp_server/tools/alerts.py
@@ -14,7 +14,11 @@ from mcp.types import ToolAnnotations
 from dateutil import parser
 
 from ..config import Settings
-from .search import _raw_arxiv_search
+from .search import (
+    ArxivRateLimitError,
+    _rate_limited_response,
+    _raw_arxiv_search,
+)
 
 logger = logging.getLogger("arxiv-mcp-server")
 settings = Settings()
@@ -412,6 +416,14 @@ async def handle_check_alerts(arguments: Dict[str, Any]) -> List[types.TextConte
             "alerts": alerts,
         }
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+    except ArxivRateLimitError as exc:
+        # Parity with search_papers (#238): structured rate_limited JSON, not bare Error:
+        logger.warning("check_alerts rate limited after retries: %s", exc)
+        return _rate_limited_response(
+            str(exc),
+            retry_after_seconds=exc.retry_after_seconds,
+            status_code=exc.status_code,
+        )
     except Exception as exc:
         logger.error("check_alerts error: %s", exc)
         return [types.TextContent(type="text", text=f"Error: {str(exc)}")]

--- a/tests/tools/test_alerts.py
+++ b/tests/tools/test_alerts.py
@@ -776,3 +776,29 @@ async def test_check_alerts_new_watch_still_surfaces_future_papers(
     assert result["alerts"][0]["new_paper_count"] == 1
     assert result["alerts"][0]["new_papers"][0]["id"] == "2608.00001"
     assert result["alerts"][0]["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_check_alerts_429_returns_rate_limited_json(monkeypatch, alerts_test_env):
+    """Regression #255: arXiv 429 must return JSON status=rate_limited, not Error: text."""
+    from arxiv_mcp_server.tools.search import ArxivRateLimitError
+
+    async def _raise_rate_limit(**kwargs):
+        raise ArxivRateLimitError(
+            "arXiv is rate limiting this IP (HTTP 429). Please wait before retrying.",
+            status_code=429,
+            retry_after_seconds=30.0,
+        )
+
+    monkeypatch.setattr(alerts_module, "_raw_arxiv_search", _raise_rate_limit)
+
+    await alerts_module.handle_watch_topic({"topic": "rate-limit-demo"})
+    response = await alerts_module.handle_check_alerts({})
+
+    assert len(response) >= 1
+    assert not response[0].text.startswith("Error:")
+    payload = json.loads(response[0].text)
+    assert payload["status"] == "rate_limited"
+    assert "HTTP 429" in payload["message"] or "rate limiting" in payload["message"]
+    assert payload["http_status"] == 429
+    assert payload["retry_after_seconds"] == 30.0


### PR DESCRIPTION
## Summary
- `handle_check_alerts` now catches `ArxivRateLimitError` and returns structured JSON via `_rate_limited_response` (`status=rate_limited`, `http_status`, `retry_after_seconds`) instead of bare `Error: ...` text.
- Parity with `search_papers` (#238) / soft rate-limit UX used elsewhere.
- Regression test covers the 429 path.

Closes #255.

## Test plan
- [x] `pytest tests/tools/test_alerts.py` (25 passed)
- [x] Black 26.1.0