### PR TITLE
fix: expose return_full_text on latex tool inputSchemas

### DIFF
--- a/src/arxiv_mcp_server/tools/latex.py
+++ b/src/arxiv_mcp_server/tools/latex.py
@@ -260,6 +260,13 @@ def _page_properties() -> dict[str, Any]:
             "maximum": MAX_RETURN_CHARS,
             "description": f"Maximum source characters to return (default {DEFAULT_MAX_CHARS})",
         },
+        "return_full_text": {
+            "type": "boolean",
+            "description": (
+                "Set true to opt out of the bounded default and return the "
+                "entire remaining source or section from start in one call"
+            ),
+        },
     }
 
 

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -151,7 +151,7 @@ async def test_tools_list_serialized_size_snapshot():
     # Soft ceiling: after shrinking search_papers, total list should stay well
     # under the pre-change ~16k measurement on main @94a1317.
     assert search_chars < 3000
-    # Soft ceiling allows abstract_mode (#128) and markdown outline tools (#129)
-    # on top of the #131 shrink.
-    assert total_chars < 17500
+    # Soft ceiling allows abstract_mode (#128), markdown outline tools (#129),
+    # and latex return_full_text schema parity (#256) on top of the #131 shrink.
+    assert total_chars < 18000
     assert len(search.description) < 1500

--- a/tests/tools/test_latex.py
+++ b/tests/tools/test_latex.py
@@ -433,9 +433,16 @@ def test_tool_schemas_are_closed_and_content_is_bounded():
     assert latex.get_paper_latex_tool.inputSchema["additionalProperties"] is False
     props = latex.get_paper_latex_tool.inputSchema["properties"]
     assert props["max_chars"]["maximum"] == latex.MAX_RETURN_CHARS
+    assert "return_full_text" in props
+    assert props["return_full_text"]["type"] == "boolean"
+    assert "start" in props and props["start"]["type"] == "integer"
     assert (
         latex.get_paper_latex_section_tool.inputSchema["additionalProperties"] is False
     )
+    section_props = latex.get_paper_latex_section_tool.inputSchema["properties"]
+    assert "return_full_text" in section_props
+    assert section_props["return_full_text"]["type"] == "boolean"
+    assert "start" in section_props and "max_chars" in section_props
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `return_full_text` (boolean) to `get_paper_latex` and `get_paper_latex_section` `inputSchema` via shared `_page_properties()`, matching `download_paper` / `read_paper` semantics.
- Handlers already honor the flag through content pagination; this is a schema parity gap so strict MCP clients can follow `next_retrieval` guidance under `additionalProperties: false`.
- Extend latex schema tests; bump tools/list soft size ceiling for the added properties.

Closes #256

## Test plan
- [x] `black==26.1.0` on touched files
- [x] `pytest tests/tools/test_latex.py::test_tool_schemas_are_closed_and_content_is_bounded tests/test_tool_schemas.py tests/test_mcp_bound_content_defaults.py`
- [ ] Confirm `tools/list` shows `return_full_text` on both latex tools