### PR TITLE
fix: join decorative HTML title letter spans (#258)

### DIFF
--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -130,7 +130,7 @@ settings = Settings()
 
 # Bump when HTML extraction changes so cached markdown is treated as stale
 # and re-downloaded without requiring the caller to pass force=true.
-EXTRACTOR_VERSION = 5
+EXTRACTOR_VERSION = 6
 
 
 # ---------------------------------------------------------------------------
@@ -147,8 +147,10 @@ class _ArticleTextExtractor(HTMLParser):
       - Skip script/style/nav/header/footer plus arXiv UI widgets.
       - Skip author-note chrome (Thanks/ORCID/affiliation/email blocks).
       - Skip conference/DOI/ISBN/CCS pubnotes and date/license chrome.
-      - Coalesce author lines; drop affiliation superscripts and TeX
-        superscript debris in the author block.
+      - Coalesce decorative letter-span titles into one line (keep
+        subtitle colons attached); coalesce author lines; drop
+        affiliation superscripts and TeX superscript debris in the
+        author block.
       - Skip footnotemark markers (class, role, or the literal token).
       - Skip license/permission one-liners and ICML/LaTeX page-layout
         style warnings (marginparsep and similar) that appear before the
@@ -253,6 +255,9 @@ class _ArticleTextExtractor(HTMLParser):
         self._authors_depth: int = 0
         self._authors_stack: list[bool] = []
         self._author_buf: list[str] = []
+        self._title_depth: int = 0
+        self._title_stack: list[bool] = []
+        self._title_buf: list[str] = []
 
     def _should_skip(self, tag: str, attr_map: dict[str, str]) -> bool:
         if tag in self.SKIP_TAGS:
@@ -293,6 +298,17 @@ class _ArticleTextExtractor(HTMLParser):
         if line:
             self._append_chunk(line)
 
+    def _flush_title(self) -> None:
+        """Join decorative title letter spans into one coherent line."""
+        if not self._title_buf:
+            return
+        # Concatenate raw pieces so underlined acronym letters reattach
+        # to the rest of each word (D+ata- → Data-), then collapse space.
+        line = re.sub(r"\s+", " ", "".join(self._title_buf)).strip()
+        self._title_buf = []
+        if line:
+            self._append_chunk(line)
+
     def _append_chunk(self, text: str) -> None:
         if self._article_depth > 0:
             self._article_chunks.append(text)
@@ -305,6 +321,9 @@ class _ArticleTextExtractor(HTMLParser):
         if self.FOOTNOTEMARK_TOKEN in text.lower():
             return
         if not self._seen_title and self._is_pre_title_chrome(text):
+            return
+        if self._title_depth > 0:
+            self._title_buf.append(text)
             return
         if self._authors_depth > 0:
             self._author_buf.append(text)
@@ -319,6 +338,11 @@ class _ArticleTextExtractor(HTMLParser):
         if tag in {"h1", "h2"} or "ltx_title" in classes:
             self._seen_title = True
 
+        # Document title only — not abstract/section ``ltx_title_*``.
+        entering_title = tag == "h1" or "ltx_title_document" in classes
+        if entering_title:
+            self._title_depth += 1
+
         entering_authors = "ltx_authors" in classes
         if entering_authors:
             self._authors_depth += 1
@@ -326,7 +350,7 @@ class _ArticleTextExtractor(HTMLParser):
         # Void elements have no children. Incrementing skip_depth for
         # <input> etc. and never seeing an end tag left the rest of the
         # document, including <article>, permanently skipped. Do not push
-        # authors_stack either — void tags have no matching endtag.
+        # authors/title stacks either — void tags have no matching endtag.
         if tag in self.VOID_TAGS:
             return
 
@@ -349,11 +373,16 @@ class _ArticleTextExtractor(HTMLParser):
         if skip:
             self._skip_depth += 1
         self._skip_stack.append(skip)
+        self._title_stack.append(entering_title)
         self._authors_stack.append(entering_authors)
 
     def handle_endtag(self, tag: str):
         if self._skip_stack and self._skip_stack.pop():
             self._skip_depth = max(0, self._skip_depth - 1)
+        if self._title_stack and self._title_stack.pop():
+            self._title_depth = max(0, self._title_depth - 1)
+            if self._title_depth == 0:
+                self._flush_title()
         if self._authors_stack and self._authors_stack.pop():
             self._authors_depth = max(0, self._authors_depth - 1)
             if self._authors_depth == 0:
@@ -368,9 +397,17 @@ class _ArticleTextExtractor(HTMLParser):
         self.handle_endtag(tag)
 
     def handle_data(self, data: str):
+        # Title letter spans must keep surrounding whitespace so
+        # ``D``+``ata-`` reassemble; do not strip until flush.
+        if self._title_depth > 0 and not self._skip_depth:
+            if data:
+                self._title_buf.append(data)
+            return
         self._emit(data.strip())
 
     def get_text(self) -> str:
+        if self._title_depth > 0:
+            self._flush_title()
         if self._authors_depth > 0:
             self._flush_authors()
         chunks = self._article_chunks or self._body_chunks

--- a/tests/tools/test_download_html_title.py
+++ b/tests/tools/test_download_html_title.py
@@ -1,0 +1,89 @@
+"""HTML extract: join decorative title letter spans / subtitle colon (#258)."""
+
+from arxiv_mcp_server.tools.download import EXTRACTOR_VERSION, _html_to_text
+
+# DAOP (2501.10375): underlined acronym letters are one glyph per <span>.
+DAOP_LETTER_TITLE_HTML = """
+<html>
+  <body>
+    <article class="ltx_document">
+      <h1 class="ltx_title ltx_title_document">DAOP: <span id="id1" class="ltx_text ltx_underline">D</span>ata-<span id="id2" class="ltx_text ltx_underline">A</span>ware <span id="id3" class="ltx_text ltx_underline">O</span>ffloading and Predictive <span id="id4" class="ltx_text ltx_underline">P</span>re-Calculation for Efficient MoE Inference
+        <span class="ltx_pubnotes">
+          <span class="ltx_pubnotes_content">
+            <span class="ltx_pubnote ltx_role_thanks">
+              <span class="ltx_note_name">Thanks: </span>
+              Proceedings of the DATE Conference
+            </span>
+          </span>
+        </span>
+      </h1>
+      <div class="ltx_authors">
+        <span class="ltx_personname">Yujie Zhang</span>
+      </div>
+      <div class="ltx_abstract">
+        <h6 class="ltx_title ltx_title_abstract">Abstract</h6>
+        <p>Mixture-of-Experts models face deployment challenges.</p>
+      </div>
+    </article>
+  </body>
+</html>
+"""
+
+# ExpertFlow (2410.17954): italic name span then ``:`` subtitle fragment.
+EXPERTFLOW_TITLE_COLON_HTML = """
+<html>
+  <body>
+    <article class="ltx_document">
+      <h1 class="ltx_title ltx_title_document"><span id="id1" class="ltx_text ltx_font_italic">ExpertFlow</span>: Optimized Expert Activation and Token Allocation for Efficient Mixture-of-Experts Inference
+        <span class="ltx_pubnotes">
+          <span class="ltx_pubnote ltx_role_doi">
+            <span class="ltx_note_name">DOI: </span>10.1145/example
+          </span>
+        </span>
+      </h1>
+      <div class="ltx_authors">
+        <span class="ltx_personname">Xin He</span>
+      </div>
+      <div class="ltx_abstract">
+        <h6 class="ltx_title ltx_title_abstract">Abstract.</h6>
+        <p>Sparse Mixture of Experts models face inference challenges.</p>
+      </div>
+    </article>
+  </body>
+</html>
+"""
+
+
+def test_extractor_version_bumped_for_title_letter_join():
+    """#175 auto-invalidates old DAOP/ExpertFlow caches after this change."""
+    assert EXTRACTOR_VERSION >= 6
+
+
+def test_html_to_text_joins_decorative_title_letter_spans():
+    text = _html_to_text(DAOP_LETTER_TITLE_HTML)
+    expected = (
+        "DAOP: Data-Aware Offloading and Predictive "
+        "Pre-Calculation for Efficient MoE Inference"
+    )
+    assert expected in text
+    # Must not remain letter-per-line after conversion.
+    assert "\nD\n" not in text
+    assert "\nA\n" not in text
+    assert "\nO\n" not in text
+    assert "\nP\n" not in text
+    assert "Proceedings of the DATE Conference" not in text
+    assert "Abstract" in text
+    assert "Mixture-of-Experts models face deployment challenges." in text
+
+
+def test_html_to_text_keeps_subtitle_colon_on_title_line():
+    text = _html_to_text(EXPERTFLOW_TITLE_COLON_HTML)
+    expected = (
+        "ExpertFlow: Optimized Expert Activation and Token Allocation "
+        "for Efficient Mixture-of-Experts Inference"
+    )
+    assert expected in text
+    assert "\n: " not in text
+    assert text.splitlines()[0] == expected
+    assert "10.1145/example" not in text
+    assert "Abstract." in text


### PR DESCRIPTION
## Summary
- Coalesce document-title (`h1` / `ltx_title_document`) text nodes so decorative letter spans reassemble into one coherent title line.
- Fixes DAOP `2501.10375` letter-per-line titles and ExpertFlow `2410.17954` orphaned subtitle `:` fragments.
- Bump `EXTRACTOR_VERSION` to 6 so cached markdown is refreshed (#175).
- Distinct from #239 author/CCS/`×` front-matter cleanup; #260 Switch citation/author noise left scoped out (not tightly coupled beyond sharing the extractor).

## Test plan
- [x] `pytest tests/tools/test_download_html_title.py` (DAOP + ExpertFlow fixtures)
- [x] Existing HTML extractor tests still pass (`test_download_html*.py`, footnotemark, ICML)
- [x] Live ar5iv HTML for `2501.10375` / `2410.17954` titles join correctly
- [x] Formatted with Black 26.1.0

Closes #258