### PR TITLE
fix: reduce Switch Transformers HTML→md author/cite noise (#260)

### DIFF
--- a/src/arxiv_mcp_server/tools/download.py
+++ b/src/arxiv_mcp_server/tools/download.py
@@ -132,7 +132,9 @@ settings = Settings()
 
 # Bump when HTML extraction changes so cached markdown is treated as stale
 # and re-downloaded without requiring the caller to pass force=true.
-EXTRACTOR_VERSION = 6
+# #265 already claimed 6 for decorative titles; this Switch noise cleanup
+# bumps to 7 so both changes invalidate caches (#175).
+EXTRACTOR_VERSION = 7
 
 
 # ---------------------------------------------------------------------------
@@ -152,8 +154,11 @@ class _ArticleTextExtractor(HTMLParser):
       - Coalesce decorative letter-span titles into one line (keep
         subtitle colons attached); coalesce author lines; drop
         affiliation superscripts and TeX superscript debris in the
-        author block.
+        author block; drop pre-title bylines that duplicate authors.
+      - Skip journal heading/shortheadings/editor note chrome.
       - Skip footnotemark markers (class, role, or the literal token).
+      - Join decorative breaks in bracket cites, figure/table refs, and
+        parenthetical citations where HTML split them across lines.
       - Skip license/permission one-liners and ICML/LaTeX page-layout
         style warnings (marginparsep and similar) that appear before the
         title.
@@ -200,6 +205,13 @@ class _ArticleTextExtractor(HTMLParser):
         "ltx_pubnote",
         "ltx_dates",
         "ltx_role_cc-license",
+        # Journal/PDF chrome notes (running headers, editor, page marks).
+        "ltx_role_heading",
+        "ltx_role_shortheadings",
+        "ltx_role_firstpage",
+        "ltx_role_editor",
+        "ltx_role_newpage",
+        "ltx_role_refnum",
     }
     FOOTNOTEMARK_TOKEN = "footnotemark"
     PERMISSION_MARKERS = (
@@ -245,6 +257,7 @@ class _ArticleTextExtractor(HTMLParser):
         r"^\{\}\^|textsuperscript",
         re.IGNORECASE,
     )
+    _AUTHOR_STOPWORDS = frozenset({"and", "or", "the", "of", "for"})
 
     def __init__(self):
         super().__init__()
@@ -288,6 +301,36 @@ class _ArticleTextExtractor(HTMLParser):
         # ``\times`` alone or embedded (e.g. ``2.0\times``, ``L\times E``).
         return alttext.replace(r"\times", "\u00d7")
 
+    @classmethod
+    def _author_name_tokens(cls, text: str) -> set[str]:
+        """Alphabetic tokens from an author/byline string (for dedupe)."""
+        return {
+            tok
+            for tok in re.findall(r"[A-Za-z]+", text.lower())
+            if len(tok) > 1 and tok not in cls._AUTHOR_STOPWORDS
+        }
+
+    def _drop_duplicate_author_bylines(self, author_line: str) -> None:
+        """Remove earlier chunks that only repeat the author names.
+
+        Some latexml/ar5iv pages emit a plain-paragraph byline before the
+        title in addition to ``ltx_authors`` (Switch Transformers).
+        """
+        name_tokens = self._author_name_tokens(author_line)
+        if not name_tokens:
+            return
+        chunks = self._article_chunks if self._article_depth > 0 else self._body_chunks
+        kept: list[str] = []
+        for chunk in chunks:
+            chunk_tokens = self._author_name_tokens(chunk)
+            if chunk_tokens and chunk_tokens <= name_tokens and len(chunk) < 300:
+                continue
+            kept.append(chunk)
+        if self._article_depth > 0:
+            self._article_chunks = kept
+        else:
+            self._body_chunks = kept
+
     def _flush_authors(self) -> None:
         """Join buffered author tokens into one coherent line."""
         if not self._author_buf:
@@ -298,6 +341,7 @@ class _ArticleTextExtractor(HTMLParser):
         line = re.sub(r"\s+", " ", line).strip(" ,")
         self._author_buf = []
         if line:
+            self._drop_duplicate_author_bylines(line)
             self._append_chunk(line)
 
     def _flush_title(self) -> None:
@@ -348,6 +392,10 @@ class _ArticleTextExtractor(HTMLParser):
         entering_authors = "ltx_authors" in classes
         if entering_authors:
             self._authors_depth += 1
+        # latexml inserts ``ltx_author_before`` between creators; keep commas.
+        if self._authors_depth > 0 and "ltx_author_before" in classes:
+            if self._author_buf and self._author_buf[-1] != ",":
+                self._author_buf.append(",")
 
         # Void elements have no children. Incrementing skip_depth for
         # <input> etc. and never seeing an end tag left the rest of the
@@ -428,6 +476,50 @@ def _extract_article_fragment(html: str) -> str | None:
     return html[start : end + len("</article>")]
 
 
+def _join_split_ref_noise(text: str) -> str:
+    """Rejoin decorative HTML line breaks in cites and figure/table refs.
+
+    latexml often emits ``[``, ``1``, ``]`` or ``Fig.`` / ``2`` as separate
+    text nodes; with newline-joined chunks that becomes ``[\n1\n]`` or
+    ``Fig.\n2``. Parenthetical author-year cites split the same way.
+    """
+    # Bracket cites: [\n1\n] → [1]
+    text = re.sub(r"\[\n(\d+)\n\]", r"[\1]", text)
+    # Fig./Figure/Table/Section/Eq. N[+optional letter] on the next line(s).
+    text = re.sub(
+        r"\b(Fig\.|Figure|Table|Section|Sec\.|Eq\.|Equation)\n(\d+[a-zA-Z]?)\n",
+        r"\1 \2 ",
+        text,
+    )
+    text = re.sub(
+        r"\b(Fig\.|Figure|Table|Section|Sec\.|Eq\.|Equation)\n(\d+[a-zA-Z]?)$",
+        r"\1 \2",
+        text,
+        flags=re.MULTILINE,
+    )
+
+    def _join_paren_block(match: re.Match[str]) -> str:
+        parts = [p.strip() for p in match.group(1).split("\n") if p.strip()]
+        if not parts or any(len(p) >= 80 for p in parts):
+            return match.group(0)
+        out: list[str] = []
+        for part in parts:
+            if part in {";", ","}:
+                if out:
+                    out[-1] = out[-1] + part
+                else:
+                    out.append(part)
+            elif out and out[-1].endswith((";", ",")):
+                out[-1] = f"{out[-1]} {part}"
+            else:
+                out.append(part)
+        return "(" + " ".join(out) + ")"
+
+    # (\nAuthor year\n) and multi-cite (\nA\n;\nB\n) lists.
+    text = re.sub(r"\(([^\n()]*(?:\n[^\n()]*)+)\)", _join_paren_block, text)
+    return text
+
+
 def _html_to_text(html: str) -> str:
     """Parse raw HTML and return cleaned paper text."""
     parser = _ArticleTextExtractor()
@@ -438,7 +530,7 @@ def _html_to_text(html: str) -> str:
     text = re.sub(r"\n×\n", "× ", text)
     text = re.sub(r"\n×$", "×", text)
     text = re.sub(r"^×\n", "× ", text)
-    return text
+    return _join_split_ref_noise(text)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_download_html_switch_noise.py
+++ b/tests/tools/test_download_html_switch_noise.py
@@ -1,0 +1,119 @@
+"""HTML extract: Switch Transformers author/cite/figure noise (#260)."""
+
+from arxiv_mcp_server.tools.download import EXTRACTOR_VERSION, _html_to_text
+
+# Shaped like Switch Transformers (2101.03961): pre-title byline duplicates
+# ``ltx_authors``, journal heading/shortheadings notes, and latexml splits
+# citations / figure refs across text nodes.
+SWITCH_NOISE_HTML = """
+<html>
+  <body>
+    <article class="ltx_document ltx_authors_1line">
+      <div id="p1" class="ltx_para">
+        <p id="p1.1" class="ltx_p">William Fedus, Barret Zoph and Noam Shazeer</p>
+      </div>
+      <h1 class="ltx_title ltx_title_document">
+        Switch Transformers: Scaling to Trillion Parameter Models
+      </h1>
+      <div class="ltx_authors">
+        <span class="ltx_creator ltx_role_author">
+          <span class="ltx_personname">William Fedus</span>
+        </span>
+        <span class="ltx_author_before">  </span>
+        <span class="ltx_creator ltx_role_author">
+          <span class="ltx_personname">Barret Zoph<sup class="ltx_sup">*</sup></span>
+        </span>
+        <span class="ltx_author_before">  </span>
+        <span class="ltx_creator ltx_role_author">
+          <span class="ltx_personname">Noam Shazeer</span>
+          <span class="ltx_author_notes">
+            <span class="ltx_contact ltx_role_affiliation">
+              <span class="ltx_contact_name">Affiliation: </span>Google
+            </span>
+          </span>
+        </span>
+      </div>
+      <span class="ltx_note ltx_role_heading">
+        <sup class="ltx_note_mark">†</sup>
+        <span class="ltx_note_type">heading: </span>23 2022 1- 8/21; Revised
+      </span>
+      <span class="ltx_note ltx_role_shortheadings">
+        <sup class="ltx_note_mark">†</sup>
+        <span class="ltx_note_type">shortheadings: </span>
+        Switch Transformers / Fedus, Zoph and Shazeer
+      </span>
+      <span class="ltx_note ltx_role_editor">
+        <sup class="ltx_note_mark">†</sup>
+        <span class="ltx_note_type">editor: </span>Alexander Clark
+      </span>
+      <div class="ltx_abstract">
+        <h6 class="ltx_title ltx_title_abstract">Abstract</h6>
+        <p>
+          We design models based off T5-Base and T5-Large
+          <cite class="ltx_cite ltx_citemacro_citep">
+            (<a href="#bib.bib36" class="ltx_ref">Raffel et al. 2019</a>)
+          </cite>
+          and cite prior work
+          <cite class="ltx_cite ltx_citemacro_citep">
+            (<a href="#bib.bib1" class="ltx_ref">Radford et al. 2018</a>;
+            <a href="#bib.bib2" class="ltx_ref">Kaplan et al. 2020</a>;
+            <a href="#bib.bib3" class="ltx_ref">Brown et al. 2020</a>)
+          </cite>.
+          Bracket form
+          <cite class="ltx_cite">[<a href="#bib.bib4" class="ltx_ref">1</a>]</cite>
+          and figure reference Figure
+          <a href="#S2.F3" class="ltx_ref"><span class="ltx_text ltx_ref_tag">3</span></a>
+          shows routing. Also Fig.
+          <a href="#S2.F2" class="ltx_ref"><span class="ltx_text ltx_ref_tag">2</span></a>
+          for comparison.
+        </p>
+      </div>
+    </article>
+  </body>
+</html>
+"""
+
+
+def test_extractor_version_bumped_for_switch_noise_cleanup():
+    """#175 auto-invalidates Switch caches after this extractor change."""
+    assert EXTRACTOR_VERSION >= 7
+
+
+def test_html_to_text_dedupes_switch_author_byline():
+    text = _html_to_text(SWITCH_NOISE_HTML)
+    assert text.count("William Fedus") == 1
+    assert text.count("Barret Zoph") == 1
+    assert text.count("Noam Shazeer") == 1
+    # Coherent single author line with commas between creators.
+    assert "William Fedus, Barret Zoph, Noam Shazeer" in text
+    assert "Affiliation:" not in text
+    assert "Google" not in text
+
+
+def test_html_to_text_drops_journal_heading_chrome():
+    text = _html_to_text(SWITCH_NOISE_HTML)
+    for leaked in [
+        "Switch Transformers / Fedus, Zoph and Shazeer",
+        "Alexander Clark",
+        "8/21; Revised",
+        "heading:",
+        "shortheadings:",
+        "editor:",
+    ]:
+        assert leaked not in text, leaked
+
+
+def test_html_to_text_joins_split_citations_and_figure_refs():
+    text = _html_to_text(SWITCH_NOISE_HTML)
+    assert "(Raffel et al. 2019)" in text
+    assert "(Radford et al. 2018; Kaplan et al. 2020; Brown et al. 2020)" in text
+    assert "[1]" in text
+    assert "\n1\n" not in text
+    assert "[\n" not in text
+    assert "Figure 3 shows" in text
+    assert "Fig. 2 for" in text
+    assert "\nFigure\n" not in text
+    assert "\nFig.\n" not in text
+    lines = text.splitlines()
+    assert "Figure" not in lines
+    assert "Fig." not in lines


### PR DESCRIPTION
## Summary
- Deduplicate pre-title author bylines that repeat `ltx_authors` (Switch Transformers `2101.03961`).
- Skip journal heading/shortheadings/editor/firstpage note chrome.
- Join decorative HTML line breaks in `[1]`, `Fig. 2` / `Figure 3`, and parenthetical author-year cites.
- Insert commas between latexml `ltx_author_before` creators.
- Bump `EXTRACTOR_VERSION` to **7** (`#265` already claimed 6 for decorative titles) so cached markdown refreshes (#175).
- Update obsolete `test_download_sidecar` title-split characterization left failing on main after #265.

## Test plan
- [x] `pytest tests/tools/test_download_html_switch_noise.py`
- [x] `pytest tests/tools/test_download*.py` (58 passed)
- [x] Live ar5iv HTML for `2101.03961`: single author line, `(Raffel …)`, `Figure 3 shows`, no shortheadings chrome
- [x] Formatted with Black 26.1.0

Closes #260