### PR TITLE
fix: keep numbered body lists out of paper outlines (#257)

### DIFF
--- a/src/arxiv_mcp_server/tools/paper_outline.py
+++ b/src/arxiv_mcp_server/tools/paper_outline.py
@@ -59,6 +59,44 @@ _MAX_BARE_TITLE_CHARS = 80
 _OUTLINE_TERMINATORS = frozenset({"reference", "references", "bibliography"})
 # Top-level section indices stay small; years like 2023 USENIX… are common FPs.
 _MAX_SECTION_INDEX = 99
+# Minor words allowed lowercase inside otherwise Title-Case headings.
+_TITLE_CASE_MINOR_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "nor",
+        "but",
+        "so",
+        "yet",
+        "of",
+        "for",
+        "to",
+        "in",
+        "on",
+        "at",
+        "by",
+        "as",
+        "per",
+        "via",
+        "vs",
+        "with",
+        "from",
+        "into",
+        "onto",
+        "over",
+        "than",
+        "upon",
+        "de",
+        "von",
+        "van",
+        "der",
+        "la",
+        "le",
+    }
+)
 
 # Common standalone section titles from arXiv HTML→md conversions.
 _BARE_SECTION_TITLES = frozenset(
@@ -186,8 +224,28 @@ def _is_outline_terminator(title: str) -> bool:
     return _normalize_heading_title(title).casefold() in _OUTLINE_TERMINATORS
 
 
+def _is_title_case_phrase(title: str) -> bool:
+    """True when the phrase looks Title Case, not sentence-case body prose."""
+    words = re.findall(r"[A-Za-z0-9][A-Za-z0-9'’.-]*", title)
+    if not words:
+        return False
+    for word in words[1:]:
+        core = word.rstrip(".")
+        if not core:
+            continue
+        # Allow ALLCAPS / Title Case tokens; reject sentence-case content words.
+        if core[0].islower() and core.casefold() not in _TITLE_CASE_MINOR_WORDS:
+            return False
+    return True
+
+
 def _title_looks_like_heading(title: str, *, line_len: int) -> bool:
-    """Shared capitalization / length / venue guards for numbered headings."""
+    """Shared capitalization / length / venue guards for numbered headings.
+
+    Rejects numbered body-list items (e.g. Future Work ``4.`` / ``5.`` prose)
+    that HTML→text otherwise promotes to fake L1 sections. Does not use fuzzy
+    title matching against known section names.
+    """
     title = title.strip()
     if not title or line_len > _MAX_BARE_TITLE_CHARS:
         return False
@@ -196,6 +254,14 @@ def _title_looks_like_heading(title: str, *, line_len: int) -> bool:
         return False
     # Citation venues often look like "USENIX ATC 23" after a year number.
     if re.search(r"\b(?:19|20)\d{2}\b", title):
+        return False
+    normalized = _normalize_heading_title(title)
+    # Full-sentence list items end with ``.``; allow only known bare titles
+    # such as ``Abstract.`` / ``Introduction.``.
+    if title.endswith(".") and normalized.casefold() not in _BARE_SECTION_TITLES:
+        return False
+    # Headings are Title Case noun phrases; body lists are sentence case.
+    if not _is_title_case_phrase(normalized):
         return False
     return True
 

--- a/tests/tools/test_paper_outline.py
+++ b/tests/tools/test_paper_outline.py
@@ -786,6 +786,115 @@ def test_daop_ieee_roman_html_outline_order_without_dupes():
     assert "illustrates similarity" not in titles
 
 
+SWITCH_FUTURE_WORK_HTML_STYLE = """Switch Transformers title line
+
+1.
+Introduction
+
+Intro body about sparse models.
+
+8.
+Future Work
+
+This paper lays out a simplified architecture, improved training procedures,
+and a study of how sparse models scale. However, there remain many open
+future directions which we briefly describe here:
+
+1.
+A significant challenge is further improving training stability for the largest models.
+
+2.
+Generally we find that improved pre-training quality leads to better downstream results.
+
+3.
+Perform a comprehensive study of scaling relationships to guide the design.
+
+4.
+Our work falls within the family of adaptive computation algorithms.
+
+5.
+Investigating expert layers outside the FFN layer of the Transformer.
+
+6.
+Examining Switch Transformer in new and across different modalities.
+
+9.
+Conclusion
+
+Conclusion body.
+
+References
+
+[1] Someone et al.
+"""
+
+
+def test_switch_future_work_numbered_lists_not_outline_sections():
+    """Regression for #257: Switch Transformers Future Work list items.
+
+    HTML→text emits ``4.`` / ``5.`` body-list sentences under Future Work.
+    Those must not become fake L1 outline sections.
+    """
+    sections = parse_markdown_sections(SWITCH_FUTURE_WORK_HTML_STYLE)
+    titles = [s.title for s in sections]
+    assert "Future Work" in titles
+    assert "Conclusion" in titles
+    assert "Introduction" in titles
+    assert titles[-1] == "References"
+    # Numbered body-list prose must stay out of the outline.
+    for banned in (
+        "Our work falls within the family of adaptive computation algorithms",
+        "Investigating expert layers outside the FFN layer of the Transformer",
+        "Examining Switch Transformer in new and across different modalities",
+        "Perform a comprehensive study of scaling relationships to guide the design",
+        "A significant challenge is further improving training stability for the largest models",
+        "Generally we find that improved pre-training quality leads to better downstream results",
+    ):
+        assert banned not in titles
+        assert not any(banned in t for t in titles)
+    # Real numbered sections still parse; list markers do not inflate L1 count.
+    by_title = {s.title: s for s in sections}
+    assert by_title["Introduction"].level == 1
+    assert by_title["Future Work"].level == 1
+    assert by_title["Conclusion"].level == 1
+    assert [s.title for s in sections if s.level == 1] == [
+        "Introduction",
+        "Future Work",
+        "Conclusion",
+        "References",
+    ]
+
+
+def test_numbered_sentence_case_and_period_rejected():
+    """Sentence-case / trailing-period numbered lines are body lists, not headings."""
+    md = """1 Introduction
+
+Body.
+
+2.
+Our approach always used identical homogeneous experts.
+
+3 Methods
+
+Methods body.
+
+4.
+Investigating expert layers outside the feed-forward network.
+
+5 Conclusion
+
+Done.
+
+References
+
+[1] x
+"""
+    titles = [s.title for s in parse_markdown_sections(md)]
+    assert titles == ["Introduction", "Methods", "Conclusion", "References"]
+    assert "Our approach always used identical homogeneous experts" not in titles
+    assert "Investigating expert layers outside the feed-forward network" not in titles
+
+
 def test_roman_inline_and_reject_colon_bare_titles():
     inline = parse_markdown_sections(
         "I Introduction\n\nIntro body.\n\nII-A Background Details\n\nMore.\n"


### PR DESCRIPTION
## Summary
- Tighten numbered/roman heading heuristics so HTML→text body lists (Switch Transformers `2101.03961` Future Work `4.` / `5.` sentence-case items) are not promoted to fake L1 outline sections.
- Require Title Case (with minor-word exceptions) and reject trailing-`.` prose unless the title is a known bare section name; no fuzzy section-title matching.
- Add regression fixtures covering the Switch Future Work repro and sentence-case numbered lines.

## Test plan
- [x] `uv run black --check` on touched files (Black 26.1.0)
- [x] `uv run pytest tests/tools/test_paper_outline.py -q` (23 passed)
- [ ] Optional dogfood: `download_paper(2101.03961)` HTML path then `get_paper_outline` — Future Work list items must not appear as L1 sections

Closes #257