### PR TITLE
feat: citation_graph fewer S2 calls, disk cache, unmistakable 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The server currently exposes 19 tools.
 | `get_paper_latex` | Retrieve bounded author-submitted LaTeX | Remote arXiv source archive |
 | `list_paper_latex_sections` | Return a paginated LaTeX outline | Supports `start` and `max_sections` |
 | `get_paper_latex_section` | Read one bounded LaTeX section | Select by outline ID or exact title |
-| `citation_graph` | Fetch references and citing papers | Remote Semantic Scholar API; optional `SEMANTIC_SCHOLAR_API_KEY` |
+| `citation_graph` | Fetch references and citing papers | Remote Semantic Scholar API (1 call per paper, cached on disk); optional free API key improves reliability |
 | `export_citations` | Export BibTeX for one or more arXiv IDs | Authoritative arXiv metadata |
 | `watch_topic` | Save or update an arXiv topic watch | Stored locally; omit `categories` to preserve on update, `categories: []` to clear |
 | `list_watches` | List saved topic watches | Read-only; does not advance last_checked |
@@ -464,7 +464,7 @@ The server binds to `127.0.0.1` by default and enables MCP DNS-rebinding protect
 | `PORT` | `8000` | HTTP bind port |
 | `ALLOWED_HOSTS` | empty | Additional accepted HTTP Host values |
 | `ALLOWED_ORIGINS` | empty | Additional accepted HTTP Origin values |
-| `SEMANTIC_SCHOLAR_API_KEY` | empty | Optional Semantic Scholar API key for `citation_graph` |
+| `SEMANTIC_SCHOLAR_API_KEY` | empty | Free Semantic Scholar API key for `citation_graph`. Get one at https://www.semanticscholar.org/product/api#api-key to avoid rate limits. Unauthenticated requests work until quota exhausted. |
 
 Environment variable names are case-insensitive through Pydantic settings. `--storage-path` is a command-line option rather than an environment setting.
 

--- a/src/arxiv_mcp_server/tools/citation_graph.py
+++ b/src/arxiv_mcp_server/tools/citation_graph.py
@@ -6,6 +6,8 @@ import asyncio
 import json
 import logging
 import random
+import time
+from pathlib import Path
 from typing import Any, Dict, List
 from urllib.parse import quote
 
@@ -27,22 +29,32 @@ settings = Settings()
 SEMANTIC_SCHOLAR_API_URL = "https://api.semanticscholar.org/graph/v1"
 DEFAULT_MAX_CITATIONS = 50
 MAX_CITATIONS_CAP = 200
-PAPER_FIELDS = "title,year,authors,externalIds,citationCount,referenceCount"
-# Include externalIds so neighbors can expose arxiv_id for download/get_abstract
-# hops. Keep default max_citations=50 and 429 retries to stay under quota.
-NEIGHBOR_FIELDS = "paperId,title,year,authors,externalIds"
+# Request paper metadata plus up to limit citations/references in one call.
+# Subfield syntax (citations.year, references.externalIds) lets neighbors expose
+# arxiv_id for tool hops while keeping responses small.
+PAPER_FIELDS = (
+    "title,year,authors,externalIds,citationCount,referenceCount,citations,references"
+)
+CITATION_SUBFIELDS = "citations.paperId,citations.title,citations.year,citations.authors,citations.externalIds"
+REFERENCE_SUBFIELDS = "references.paperId,references.title,references.year,references.authors,references.externalIds"
 RATE_LIMIT_MESSAGE = (
-    "Semantic Scholar rate-limited this request. "
-    "Set the SEMANTIC_SCHOLAR_API_KEY environment variable for a higher quota, "
-    "or retry later with a smaller max_citations."
+    "⚠️ RATE LIMITED: Semantic Scholar quota exhausted. "
+    "This is NOT an empty graph—the API blocked the request. "
+    "Get a free API key at https://www.semanticscholar.org/product/api#api-key "
+    "and set SEMANTIC_SCHOLAR_API_KEY, or retry later with a smaller max_citations."
 )
 RATE_LIMIT_MESSAGE_WITH_KEY = (
-    "Semantic Scholar rate-limited this request despite SEMANTIC_SCHOLAR_API_KEY. "
+    "⚠️ RATE LIMITED: Semantic Scholar quota exhausted despite SEMANTIC_SCHOLAR_API_KEY. "
+    "This is NOT an empty graph—the API blocked the request. "
     "Wait and retry, or reduce max_citations."
 )
 _MAX_RETRIES = 5
 _INITIAL_BACKOFF_SECONDS = 2.0
 _MAX_BACKOFF_SECONDS = 60.0
+# Cache citation graphs on disk to reduce repeated S2 calls. Rate-limited results
+# expire quickly; successful graphs persist longer.
+CACHE_TTL_SUCCESS_SECONDS = 7 * 24 * 3600  # 7 days
+CACHE_TTL_RATE_LIMITED_SECONDS = 5 * 60  # 5 minutes
 
 citation_graph_tool = types.Tool(
     name="citation_graph",
@@ -50,9 +62,11 @@ citation_graph_tool = types.Tool(
     description=(
         "Return papers citing an arXiv paper and papers that it references "
         "using Semantic Scholar's citation graph. Results are bounded "
-        "(default 50) to stay within the unauthenticated quota. Under load, "
-        "export SEMANTIC_SCHOLAR_API_KEY for a higher limit; without a key, "
-        "persistent rate limits return status=rate_limited instead of failing hard."
+        "(default 50) to stay within the unauthenticated quota. Graphs are "
+        "cached on disk to reduce repeated API calls. Under load, "
+        "a free Semantic Scholar API key (https://www.semanticscholar.org/product/api#api-key) "
+        "makes this reliable; without a key, persistent rate limits return "
+        "status=rate_limited with an unmistakable warning instead of failing hard."
     ),
     inputSchema={
         "type": "object",
@@ -139,7 +153,9 @@ def _rate_limited_payload(
     """Soft rate-limit result so callers can continue without a hard tool error."""
     payload: Dict[str, Any] = {
         "status": "rate_limited",
+        "error": "RATE_LIMITED",
         "message": _rate_limit_message(),
+        "warning": "This is NOT an empty citation graph. The API request was blocked by rate limiting.",
         "citation_count": 0,
         "reference_count": 0,
         "citations": [],
@@ -150,8 +166,130 @@ def _rate_limited_payload(
     if max_citations is not None:
         payload["max_citations"] = max_citations
     if not _has_api_key():
-        payload["hint"] = "export SEMANTIC_SCHOLAR_API_KEY=<your-key>"
+        payload["hint"] = (
+            "Get a free API key at https://www.semanticscholar.org/product/api#api-key and set SEMANTIC_SCHOLAR_API_KEY"
+        )
     return payload
+
+
+def _cache_dir() -> Path:
+    """Return the citation graph cache directory under the configured storage path."""
+    cache_path = settings.STORAGE_PATH / "citation_graphs"
+    cache_path.mkdir(parents=True, exist_ok=True)
+    return cache_path
+
+
+def _cache_key(arxiv_id: str, max_citations: int) -> str:
+    """Build a cache filename for this arXiv ID and max_citations."""
+    # Normalize to bare ID for consistent cache keys
+    bare_id = bare_arxiv_id(arxiv_id)
+    return f"{bare_id}__limit_{max_citations}.json"
+
+
+def _load_cached_graph(arxiv_id: str, max_citations: int) -> Dict[str, Any] | None:
+    """Load a cached citation graph if valid and not expired.
+
+    This function looks for a cache file that matches the arxiv_id and has
+    max_citations >= requested max_citations. If multiple cache files exist,
+    it prefers the one closest to the requested limit.
+    """
+    cache_dir_path = _cache_dir()
+    bare_id = bare_arxiv_id(arxiv_id)
+
+    # Find all cache files for this arxiv_id
+    pattern = f"{bare_id}__limit_*.json"
+    import glob
+
+    cache_files = glob.glob(str(cache_dir_path / pattern))
+
+    if not cache_files:
+        return None
+
+    # Find a suitable cache file (with limit >= requested)
+    best_cache = None
+    best_limit = float("inf")
+
+    for cache_file in cache_files:
+        try:
+            # Extract limit from filename
+            filename = Path(cache_file).stem
+            limit_str = filename.split("__limit_")[1]
+            cached_limit = int(limit_str)
+
+            # Check if this cache can satisfy the request
+            if cached_limit >= max_citations and cached_limit < best_limit:
+                best_cache = cache_file
+                best_limit = cached_limit
+        except (IndexError, ValueError):
+            continue
+
+    if best_cache is None:
+        logger.debug(
+            "No suitable cache found for %s with limit %d", bare_id, max_citations
+        )
+        return None
+
+    try:
+        with open(best_cache, "r", encoding="utf-8") as f:
+            cached = json.load(f)
+
+        cached_at = cached.get("cached_at", 0)
+        status = cached.get("status", "success")
+        now = time.time()
+
+        # Rate-limited results expire quickly; successful graphs persist longer
+        if status == "rate_limited":
+            ttl = CACHE_TTL_RATE_LIMITED_SECONDS
+        else:
+            ttl = CACHE_TTL_SUCCESS_SECONDS
+
+        if now - cached_at > ttl:
+            logger.debug(
+                "Cache expired for %s (age %.1fs)",
+                Path(best_cache).name,
+                now - cached_at,
+            )
+            return None
+
+        logger.info(
+            "Cache hit for %s (age %.1fs)", Path(best_cache).name, now - cached_at
+        )
+
+        # If we cached more than requested, slice the results.
+        # Work on a copy to avoid issues with json.load() returning shared lists.
+        cached_limit = cached.get("max_citations", DEFAULT_MAX_CITATIONS)
+        if cached_limit > max_citations and status == "success":
+            import copy
+
+            result = copy.deepcopy(cached)
+            result["citations"] = result.get("citations", [])[:max_citations]
+            result["references"] = result.get("references", [])[:max_citations]
+            result["citation_count"] = len(result["citations"])
+            result["reference_count"] = len(result["references"])
+            result["max_citations"] = max_citations
+            return result
+
+        return cached
+
+    except Exception as exc:
+        logger.warning("Failed to load cache %s: %s", Path(best_cache).name, exc)
+        return None
+
+
+def _save_cached_graph(
+    arxiv_id: str, max_citations: int, result: Dict[str, Any]
+) -> None:
+    """Save a citation graph result to disk cache."""
+    cache_file = _cache_dir() / _cache_key(arxiv_id, max_citations)
+    try:
+        # Create a copy to avoid mutating the original result
+        cached_result = result.copy()
+        cached_result["cached_at"] = time.time()
+        with open(cache_file, "w", encoding="utf-8") as f:
+            json.dump(cached_result, f, indent=2)
+        logger.debug("Cached citation graph to %s", cache_file.name)
+    except Exception as exc:
+        logger.warning("Failed to cache citation graph to %s: %s", cache_file.name, exc)
 
 
 def _backoff_seconds(attempt: int, retry_after: str | None) -> float:
@@ -184,14 +322,28 @@ async def _s2_get(
     raise SemanticScholarRateLimitError(_rate_limit_message())
 
 
-def _neighbor_papers(payload: Dict[str, Any], wrapper_key: str) -> List[Dict[str, Any]]:
-    """Unwrap citation/reference endpoint rows into paper objects."""
-    papers: List[Dict[str, Any]] = []
-    for row in payload.get("data") or []:
-        paper = row.get(wrapper_key) if isinstance(row, dict) else None
-        if isinstance(paper, dict):
-            papers.append(paper)
-    return papers
+def _extract_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract citations list from paper endpoint response."""
+    citations = payload.get("citations", {})
+    if isinstance(citations, dict):
+        # Citations returned as {data: [...]}
+        return citations.get("data", [])
+    elif isinstance(citations, list):
+        # Citations returned as direct list
+        return citations
+    return []
+
+
+def _extract_references(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract references list from paper endpoint response."""
+    references = payload.get("references", {})
+    if isinstance(references, dict):
+        # References returned as {data: [...]}
+        return references.get("data", [])
+    elif isinstance(references, list):
+        # References returned as direct list
+        return references
+    return []
 
 
 def _bound_max_citations(value: Any) -> int:
@@ -223,7 +375,20 @@ def _rate_limited_response(
 
 
 async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextContent]:
-    """Handle citation graph lookup for a single arXiv paper ID."""
+    """Handle citation graph lookup for a single arXiv paper ID.
+
+    This function:
+    1. Checks the disk cache first to avoid redundant S2 API calls
+    2. Makes ONE S2 API call to fetch paper + citations + references together
+    3. Caches the result for future lookups
+    4. Returns unmistakable rate-limit responses on 429
+
+    Args:
+        arguments: Tool arguments with paper_id (required) and max_citations (optional).
+
+    Returns:
+        List of TextContent with the citation graph or error.
+    """
     bare_id: str | None = None
     limit: int | None = None
     try:
@@ -239,24 +404,45 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
         bare_id = bare_arxiv_id(paper_id)
         requested_version = arxiv_version_suffix(paper_id)
         limit = _bound_max_citations(arguments.get("max_citations"))
+
+        # Check cache first
+        cached = _load_cached_graph(bare_id, limit)
+        if cached is not None:
+            # Restore requested version metadata if present
+            if requested_version is not None and "paper" in cached:
+                cached["paper"]["requested_arxiv_id"] = paper_id
+                cached["paper"]["requested_version"] = requested_version
+            return [types.TextContent(type="text", text=json.dumps(cached, indent=2))]
+
+        # Cache miss: fetch from S2 with a single API call
         s2_paper_identifier = quote(f"ARXIV:{bare_id}", safe=":")
         paper_url = f"{SEMANTIC_SCHOLAR_API_URL}/paper/{s2_paper_identifier}"
-        citations_url = f"{paper_url}/citations"
-        references_url = f"{paper_url}/references"
-        neighbor_params = {"fields": NEIGHBOR_FIELDS, "limit": limit}
+
+        # Request paper metadata plus citations and references with subfields.
+        # This reduces from 3 sequential calls to 1.
+        fields = f"{PAPER_FIELDS},{CITATION_SUBFIELDS},{REFERENCE_SUBFIELDS}"
+        params = {
+            "fields": fields,
+            # Note: The paper endpoint does not support limit/offset for nested
+            # citations/references fields. S2 returns a bounded subset (typically
+            # up to 1000 per field). For our default 50 / cap 200 use case, this
+            # is sufficient. If we need precise control, we'd fall back to separate
+            # /citations and /references calls, but that defeats the quota goal.
+        }
 
         async with httpx.AsyncClient(timeout=30.0) as client:
-            paper_response = await _s2_get(client, paper_url, {"fields": PAPER_FIELDS})
-            citations_response = await _s2_get(client, citations_url, neighbor_params)
-            references_response = await _s2_get(client, references_url, neighbor_params)
+            paper_response = await _s2_get(client, paper_url, params)
 
         payload = paper_response.json()
-        citations = _normalize_paper_items(
-            _neighbor_papers(citations_response.json(), "citingPaper")
-        )
-        references = _normalize_paper_items(
-            _neighbor_papers(references_response.json(), "citedPaper")
-        )
+
+        # Extract citations and references from the unified response
+        citations_raw = _extract_citations(payload)
+        references_raw = _extract_references(payload)
+
+        # Semantic Scholar may return more than we requested since we can't pass
+        # limit to the paper endpoint's nested fields. Slice to the requested limit.
+        citations = _normalize_paper_items(citations_raw[:limit])
+        references = _normalize_paper_items(references_raw[:limit])
 
         paper_meta = {
             "paper_id": payload.get("paperId"),
@@ -284,14 +470,24 @@ async def handle_citation_graph(arguments: Dict[str, Any]) -> List[types.TextCon
             "references": references,
         }
 
+        # Cache the successful result
+        _save_cached_graph(bare_id, limit, result)
+
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     except SemanticScholarRateLimitError as exc:
         logger.error("Semantic Scholar rate limited: %s", exc)
+        rate_limited = _rate_limited_payload(arxiv_id=bare_id, max_citations=limit)
+        # Cache rate-limited results with a short TTL so we don't hammer S2
+        if bare_id is not None and limit is not None:
+            _save_cached_graph(bare_id, limit, rate_limited)
         return _rate_limited_response(arxiv_id=bare_id, max_citations=limit)
     except httpx.HTTPStatusError as exc:
         if exc.response is not None and exc.response.status_code == 429:
             logger.error("Semantic Scholar rate limited: %s", exc)
+            rate_limited = _rate_limited_payload(arxiv_id=bare_id, max_citations=limit)
+            if bare_id is not None and limit is not None:
+                _save_cached_graph(bare_id, limit, rate_limited)
             return _rate_limited_response(arxiv_id=bare_id, max_citations=limit)
         status = exc.response.status_code if exc.response is not None else None
         # Never leak upstream status lines / URLs (issue #166 class).

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -524,6 +524,64 @@ async def test_citation_graph_cache_rate_limited_expires_quickly():
 
 
 @pytest.mark.asyncio
+async def test_citation_graph_rate_limited_cached_not_as_empty_success():
+    """Rate-limited results ARE cached but served with unmistakable rate-limit markers, NOT as empty success."""
+    attempts = citation_graph_module._MAX_RETRIES + 1
+    rate_limited = _json_response({}, status_code=429)
+    # Only provide responses for first call; second call should serve from cache
+    mock_client = _mock_async_client([rate_limited] * attempts)
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module.asyncio, "sleep", new_callable=AsyncMock),
+        patch.object(citation_graph_module.random, "random", return_value=0.5),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        cache_dir = Path("/tmp/test_citation_cache_rate_limited_not_empty")
+        import shutil
+
+        shutil.rmtree(cache_dir, ignore_errors=True)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        mock_cache_dir.return_value = cache_dir
+
+        # First call: rate limited (makes 6 attempts: initial + 5 retries)
+        response1 = await handle_citation_graph({"paper_id": "2401.12345"})
+        payload1 = json.loads(response1[0].text)
+        assert payload1["status"] == "rate_limited"
+        assert payload1["error"] == "RATE_LIMITED"
+        assert (
+            payload1["warning"]
+            == "This is NOT an empty citation graph. The API request was blocked by rate limiting."
+        )
+        assert payload1["citations"] == []
+        assert payload1["references"] == []
+        assert "SEMANTIC_SCHOLAR_API_KEY" in payload1["message"]
+        assert "free API key" in payload1["hint"]
+        assert mock_client.get.call_count == attempts
+
+        # Second call immediately: should return CACHED rate-limited result WITHOUT new API calls
+        # This prevents API hammering while still making rate-limit unmistakable
+        response2 = await handle_citation_graph({"paper_id": "2401.12345"})
+        payload2 = json.loads(response2[0].text)
+
+        # Verify cached result is still rate-limited (not empty success)
+        assert payload2["status"] == "rate_limited"
+        assert payload2["error"] == "RATE_LIMITED"
+        assert (
+            payload2["warning"]
+            == "This is NOT an empty citation graph. The API request was blocked by rate limiting."
+        )
+        assert payload2["citations"] == []
+        assert payload2["references"] == []
+
+        # Most important: NO new API calls were made (cached result served)
+        assert mock_client.get.call_count == attempts  # Still same count, no new calls
+
+        # Clean up
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
 async def test_citation_graph_cache_can_serve_smaller_limit():
     """Cached result with larger limit can satisfy smaller limit request."""
     import shutil

--- a/tests/tools/test_citation_graph.py
+++ b/tests/tools/test_citation_graph.py
@@ -1,6 +1,8 @@
 """Tests for citation graph tool."""
 
 import json
+import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -8,6 +10,35 @@ import pytest
 
 from arxiv_mcp_server.tools import citation_graph as citation_graph_module
 from arxiv_mcp_server.tools.citation_graph import handle_citation_graph
+
+# Updated payload to include citations and references in the paper response
+PAPER_PAYLOAD_WITH_CITATIONS_AND_REFERENCES = {
+    "paperId": "root-paper",
+    "title": "Root Paper",
+    "year": 2024,
+    "authors": [{"name": "Author A"}],
+    "externalIds": {"ArXiv": "2401.12345"},
+    "citationCount": 12,
+    "referenceCount": 3,
+    "citations": [
+        {
+            "paperId": "citing-1",
+            "title": "Citing Paper",
+            "year": 2025,
+            "authors": [{"name": "Author B"}],
+            "externalIds": {"ArXiv": "2501.00001"},
+        }
+    ],
+    "references": [
+        {
+            "paperId": "ref-1",
+            "title": "Referenced Paper",
+            "year": 2020,
+            "authors": [{"name": "Author C"}],
+            "externalIds": {"ArXiv": "2001.00001"},
+        }
+    ],
+}
 
 PAPER_PAYLOAD = {
     "paperId": "root-paper",
@@ -70,20 +101,21 @@ def _mock_async_client(responses):
     return mock_client
 
 
-def _success_responses():
-    return [
-        _json_response(PAPER_PAYLOAD),
-        _json_response(CITATIONS_PAYLOAD),
-        _json_response(REFERENCES_PAYLOAD),
-    ]
+def _success_response():
+    """Return a single response with paper + citations + references."""
+    return _json_response(PAPER_PAYLOAD_WITH_CITATIONS_AND_REFERENCES)
 
 
 @pytest.mark.asyncio
 async def test_citation_graph_success():
-    """Citation graph should return citations and references with normalized fields."""
-    mock_client = _mock_async_client(_success_responses())
+    """Citation graph should return citations and references with normalized fields from ONE API call."""
+    mock_client = _mock_async_client([_success_response()])
 
-    with patch("httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph({"paper_id": "2401.12345"})
 
     payload = json.loads(response[0].text)
@@ -93,11 +125,12 @@ async def test_citation_graph_success():
     assert payload["citation_total"] == 12
     assert payload["max_citations"] == 50
     assert payload["citations"][0]["arxiv_id"] == "2501.00001"
-    assert mock_client.get.call_count == 3
-    citation_call = mock_client.get.call_args_list[1]
-    assert citation_call.args[0].endswith("/citations")
-    assert citation_call.kwargs["params"]["limit"] == 50
-    assert "externalIds" in citation_call.kwargs["params"]["fields"]
+    # Should only make 1 API call now (not 3)
+    assert mock_client.get.call_count == 1
+    # Verify the single call includes citations and references fields
+    call_args = mock_client.get.call_args
+    assert "citations" in call_args.kwargs["params"]["fields"]
+    assert "references" in call_args.kwargs["params"]["fields"]
     assert payload["citations"][0]["external_ids"]["ArXiv"] == "2501.00001"
     assert payload["references"][0]["arxiv_id"] == "2001.00001"
     assert payload["references"][0]["external_ids"]["ArXiv"] == "2001.00001"
@@ -128,8 +161,8 @@ async def test_citation_graph_http_error():
 
 @pytest.mark.asyncio
 async def test_citation_graph_retries_on_429_then_succeeds():
-    """A transient Semantic Scholar 429 should be retried and then succeed."""
-    responses = [_json_response({}, status_code=429), *_success_responses()]
+    """A transient Semantic Scholar 429 should be retried and then succeed with ONE final API call."""
+    responses = [_json_response({}, status_code=429), _success_response()]
     mock_client = _mock_async_client(responses)
 
     with (
@@ -138,19 +171,22 @@ async def test_citation_graph_retries_on_429_then_succeeds():
             citation_graph_module.asyncio, "sleep", new_callable=AsyncMock
         ) as sleep,
         patch.object(citation_graph_module.random, "random", return_value=0.5),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
     ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph({"paper_id": "1706.03762"})
 
     payload = json.loads(response[0].text)
     assert payload["status"] == "success"
     assert payload["paper"]["arxiv_id"] == "1706.03762"
-    assert mock_client.get.call_count == 4
+    # First call gets 429, second call succeeds
+    assert mock_client.get.call_count == 2
     sleep.assert_awaited_once_with(2.0)
 
 
 @pytest.mark.asyncio
 async def test_citation_graph_429_exhausted_returns_soft_rate_limited():
-    """Persistent 429s should soft-fail with actionable API-key guidance."""
+    """Persistent 429s should soft-fail with unmistakable API-key guidance."""
     attempts = citation_graph_module._MAX_RETRIES + 1
     rate_limited = _json_response({}, status_code=429)
     mock_client = _mock_async_client([rate_limited] * attempts)
@@ -159,13 +195,16 @@ async def test_citation_graph_429_exhausted_returns_soft_rate_limited():
         patch("httpx.AsyncClient", return_value=mock_client),
         patch.object(citation_graph_module.asyncio, "sleep", new_callable=AsyncMock),
         patch.object(citation_graph_module.random, "random", return_value=0.5),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
     ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph(
             {"paper_id": "2608.18261", "max_citations": 10}
         )
 
     payload = json.loads(response[0].text)
     assert payload["status"] == "rate_limited"
+    assert payload["error"] == "RATE_LIMITED"
     assert payload["arxiv_id"] == "2608.18261"
     assert payload["max_citations"] == 10
     assert payload["citations"] == []
@@ -173,7 +212,8 @@ async def test_citation_graph_429_exhausted_returns_soft_rate_limited():
     assert payload["citation_count"] == 0
     assert payload["reference_count"] == 0
     assert "SEMANTIC_SCHOLAR_API_KEY" in payload["message"]
-    assert payload["hint"] == "export SEMANTIC_SCHOLAR_API_KEY=<your-key>"
+    assert "NOT an empty" in payload["warning"]
+    assert "free API key" in payload["hint"]
     assert not response[0].text.startswith("Error:")
     assert mock_client.get.call_count == attempts
 
@@ -191,12 +231,16 @@ async def test_citation_graph_429_exhausted_with_api_key_guidance():
         patch.object(
             citation_graph_module.settings, "SEMANTIC_SCHOLAR_API_KEY", "s2-key"
         ),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
     ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph({"paper_id": "2410.17954"})
 
     payload = json.loads(response[0].text)
     assert payload["status"] == "rate_limited"
+    assert payload["error"] == "RATE_LIMITED"
     assert "despite SEMANTIC_SCHOLAR_API_KEY" in payload["message"]
+    assert "NOT an empty" in payload["warning"]
     assert "hint" not in payload
 
 
@@ -224,14 +268,16 @@ def test_backoff_seconds_longer_with_jitter():
 @pytest.mark.asyncio
 async def test_citation_graph_sends_api_key_and_honors_max_citations():
     """Optional API key and max_citations should be forwarded to Semantic Scholar."""
-    mock_client = _mock_async_client(_success_responses())
+    mock_client = _mock_async_client([_success_response()])
 
     with (
         patch("httpx.AsyncClient", return_value=mock_client),
         patch.object(
             citation_graph_module.settings, "SEMANTIC_SCHOLAR_API_KEY", "s2-key"
         ),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
     ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph(
             {"paper_id": "2401.12345", "max_citations": 10}
         )
@@ -241,56 +287,55 @@ async def test_citation_graph_sends_api_key_and_honors_max_citations():
     assert payload["max_citations"] == 10
     for call in mock_client.get.call_args_list:
         assert call.kwargs["headers"]["x-api-key"] == "s2-key"
-    assert mock_client.get.call_args_list[1].kwargs["params"]["limit"] == 10
 
 
 @pytest.mark.asyncio
 async def test_citation_graph_neighbors_include_arxiv_id_from_external_ids():
     """Neighbors with ArXiv in externalIds must surface arxiv_id for tool hops."""
-    citations = {
-        "data": [
+    payload_with_neighbors = {
+        "paperId": "root-paper",
+        "title": "Root Paper",
+        "year": 2024,
+        "authors": [{"name": "Author A"}],
+        "externalIds": {"ArXiv": "2505.16056"},
+        "citationCount": 2,
+        "referenceCount": 2,
+        "citations": [
             {
-                "citingPaper": {
-                    "paperId": "sticky-routing",
-                    "title": "Sticky Routing",
-                    "year": 2026,
-                    "authors": [{"name": "Author S"}],
-                    "externalIds": {"ArXiv": "2607.08780"},
-                }
+                "paperId": "sticky-routing",
+                "title": "Sticky Routing",
+                "year": 2026,
+                "authors": [{"name": "Author S"}],
+                "externalIds": {"ArXiv": "2607.08780"},
             }
-        ]
-    }
-    references = {
-        "data": [
+        ],
+        "references": [
             {
-                "citedPaper": {
-                    "paperId": "promoe",
-                    "title": "ProMoE",
-                    "year": 2024,
-                    "authors": [{"name": "Author P"}],
-                    "externalIds": {"ArXiv": "2410.22134"},
-                }
+                "paperId": "promoe",
+                "title": "ProMoE",
+                "year": 2024,
+                "authors": [{"name": "Author P"}],
+                "externalIds": {"ArXiv": "2410.22134"},
             }
-        ]
+        ],
     }
-    mock_client = _mock_async_client(
-        [
-            _json_response(PAPER_PAYLOAD),
-            _json_response(citations),
-            _json_response(references),
-        ]
-    )
+    mock_client = _mock_async_client([_json_response(payload_with_neighbors)])
 
-    with patch("httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph({"paper_id": "2505.16056"})
 
     payload = json.loads(response[0].text)
     assert payload["status"] == "success"
     assert payload["citations"][0]["arxiv_id"] == "2607.08780"
     assert payload["references"][0]["arxiv_id"] == "2410.22134"
-    neighbor_fields = mock_client.get.call_args_list[1].kwargs["params"]["fields"]
-    assert neighbor_fields == citation_graph_module.NEIGHBOR_FIELDS
-    assert "externalIds" in neighbor_fields
+    call_fields = mock_client.get.call_args.kwargs["params"]["fields"]
+    assert "citations" in call_fields
+    assert "references" in call_fields
+    assert "externalIds" in call_fields
 
 
 @pytest.mark.asyncio
@@ -301,18 +346,16 @@ async def test_citation_graph_neighbors_include_arxiv_id_from_external_ids():
 async def test_citation_graph_strips_version_for_s2_lookup(paper_id, expected_version):
     """Versioned arXiv IDs must query Semantic Scholar with the bare ARXIV id."""
     paper_payload = {
-        **PAPER_PAYLOAD,
+        **PAPER_PAYLOAD_WITH_CITATIONS_AND_REFERENCES,
         "externalIds": {"ArXiv": "1706.03762"},
     }
-    mock_client = _mock_async_client(
-        [
-            _json_response(paper_payload),
-            _json_response(CITATIONS_PAYLOAD),
-            _json_response(REFERENCES_PAYLOAD),
-        ]
-    )
+    mock_client = _mock_async_client([_json_response(paper_payload)])
 
-    with patch("httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph({"paper_id": paper_id})
 
     payload = json.loads(response[0].text)
@@ -321,27 +364,21 @@ async def test_citation_graph_strips_version_for_s2_lookup(paper_id, expected_ve
     assert payload["paper"]["requested_arxiv_id"] == paper_id
     assert payload["paper"]["requested_version"] == expected_version
 
-    paper_url = mock_client.get.call_args_list[0].args[0]
+    paper_url = mock_client.get.call_args.args[0]
     assert paper_url.endswith("/paper/ARXIV:1706.03762")
     assert expected_version not in paper_url.split("/paper/", 1)[1]
-    assert (
-        mock_client.get.call_args_list[1]
-        .args[0]
-        .endswith("/paper/ARXIV:1706.03762/citations")
-    )
-    assert (
-        mock_client.get.call_args_list[2]
-        .args[0]
-        .endswith("/paper/ARXIV:1706.03762/references")
-    )
 
 
 @pytest.mark.asyncio
 async def test_citation_graph_bare_id_omits_requested_version_fields():
     """Bare IDs should not invent requested_version metadata."""
-    mock_client = _mock_async_client(_success_responses())
+    mock_client = _mock_async_client([_success_response()])
 
-    with patch("httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph({"paper_id": "2401.12345"})
 
     payload = json.loads(response[0].text)
@@ -349,7 +386,7 @@ async def test_citation_graph_bare_id_omits_requested_version_fields():
     assert payload["paper"]["arxiv_id"] == "2401.12345"
     assert "requested_arxiv_id" not in payload["paper"]
     assert "requested_version" not in payload["paper"]
-    assert mock_client.get.call_args_list[0].args[0].endswith("/paper/ARXIV:2401.12345")
+    assert mock_client.get.call_args.args[0].endswith("/paper/ARXIV:2401.12345")
 
 
 @pytest.mark.asyncio
@@ -365,9 +402,161 @@ async def test_citation_graph_404_does_not_leak_s2_url():
     )
     mock_client = _mock_async_client([mock_response])
 
-    with patch("httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        mock_cache_dir.return_value = Path("/tmp/nonexistent_cache")
         response = await handle_citation_graph({"paper_id": "1706.03762v1"})
 
     assert response[0].text == "Error: paper not found on Semantic Scholar"
     assert "semanticscholar.org" not in response[0].text
     assert "https://" not in response[0].text
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_cache_hit():
+    """Second call for same paper should return cached result without API call."""
+    mock_client = _mock_async_client([_success_response()])
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        cache_dir = Path("/tmp/test_citation_cache")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        mock_cache_dir.return_value = cache_dir
+
+        # First call: cache miss, API call made
+        response1 = await handle_citation_graph({"paper_id": "2401.12345"})
+        payload1 = json.loads(response1[0].text)
+        assert payload1["status"] == "success"
+        assert mock_client.get.call_count == 1
+
+        # Second call: cache hit, no API call
+        response2 = await handle_citation_graph({"paper_id": "2401.12345"})
+        payload2 = json.loads(response2[0].text)
+        assert payload2["status"] == "success"
+        assert mock_client.get.call_count == 1  # Still 1, no new call
+        assert payload2["paper"]["arxiv_id"] == "2401.12345"
+
+        # Clean up
+        import shutil
+
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_cache_respects_max_citations():
+    """Cached result with smaller limit should not satisfy larger limit request."""
+    mock_client = _mock_async_client([_success_response(), _success_response()])
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        cache_dir = Path("/tmp/test_citation_cache_limits")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        mock_cache_dir.return_value = cache_dir
+
+        # First call with max_citations=10
+        response1 = await handle_citation_graph(
+            {"paper_id": "2401.12345", "max_citations": 10}
+        )
+        payload1 = json.loads(response1[0].text)
+        assert payload1["status"] == "success"
+        assert payload1["max_citations"] == 10
+        assert mock_client.get.call_count == 1
+
+        # Second call with max_citations=50 should NOT use cache
+        response2 = await handle_citation_graph(
+            {"paper_id": "2401.12345", "max_citations": 50}
+        )
+        payload2 = json.loads(response2[0].text)
+        assert payload2["status"] == "success"
+        assert payload2["max_citations"] == 50
+        assert mock_client.get.call_count == 2  # New API call made
+
+        # Clean up
+        import shutil
+
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_cache_rate_limited_expires_quickly():
+    """Rate-limited results should expire quickly from cache."""
+    attempts = citation_graph_module._MAX_RETRIES + 1
+    rate_limited = _json_response({}, status_code=429)
+    mock_client = _mock_async_client([rate_limited] * attempts + [_success_response()])
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module.asyncio, "sleep", new_callable=AsyncMock),
+        patch.object(citation_graph_module.random, "random", return_value=0.5),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+        patch.object(citation_graph_module, "CACHE_TTL_RATE_LIMITED_SECONDS", 0.1),
+    ):
+        cache_dir = Path("/tmp/test_citation_cache_rate_limited")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        mock_cache_dir.return_value = cache_dir
+
+        # First call: rate limited
+        response1 = await handle_citation_graph({"paper_id": "2401.12345"})
+        payload1 = json.loads(response1[0].text)
+        assert payload1["status"] == "rate_limited"
+        assert payload1["error"] == "RATE_LIMITED"
+        assert mock_client.get.call_count == attempts
+
+        # Wait for cache to expire
+        time.sleep(0.2)
+
+        # Second call: cache expired, new API call succeeds
+        response2 = await handle_citation_graph({"paper_id": "2401.12345"})
+        payload2 = json.loads(response2[0].text)
+        assert payload2["status"] == "success"
+        assert mock_client.get.call_count == attempts + 1  # New call made
+
+        # Clean up
+        import shutil
+
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+@pytest.mark.asyncio
+async def test_citation_graph_cache_can_serve_smaller_limit():
+    """Cached result with larger limit can satisfy smaller limit request."""
+    import shutil
+
+    mock_client = _mock_async_client([_success_response()])
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(citation_graph_module, "_cache_dir") as mock_cache_dir,
+    ):
+        cache_dir = Path("/tmp/test_citation_cache_slice")
+        # Clean up any previous cache
+        shutil.rmtree(cache_dir, ignore_errors=True)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        mock_cache_dir.return_value = cache_dir
+
+        # First call with max_citations=50
+        response1 = await handle_citation_graph(
+            {"paper_id": "2401.12345", "max_citations": 50}
+        )
+        payload1 = json.loads(response1[0].text)
+        assert payload1["status"] == "success"
+        assert payload1["max_citations"] == 50
+        assert mock_client.get.call_count == 1
+
+        # Second call with max_citations=10 should use cache
+        response2 = await handle_citation_graph(
+            {"paper_id": "2401.12345", "max_citations": 10}
+        )
+        payload2 = json.loads(response2[0].text)
+        assert payload2["status"] == "success"
+        assert payload2["max_citations"] == 10
+        assert mock_client.get.call_count == 1  # No new call
+
+        # Clean up
+        shutil.rmtree(cache_dir, ignore_errors=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scoped GO approved by Joe for **citation_graph only** on blazickjp/arxiv-mcp-server.

### Changes

**1. Fewer S2 API calls per hop**
- Reduced from **3 sequential calls** (paper + citations + references) to **1 call**
- Uses the S2 graph paper endpoint with `citations` and `references` fields + subfield syntax
- Stays within default 50 / cap 200 behavior

**2. Disk cache under existing storage path**
- Caches graphs at `{storage_path}/citation_graphs/{bare_arxiv_id}__limit_{max_citations}.json`
- Smart lookup: cached results with larger limits satisfy smaller requests by slicing
- Reasonable invalidation:
  - Successful graphs: 7 days TTL
  - Rate-limited results: 5 minutes TTL (prevents hammering S2)
- Same-paper different max_citations handled correctly

**3. Unmistakable rate-limit responses**
- Added explicit `error: "RATE_LIMITED"` field
- Added `warning` text: "This is NOT an empty citation graph. The API request was blocked by rate limiting."
- Improved `message` with emoji warning: ⚠️ RATE LIMITED
- Updated `hint` with direct link to free API key signup: https://www.semanticscholar.org/product/api#api-key
- Clients cannot mistake rate limits for empty success graphs

### Constraints preserved

✅ `SEMANTIC_SCHOLAR_API_KEY` stays optional (no bundled key)  
✅ One-hop, default 50, cap 200 unchanged  
✅ Version-strip for S2 lookup  
✅ Neighbor `arxiv_id` from `externalIds`  
✅ No S2 URLs leaked in errors  
✅ Updated mocked tests (no live S2 in CI)  
✅ Docs updated with short note about free S2 key  
✅ No changes to unrelated tools  

### Out of scope (per constraints)

❌ Multi-hop graphs  
❌ Offset pagination  
❌ Bundled/shared API key  

### Tests

All 16 citation_graph tests pass, including new tests for:
- Single API call verification
- Cache hit/miss behavior
- Cache respects max_citations logic
- Rate-limited result expiration
- Unmistakable 429 response format

### Documentation

- Updated README tool table: mentions 1 call + disk cache + optional free key
- Updated `SEMANTIC_SCHOLAR_API_KEY` env var docs with free key link and quota note

---

**Ready for review.** Do not merge yet per instructions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f34ec45-03d0-4c09-aae6-3713c8f25e91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f34ec45-03d0-4c09-aae6-3713c8f25e91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

