### PR TITLE
test: align 2608 title fixture with joined HTML titles (#258)

### DIFF
--- a/tests/tools/test_download_sidecar.py
+++ b/tests/tools/test_download_sidecar.py
@@ -33,6 +33,8 @@ API_TITLE = (
     "for Locality Against the Edge Memory-Bandwidth Wall "
     "A Pre-Registered Negative Result, with a Systems Measurement Study"
 )
+# Historical truncated first line from pre-#258 <br>-split HTML scrape;
+# still useful as a stale sidecar fixture for force-refresh coverage.
 HTML_FIRST_LINE = "Cacheable by Design? Training Mixture-of-Experts Routers"
 
 
@@ -43,11 +45,11 @@ def _patch_path(mocker, storage):
     )
 
 
-def test_2608_shaped_html_title_is_split_across_lines():
-    """Document the HTML scrape failure mode that #176 must not use."""
+def test_2608_shaped_html_title_is_joined_across_breaks():
+    """#258 joins <br>-broken document titles into one line (same as API)."""
     text = _html_to_text(SPLIT_TITLE_HTML)
-    assert text.splitlines()[0] == HTML_FIRST_LINE
-    assert API_TITLE not in text.splitlines()[0]
+    assert text.splitlines()[0] == API_TITLE
+    assert HTML_FIRST_LINE != text.splitlines()[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- After #265 (`EXTRACTOR_VERSION=6`), decorative/`<br>`-broken HTML document titles are joined into one line (#258).
- Update `test_2608_shaped_html_title_*` to expect the joined full title instead of the old split first-line scrape.
- Sidecar API-metadata preference tests unchanged in intent; keep using the historical truncated first line only as a stale force-refresh fixture.

## Test plan
- [x] `black==26.1.0` on the changed file
- [x] `pytest tests/tools/test_download_sidecar.py tests/tools/test_download_html_title.py tests/tools/test_download_html.py --no-cov` (21 passed)
- [ ] CI green on this PR

Does **not** revert the #258/#265 product fix.