### PR TITLE
fix(export_citations): collapse identical normalized paper IDs

### DIFF
--- a/src/arxiv_mcp_server/tools/export_citations.py
+++ b/src/arxiv_mcp_server/tools/export_citations.py
@@ -4,8 +4,8 @@ Scoped per maintainer request in issue #41: BibTeX only (RIS/CSL-JSON are follow
 work), one ``export_citations`` tool over one or more validated arXiv IDs, metadata
 taken from the arXiv API (never model-generated), version suffixes preserved where the
 caller supplies them, bare+versioned forms of the same paper collapsed to one entry
-(preferring the versioned id), deterministic citation keys, and no heavy formatting
-dependency.
+(preferring the versioned id), identical normalized IDs collapsed to one entry,
+deterministic citation keys, and no heavy formatting dependency.
 """
 
 import json
@@ -242,6 +242,7 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
 
         results: List[Dict[str, Any]] = []
         used_keys: set = set()
+        seen_normalized: set = set()
         for pid in raw_ids:
             candidate = normalize_arxiv_id(pid) if isinstance(pid, str) else ""
             if not candidate or not is_valid_arxiv_id(candidate):
@@ -258,6 +259,11 @@ async def handle_export_citations(arguments: Dict[str, Any]) -> List[types.TextC
                 and _base_id(candidate) in bare_superseded
             ):
                 continue
+            # Collapse exact-duplicate normalized IDs to one BibTeX entry (#259).
+            # Bare↔versioned sibling collapse remains prefer-versioned (#241).
+            if candidate in seen_normalized:
+                continue
+            seen_normalized.add(candidate)
             # Prefer the exact versioned key so batching multiple versions of
             # one paper does not collapse to a single bare-id entry (#212).
             # Bare ids fall through to the latest-version mapping.

--- a/tests/tools/test_export_citations.py
+++ b/tests/tools/test_export_citations.py
@@ -494,6 +494,80 @@ async def test_bare_dropped_when_two_versions_also_requested(monkeypatch):
     ]
 
 
+@pytest.mark.asyncio
+async def test_exact_duplicate_bare_ids_one_bibtex(monkeypatch):
+    """Identical bare IDs collapse to one BibTeX entry (#259)."""
+    _stub_metadata(
+        monkeypatch,
+        [
+            _paper(
+                "1706.03762",
+                "Attention Is All You Need",
+                ["Ashish Vaswani"],
+                published="2017-06-12T00:00:00Z",
+            )
+        ],
+    )
+    payload = await _run({"paper_ids": ["1706.03762", "1706.03762"]})
+    assert payload["status"] == "success"
+    assert payload["bibtex"].count("@misc{") == 1
+    assert payload["count"]["succeeded"] == 1
+    assert payload["count"]["failed"] == 0
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["paper_id"] == "1706.03762"
+    assert "eprint = {1706.03762}" in payload["bibtex"]
+
+
+@pytest.mark.asyncio
+async def test_exact_duplicate_versioned_ids_one_bibtex(monkeypatch):
+    """Identical versioned IDs (e.g. v7+v7) collapse to one BibTeX entry (#259)."""
+    paper = _paper(
+        "1706.03762",
+        "Attention Is All You Need",
+        ["Ashish Vaswani"],
+        published="2023-08-02T00:00:00Z",
+        versioned_id="1706.03762v7",
+    )
+    _stub_metadata(monkeypatch, [paper])
+    payload = await _run({"paper_ids": ["1706.03762v7", "1706.03762v7"]})
+    assert payload["status"] == "success"
+    assert payload["bibtex"].count("@misc{") == 1
+    assert payload["count"]["succeeded"] == 1
+    assert payload["count"]["failed"] == 0
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["paper_id"] == "1706.03762v7"
+    assert "eprint = {1706.03762v7}" in payload["bibtex"]
+
+
+@pytest.mark.asyncio
+async def test_exact_duplicates_keep_bare_versioned_prefer_versioned(monkeypatch):
+    """Exact-dup collapse coexists with #241 bare+versioned prefer-versioned."""
+    paper = _paper(
+        "1706.03762",
+        "Attention Is All You Need",
+        ["Ashish Vaswani"],
+        published="2023-08-02T00:00:00Z",
+        versioned_id="1706.03762v7",
+    )
+    _stub_metadata(monkeypatch, [paper])
+    payload = await _run(
+        {
+            "paper_ids": [
+                "1706.03762",
+                "1706.03762",
+                "1706.03762v7",
+                "1706.03762v7",
+            ]
+        }
+    )
+    assert payload["status"] == "success"
+    assert payload["bibtex"].count("@misc{") == 1
+    assert payload["count"]["succeeded"] == 1
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["paper_id"] == "1706.03762v7"
+    assert "eprint = {1706.03762v7}" in payload["bibtex"]
+
+
 def test_bares_with_versioned_sibling_helper():
     assert ec._bares_with_versioned_sibling(["2410.17954", "2410.17954v2"]) == {
         "2410.17954"


### PR DESCRIPTION
## Summary
- Collapse identical normalized `paper_ids` in `export_citations` so duplicates like `1706.03762` twice or `1706.03762v7` twice emit a single BibTeX entry.
- Keep existing bare+versioned sibling collapse that prefers the versioned id (#241 / #247).

## Test plan
- [x] `pytest tests/tools/test_export_citations.py` (30 passed)
- [x] Black 26.1.0 clean on touched files
- [ ] Manual: `export_citations(paper_ids=["1706.03762", "1706.03762"])` → one BibTeX
- [ ] Manual: `export_citations(paper_ids=["1706.03762v7", "1706.03762v7"])` → one BibTeX
- [ ] Manual: bare+versioned mix still collapses prefer-versioned

Closes #259