### PR TITLE
README: context-cost badge (3,960 tokens, measured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed,_latest_0.7.2-5C5CFF?style=flat-square)](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.blazickjp%2Farxiv-mcp-server/versions/latest)
 [![Tests](https://github.com/blazickjp/arxiv-mcp-server/actions/workflows/tests.yml/badge.svg)](https://github.com/blazickjp/arxiv-mcp-server/actions/workflows/tests.yml)
 [![GitHub stars](https://img.shields.io/github/stars/blazickjp/arxiv-mcp-server)](https://github.com/blazickjp/arxiv-mcp-server/stargazers)
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Farxiv.json)](https://athakur3.github.io/mcp-context-cost/servers/arxiv.html)
 
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=arxiv-mcp-server&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22arxiv-mcp-server%22%5D%7D)
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=arxiv-mcp-server&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJhcnhpdi1tY3Atc2VydmVyIl19)


### PR DESCRIPTION
This adds one badge to the README: what arxiv-mcp-server's tool schemas cost in context tokens — **3,960 tokens** across 19 tools (o200k_base over the canonical `tools/list` bytes), which is the "light" band, i.e. good news for your users.

Where it comes from: it is one of 106 MCP servers measured on a rotation in credential-free Docker. Every number is backed by the raw capture, its SHA-256 and the exact launch command; your page has the per-tool breakdown and the history line: https://athakur3.github.io/mcp-context-cost/servers/arxiv.html · method: https://github.com/athakur3/mcp-context-cost/blob/main/docs/METHODOLOGY.md

The badge JSON is regenerated each time the server is re-measured (about every six weeks), so it follows your releases, and it links to the measurement rather than to a landing page. Anyone can re-derive the number:

    npx -y mcp-context-cost verify --remote https://raw.githubusercontent.com/athakur3/mcp-context-cost/main/results/arxiv/measurement.json

Since this repo runs CI on pull requests: the same measurement is a five-line Action that fails a PR adding more schema cost than you meant to ship, with the per-tool diff (https://github.com/athakur3/mcp-context-cost/blob/main/examples/server-author-ci.yml). Separate PR if wanted; this one is just the badge.

For what it's worth, the history line shows the release between 2026-08-19 and 2026-09-03 taking arxiv-mcp-server from 3,228 to 3,960 tokens (+732, +22.7%) as the tool count went 14 → 19 — which is exactly the kind of change the gate would have surfaced on the PR.

If you'd rather host the badge JSON yourselves, that's a one-line change here. Happy to adjust the placement or close this if it isn't wanted. Disclosure: I maintain mcp-context-cost.
