### PR TITLE
fix: flat storage for legacy slash arXiv IDs (#254)

### DIFF
--- a/src/arxiv_mcp_server/resources/papers.py
+++ b/src/arxiv_mcp_server/resources/papers.py
@@ -10,6 +10,7 @@ from pydantic import AnyUrl
 import mcp.types as types
 from ..config import Settings
 from ..arxiv_api import stream_pdf_to_path
+from ..tools.arxiv_ids import filesystem_arxiv_stem, logical_arxiv_id_from_stem
 
 logger = logging.getLogger("arxiv-mcp-server")
 
@@ -26,7 +27,9 @@ class PaperManager:
 
     def _get_paper_path(self, paper_id: str) -> Path:
         """Get the absolute file path for a paper."""
-        return self.storage_path / f"{paper_id}.md"
+        path = self.storage_path / f"{filesystem_arxiv_stem(paper_id)}.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
 
     async def store_paper(self, paper_id: str, pdf_url: str) -> bool:
         """Download and store a paper from arXiv."""
@@ -69,7 +72,9 @@ class PaperManager:
     async def list_papers(self) -> list[str]:
         """List all stored paper IDs."""
         logger.info(f"Listing papers in {self.storage_path}")
-        paper_ids = [p.stem for p in self.storage_path.glob("*.md")]
+        paper_ids = [
+            logical_arxiv_id_from_stem(p.stem) for p in self.storage_path.glob("*.md")
+        ]
         logger.info(f"Found {len(paper_ids)} papers")
         return paper_ids
 

--- a/src/arxiv_mcp_server/tools/arxiv_ids.py
+++ b/src/arxiv_mcp_server/tools/arxiv_ids.py
@@ -80,3 +80,31 @@ def arxiv_version_number(paper_id: str) -> int:
     if suffix is None:
         return -1
     return int(suffix[1:])
+
+
+def filesystem_arxiv_stem(paper_id: str) -> str:
+    """Map a logical arXiv ID to a flat on-disk stem.
+
+    Legacy category IDs contain ``/`` (e.g. ``hep-th/9901001``). Embedding that
+    slash in a path creates an uncreated parent directory and crashes writers.
+    Match the LaTeX cache convention and replace ``/`` with ``__`` so files stay
+    flat under ``STORAGE_PATH``.
+    """
+    return paper_id.replace("/", "__")
+
+
+def logical_arxiv_id_from_stem(stem: str) -> str:
+    """Restore a logical arXiv ID from an on-disk stem.
+
+    Inverse of :func:`filesystem_arxiv_stem`. Stems without ``__`` are returned
+    unchanged. Restored forms are preferred only when they look like valid
+    (possibly versioned) arXiv IDs.
+    """
+    if "__" not in stem:
+        return stem
+    restored = stem.replace("__", "/")
+    if is_valid_arxiv_id(restored):
+        return restored
+    if is_valid_arxiv_id(bare_arxiv_id(restored)):
+        return restored
+    return stem

--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -18,6 +18,8 @@ from .arxiv_ids import (
     arxiv_version_number,
     arxiv_version_suffix,
     bare_arxiv_id,
+    filesystem_arxiv_stem,
+    logical_arxiv_id_from_stem,
     parse_arxiv_id,
 )
 from .list_papers import resolve_stored_stem
@@ -408,10 +410,17 @@ def _html_to_text(html: str) -> str:
 
 
 def get_paper_path(paper_id: str, suffix: str = ".md") -> Path:
-    """Get the absolute file path for a paper with given suffix."""
+    """Get the absolute file path for a paper with given suffix.
+
+    Legacy slash-form IDs are mapped to a flat stem (``/`` -> ``__``) so the
+    path stays under ``STORAGE_PATH`` without requiring category subdirectories.
+    Parent directories are still created defensively for any nested suffix paths.
+    """
     storage_path = Path(settings.STORAGE_PATH)
     storage_path.mkdir(parents=True, exist_ok=True)
-    return storage_path / f"{paper_id}{suffix}"
+    path = storage_path / f"{filesystem_arxiv_stem(paper_id)}{suffix}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def _read_extractor_version(paper_id: str) -> int | None:
@@ -484,9 +493,10 @@ def _cleanup_versioned_aliases(storage_id: str) -> None:
             paper_stem = path.stem
         else:
             continue
-        if paper_stem == storage_id:
+        logical_stem = logical_arxiv_id_from_stem(paper_stem)
+        if logical_stem == storage_id:
             continue
-        if bare_arxiv_id(paper_stem) != storage_id:
+        if bare_arxiv_id(logical_stem) != storage_id:
             continue
         try:
             path.unlink()
@@ -1003,11 +1013,34 @@ async def handle_download(arguments: Dict[str, Any]) -> List[types.TextContent]:
                 ),
             )
         ]
-    except Exception as e:
-        logger.exception(f"Unexpected error downloading {paper_id}")
+    except OSError:
+        # Never leak absolute host paths from filesystem errors to the client.
+        safe_id = locals().get("storage_id") or locals().get("paper_id") or "unknown"
+        logger.exception("Storage error downloading %s", safe_id)
         return [
             types.TextContent(
                 type="text",
-                text=json.dumps({"status": "error", "message": f"Error: {str(e)}"}),
+                text=json.dumps(
+                    {
+                        "status": "error",
+                        "message": f"Storage error while saving paper {safe_id}",
+                    }
+                ),
+            )
+        ]
+    except Exception as e:
+        safe_id = locals().get("paper_id") or "unknown"
+        logger.exception("Unexpected error downloading %s", safe_id)
+        message = str(e)
+        try:
+            storage_root = str(Path(settings.STORAGE_PATH))
+            if storage_root and storage_root in message:
+                message = message.replace(storage_root, "<storage>")
+        except Exception:
+            pass
+        return [
+            types.TextContent(
+                type="text",
+                text=json.dumps({"status": "error", "message": f"Error: {message}"}),
             )
         ]

--- a/src/arxiv_mcp_server/tools/list_papers.py
+++ b/src/arxiv_mcp_server/tools/list_papers.py
@@ -13,7 +13,9 @@ from .arxiv_ids import (
     arxiv_version_number,
     arxiv_version_suffix,
     bare_arxiv_id,
+    filesystem_arxiv_stem,
     is_valid_arxiv_id,
+    logical_arxiv_id_from_stem,
     normalize_arxiv_id,
 )
 
@@ -52,15 +54,22 @@ list_tool = types.Tool(
 
 
 def _raw_stored_stems(storage_path: Optional[Path] = None) -> list[str]:
-    """Return every on-disk ``.md`` stem that looks like an arXiv ID."""
+    """Return every on-disk ``.md`` stem that looks like an arXiv ID.
+
+    Filenames use a flat stem (legacy ``/`` stored as ``__``); returned values
+    are logical arXiv IDs with the slash restored.
+    """
     storage = Path(storage_path or settings.STORAGE_PATH)
     if not storage.exists():
         return []
-    return [
-        p.stem
-        for p in storage.iterdir()
-        if p.is_file() and p.suffix == ".md" and is_valid_arxiv_id(p.stem)
-    ]
+    stems: list[str] = []
+    for p in storage.iterdir():
+        if not (p.is_file() and p.suffix == ".md"):
+            continue
+        logical = logical_arxiv_id_from_stem(p.stem)
+        if is_valid_arxiv_id(logical):
+            stems.append(logical)
+    return stems
 
 
 def _stems_for_bare_id(
@@ -92,7 +101,7 @@ def _sidecar_arxiv_version(
 ) -> Optional[str]:
     """Read ``arxiv_version`` from a stem's sidecar, if present."""
     path = (
-        Path(storage_path) / f"{stem}{METADATA_SUFFIX}"
+        Path(storage_path) / f"{filesystem_arxiv_stem(stem)}{METADATA_SUFFIX}"
         if storage_path is not None
         else paper_metadata_path(stem)
     )
@@ -195,7 +204,12 @@ def list_papers() -> list[str]:
 
 def paper_metadata_path(paper_id: str) -> Path:
     """Return the sidecar path for locally stored paper metadata."""
-    return Path(settings.STORAGE_PATH) / f"{paper_id}{METADATA_SUFFIX}"
+    path = (
+        Path(settings.STORAGE_PATH)
+        / f"{filesystem_arxiv_stem(paper_id)}{METADATA_SUFFIX}"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def save_paper_metadata(
@@ -210,6 +224,7 @@ def save_paper_metadata(
 ) -> None:
     """Persist lightweight paper metadata next to the downloaded markdown."""
     destination = path or paper_metadata_path(paper_id)
+    destination.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "id": paper_id,
         "title": title or None,
@@ -229,7 +244,7 @@ def save_paper_metadata(
 
 def _title_from_markdown(paper_id: str) -> Optional[str]:
     """Best-effort title from the first non-empty markdown line (local only)."""
-    md_path = Path(settings.STORAGE_PATH) / f"{paper_id}.md"
+    md_path = Path(settings.STORAGE_PATH) / f"{filesystem_arxiv_stem(paper_id)}.md"
     try:
         for line in md_path.read_text(encoding="utf-8").splitlines():
             text = line.strip().lstrip("#").strip()

--- a/src/arxiv_mcp_server/tools/read_paper.py
+++ b/src/arxiv_mcp_server/tools/read_paper.py
@@ -9,6 +9,7 @@ from ..config import Settings
 from .arxiv_ids import (
     arxiv_version_suffix,
     bare_arxiv_id,
+    filesystem_arxiv_stem,
     normalize_arxiv_id,
     parse_arxiv_id,
 )
@@ -124,7 +125,9 @@ async def handle_read_paper(arguments: Dict[str, Any]) -> List[types.TextContent
             ]
 
         # Get paper content
-        content = (storage / f"{resolved}.md").read_text(encoding="utf-8")
+        content = (storage / f"{filesystem_arxiv_stem(resolved)}.md").read_text(
+            encoding="utf-8"
+        )
 
         bare = bare_arxiv_id(resolved)
         version = _sidecar_arxiv_version(resolved, storage) or arxiv_version_suffix(

--- a/tests/tools/test_arxiv_ids.py
+++ b/tests/tools/test_arxiv_ids.py
@@ -6,7 +6,9 @@ from arxiv_mcp_server.tools.arxiv_ids import (
     arxiv_version_number,
     arxiv_version_suffix,
     bare_arxiv_id,
+    filesystem_arxiv_stem,
     is_valid_arxiv_id,
+    logical_arxiv_id_from_stem,
     normalize_arxiv_id,
     parse_arxiv_id,
 )
@@ -98,3 +100,16 @@ def test_arxiv_version_suffix(raw, expected):
 def test_arxiv_version_number_orders_versions():
     assert arxiv_version_number("1706.03762") == -1
     assert arxiv_version_number("1706.03762v3") < arxiv_version_number("1706.03762v7")
+
+
+@pytest.mark.parametrize(
+    "logical, stem",
+    [
+        ("hep-th/9901001", "hep-th__9901001"),
+        ("quant-ph/0101001v2", "quant-ph__0101001v2"),
+        ("1706.03762v7", "1706.03762v7"),
+    ],
+)
+def test_filesystem_stem_roundtrip(logical, stem):
+    assert filesystem_arxiv_stem(logical) == stem
+    assert logical_arxiv_id_from_stem(stem) == logical

--- a/tests/tools/test_legacy_id_storage.py
+++ b/tests/tools/test_legacy_id_storage.py
@@ -1,0 +1,182 @@
+"""Regression: legacy slash-form arXiv IDs must store without FileNotFoundError (#254)."""
+
+import json
+
+import pytest
+
+from arxiv_mcp_server.tools import download as download_module
+from arxiv_mcp_server.tools import list_papers as list_papers_module
+from arxiv_mcp_server.tools import read_paper as read_module
+from arxiv_mcp_server.tools.arxiv_ids import (
+    filesystem_arxiv_stem,
+    logical_arxiv_id_from_stem,
+)
+from arxiv_mcp_server.tools.download import (
+    EXTRACTOR_VERSION,
+    get_paper_path,
+    handle_download,
+)
+from arxiv_mcp_server.tools.list_papers import handle_list_papers
+from arxiv_mcp_server.tools.read_paper import handle_read_paper
+
+LEGACY_IDS = ("hep-th/9901001", "quant-ph/0101001", "math-ph/0001001")
+
+
+@pytest.mark.parametrize(
+    "logical, expected_stem",
+    [
+        ("hep-th/9901001", "hep-th__9901001"),
+        ("quant-ph/0101001", "quant-ph__0101001"),
+        ("math-ph/0001001", "math-ph__0001001"),
+        ("1706.03762", "1706.03762"),
+        ("hep-th/9901001v1", "hep-th__9901001v1"),
+    ],
+)
+def test_filesystem_arxiv_stem_flattens_legacy_slash(logical, expected_stem):
+    assert filesystem_arxiv_stem(logical) == expected_stem
+    assert logical_arxiv_id_from_stem(expected_stem) == logical
+
+
+def test_get_paper_path_legacy_id_is_flat(temp_storage_path, monkeypatch):
+    """get_paper_path must not nest under an uncreated category directory."""
+    monkeypatch.setattr(
+        download_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    path = get_paper_path("hep-th/9901001", ".md")
+    assert path.parent == temp_storage_path.resolve()
+    assert path.name == "hep-th__9901001.md"
+    # Parent exists so a subsequent write cannot FileNotFoundError.
+    assert path.parent.is_dir()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("paper_id", LEGACY_IDS)
+async def test_download_legacy_slash_id_writes_markdown(
+    temp_storage_path, mocker, monkeypatch, paper_id
+):
+    """download_paper on legacy IDs succeeds and writes a flat storage file."""
+    monkeypatch.setattr(
+        download_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    monkeypatch.setattr(
+        list_papers_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value=f"# Legacy {paper_id}\nBody text for regression.",
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_arxiv_metadata",
+        return_value={
+            "title": f"Legacy paper {paper_id}",
+            "authors": ["Test Author"],
+            "published": "1999-01-01T00:00:00Z",
+            "arxiv_version": "v1",
+        },
+    )
+    mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    response = await handle_download({"paper_id": paper_id})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "success", result
+    assert result["paper_id"] == paper_id
+    assert result["source"] == "html"
+    assert "Body text for regression." in result["content"]
+
+    flat = temp_storage_path / f"{filesystem_arxiv_stem(paper_id)}.md"
+    assert flat.exists()
+    # No category subdirectory should have been created.
+    category = paper_id.split("/", 1)[0]
+    assert not (temp_storage_path / category).exists()
+
+    sidecar = temp_storage_path / f"{filesystem_arxiv_stem(paper_id)}.meta.json"
+    assert sidecar.exists()
+    meta = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert meta["id"] == paper_id
+    assert meta["extractor_version"] == EXTRACTOR_VERSION
+
+
+@pytest.mark.asyncio
+async def test_list_and_read_roundtrip_legacy_id(
+    temp_storage_path, mocker, monkeypatch
+):
+    """Listed and read paths resolve the sanitized flat stem back to the slash ID."""
+    paper_id = "hep-th/9901001"
+    for module in (download_module, list_papers_module, read_module):
+        monkeypatch.setattr(
+            module.settings,
+            "_get_storage_path_from_args",
+            lambda: temp_storage_path,
+        )
+    mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value="# Roundtrip\nLegacy body",
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_arxiv_metadata",
+        return_value={
+            "title": "Roundtrip Legacy",
+            "authors": ["A"],
+            "published": "1999-01-01T00:00:00Z",
+            "arxiv_version": "v1",
+        },
+    )
+    mocker.patch.object(download_module, "_fetch_pdf_content")
+
+    download = await handle_download({"paper_id": paper_id})
+    assert json.loads(download[0].text)["status"] == "success"
+
+    listed = json.loads((await handle_list_papers({"compact": True}))[0].text)
+    assert paper_id in listed["papers"]
+
+    read = json.loads((await handle_read_paper({"paper_id": paper_id}))[0].text)
+    assert read["status"] == "success"
+    assert read["paper_id"] == paper_id
+    assert "Legacy body" in read["content"]
+
+
+@pytest.mark.asyncio
+async def test_download_oserror_omits_absolute_paths(
+    temp_storage_path, mocker, monkeypatch
+):
+    """Filesystem failures must not leak absolute host paths to the client (#254)."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr(
+        download_module.settings,
+        "_get_storage_path_from_args",
+        lambda: temp_storage_path,
+    )
+    mocker.patch.object(
+        download_module,
+        "_fetch_html_content",
+        return_value="# Body\nContent",
+    )
+    abs_path = str((temp_storage_path / "hep-th" / "9901001.md").resolve())
+
+    mock_path = MagicMock()
+    mock_path.exists.return_value = False
+    mock_path.write_text.side_effect = FileNotFoundError(
+        2, "No such file or directory", abs_path
+    )
+    mocker.patch.object(download_module, "get_paper_path", return_value=mock_path)
+
+    response = await handle_download({"paper_id": "hep-th/9901001"})
+    result = json.loads(response[0].text)
+
+    assert result["status"] == "error"
+    message = result["message"]
+    assert abs_path not in message
+    assert str(temp_storage_path.resolve()) not in message
+    assert "Storage error" in message


### PR DESCRIPTION
## Summary
- `download_paper` on legacy slash-form IDs (`hep-th/9901001`, `quant-ph/0101001`, `math-ph/0001001`) no longer raises `FileNotFoundError` when writing markdown.
- On-disk stems sanitize `/` → `__` (same convention as the LaTeX cache) so files stay flat under `STORAGE_PATH`; parent dirs are still created defensively.
- `list_papers` / `read_paper` restore logical IDs from flat stems; `OSError` tool responses omit absolute host paths.

Closes #254.

## Test plan
- [x] `pytest tests/tools/test_legacy_id_storage.py tests/tools/test_arxiv_ids.py` (legacy download/list/read + path-leak regression)
- [x] Existing download / versioned-storage / read / list tests
- [x] Black 26.1.0 on touched files