### PR TITLE
test: expect joined HTML titles after #258

### DIFF
--- a/tests/tools/test_download_sidecar.py
+++ b/tests/tools/test_download_sidecar.py
@@ -43,11 +43,15 @@ def _patch_path(mocker, storage):
     )
 
 
-def test_2608_shaped_html_title_is_split_across_lines():
-    """Document the HTML scrape failure mode that #176 must not use."""
+def test_2608_shaped_html_title_is_joined_across_breaks():
+    """EXTRACTOR_VERSION>=6 joins br-split document titles into one line (#258).
+
+    Sidecar metadata still must come from the API (#176); see tests below.
+    """
     text = _html_to_text(SPLIT_TITLE_HTML)
-    assert text.splitlines()[0] == HTML_FIRST_LINE
-    assert API_TITLE not in text.splitlines()[0]
+    assert text.splitlines()[0] == API_TITLE
+    # Pre-#258 failure mode was first-line-only truncation.
+    assert text.splitlines()[0] != HTML_FIRST_LINE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- After #258 (`EXTRACTOR_VERSION=6`), `_html_to_text` joins decorative / `<br>`-split document titles into one line.
- Update `test_2608_shaped_html_title_*` to expect the full joined title instead of the old first-line truncation.
- Leave sidecar-prefers-API coverage intact; do not revert product code from #258.

## Test plan
- [x] `pytest tests/tools/test_download_sidecar.py tests/tools/test_download_html_title.py`
- [x] Black 26.1.0 on the touched test file

Fixes red main CI after #265.